### PR TITLE
Polishing up texting unknown numbers via regular SMS

### DIFF
--- a/Signal/src/util/PhoneNumberUtil.m
+++ b/Signal/src/util/PhoneNumberUtil.m
@@ -5,7 +5,7 @@
 
 @implementation PhoneNumberUtil
 
-
+// country code -> country name
 + (NSString *)countryNameFromCountryCode:(NSString *)code {
     NSDictionary *countryCodeComponent = @{NSLocaleCountryCode: code};
     NSString *identifier = [NSLocale localeIdentifierFromComponents:countryCodeComponent];
@@ -14,11 +14,13 @@
     return country;
 }
 
+// country code -> calling code
 + (NSString *)callingCodeFromCountryCode:(NSString *)code {
     NSNumber *callingCode = [NBPhoneNumberUtil.sharedInstance getCountryCodeForRegion:code];
     return [NSString stringWithFormat:@"%@%@", COUNTRY_CODE_PREFIX, callingCode];
 }
 
+// search term -> country codes
 + (NSArray *)countryCodesForSearchTerm:(NSString *)searchTerm {
     
     NSArray *countryCodes = NSLocale.ISOCountryCodes;
@@ -32,10 +34,12 @@
     return countryCodes;
 }
 
+// normalizes a phone number, so parentheses and spaces are stripped
 + (NSString*) normalizePhoneNumber:(NSString *) number {
     return [NBPhoneNumberUtil.sharedInstance normalizePhoneNumber:number];
 }
 
+// black  magic
 +(NSUInteger) translateCursorPosition:(NSUInteger)offset
                                  from:(NSString*)source
                                    to:(NSString*)target


### PR DESCRIPTION
Changes made:
- updated search bar placeholder text to say "search by name or number" instead of just "search"
- alert view shows up before sending normal SMS, so a user has to confirm they want to send a normal SMS outside of signal and just through the default iMessage
- PhoneNumberUtil used to sanitize input when searching by contact number, so the same results will be displayed for "1.234.555.6789" vs "1-234-555-6789", etc
- formatted user input displayed in blue box when searching for a number using a method in PhoneNumber, so searching for "1.234.555.6789" will display as "Send SMS to: +1 234-555-6789" underneath the search bar

Important notes:
The device I have to test on is Jack's iPod touch, which doesn't support SMS. The bug where you can't cancel out of iMessage likely still exists, but I haven't done anything to fix it without a device to test my changes against.