### PR TITLE
fixes issue with android not being able to create a group due to update ...

### DIFF
--- a/Signal/src/textsecure/Messages/TSMessagesManager.m
+++ b/Signal/src/textsecure/Messages/TSMessagesManager.m
@@ -186,12 +186,12 @@
         [self.dbConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             GroupModel *emptyModelToFillOutId = [[GroupModel alloc] initWithTitle:nil memberIds:nil image:nil groupId:content.group.id]; // TODO refactor the TSGroupThread to just take in an ID (as it is all that it uses). Should not take in more than it uses
             TSGroupThread *gThread = [TSGroupThread threadWithGroupModel:emptyModelToFillOutId transaction:transaction];
-            if(gThread==nil) {
+            if(gThread==nil && content.group.type != PushMessageContentGroupContextTypeUpdate) {
                 ignoreMessage = YES;
             }
         }];
         if(ignoreMessage) {
-            DDLogDebug(@"Received message from group that I left, ignoring");
+            DDLogDebug(@"Received message from group that I left or don't know about, ignoring");
             return;
         }
         


### PR DESCRIPTION
• please test this on device (my hostel net doesn't let me connect my android :/)
• this will no longer ignore new group create (update) messages from Android having functional behavior for group creates
• continues to ignore groups the user has left or has no information about given the message.