### PR TITLE
search by contact's name or number

### DIFF
--- a/Signal/src/contact/Contact.h
+++ b/Signal/src/contact/Contact.h
@@ -34,6 +34,7 @@
                         andNotes:(NSString *)notes;
 
 - (NSString*)fullName;
+- (NSString *)allPhoneNumbers;
 
 - (BOOL)isTextSecureContact;
 - (BOOL)isRedPhoneContact;

--- a/Signal/src/contact/Contact.m
+++ b/Signal/src/contact/Contact.m
@@ -70,6 +70,15 @@ static NSString *const DEFAULTS_KEY_DATE = @"DefaultsKeyDate";
 	return fullName;
 }
 
+- (NSString *)allPhoneNumbers {
+    NSString * allNumbers = @"";
+    for (PhoneNumber *number in self.parsedPhoneNumbers) {
+        allNumbers = [allNumbers stringByAppendingString:number.toE164];
+        allNumbers = [allNumbers stringByAppendingString:@";"];
+    }
+    return allNumbers;
+}
+
 -(NSString *)description {
     return [NSString stringWithFormat:@"%@ %@: %@", firstName, lastName, userTextPhoneNumbers];
 }

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -85,7 +85,11 @@
 
 - (void)filterContentForSearchText:(NSString*)searchText scope:(NSString*)scope
 {
-    NSPredicate *resultPredicate = [NSPredicate predicateWithFormat:@"fullName contains[c] %@", searchText];
+    // (123) 456-7890 would be sanitized into 1234567890
+    NSCharacterSet *illegalCharacters = [NSCharacterSet characterSetWithCharactersInString:@" ()-+[]"];
+    NSString *sanitizedNumber = [[searchText componentsSeparatedByCharactersInSet:illegalCharacters] componentsJoinedByString:@""];
+    
+    NSPredicate *resultPredicate = [NSPredicate predicateWithFormat:@"(fullName contains[c] %@) OR (allPhoneNumbers contains[c] %@)", searchText, sanitizedNumber];
     searchResults = [contacts filteredArrayUsingPredicate:resultPredicate];
     if (!searchResults.count && _searchController.searchBar.text.length == 0) searchResults = contacts;
 }


### PR DESCRIPTION
When composing a new message, you can search through your contacts by searching by your contact's name or by their phone number(s). Since phone numbers are stored in E164, we can strip the search text of illegal characters like parentheses and spaces, and then see if the search text is "contained" in the E164 formatted phone numbers of their contacts.