### PR TITLE
New wire format

### DIFF
--- a/Signal/src/textsecure/Network/WebSockets/TSSocketManager.m
+++ b/Signal/src/textsecure/Network/WebSockets/TSSocketManager.m
@@ -138,11 +138,7 @@ NSString * const SocketConnectingNotification = @"SocketConnectingNotification";
     [self sendWebSocketMessageAcknowledgement:message];
     
     if ([message.path isEqualToString:@"/api/v1/message"] && [message.verb isEqualToString:@"PUT"]){
-        
-        NSString *base64String   = [[NSString alloc] initWithData:message.body encoding:NSUTF8StringEncoding];
-        
-        NSData *encryptedSignal  = [NSData dataFromBase64String:base64String];
-        NSData *decryptedPayload = [Cryptography decryptAppleMessagePayload:encryptedSignal
+        NSData *decryptedPayload = [Cryptography decryptAppleMessagePayload:message.body
                                                            withSignalingKey:TSStorageManager.signalingKey];
         
         if (!decryptedPayload) {


### PR DESCRIPTION
Unnecessary base64 encoding has now been removed.

Fix to be merged when deployed to production environment .
@moxie0 