### PR TITLE
can see leftover duration of audio messages

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -1311,6 +1311,8 @@ typedef enum : NSUInteger {
     TSVideoAttachmentAdapter *messageMedia = dict[@"adapter"];
     double current = [_audioPlayer currentTime]/[_audioPlayer duration];
     [messageMedia setAudioProgressFromFloat:(float)current];
+    NSTimeInterval duration = ([_audioPlayer duration] - [_audioPlayer currentTime]);
+    [messageMedia setDurationOfAudio:duration];
 }
 
 - (void) audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag{
@@ -1328,6 +1330,7 @@ typedef enum : NSUInteger {
             if ([msgMedia isAudio]) {
                 [msgMedia setAudioProgressFromFloat:0];
                 [msgMedia setAudioIconToPlay];
+                [msgMedia removeDurationLabel];
             }
         }
     }

--- a/Signal/src/view controllers/TSVideoAttachmentAdapter.h
+++ b/Signal/src/view controllers/TSVideoAttachmentAdapter.h
@@ -26,5 +26,6 @@
 - (void)setAudioIconToPlay;
 - (void)setAudioIconToPause;
 - (void)setDurationOfAudio:(NSTimeInterval)duration;
+- (void)removeDurationLabel;
 
 @end

--- a/Signal/src/view controllers/TSVideoAttachmentAdapter.m
+++ b/Signal/src/view controllers/TSVideoAttachmentAdapter.m
@@ -80,6 +80,7 @@
 }
 
 -(void) setDurationOfAudio:(NSTimeInterval)duration {
+    [_durationLabel removeFromSuperview];
     double dur = duration;
     int minutes = (int) (dur/60);
     int seconds = (int) (dur - minutes*60);
@@ -88,10 +89,14 @@
     NSString *label_text = [NSString stringWithFormat:@"%@:%@", minutes_str, seconds_str];
 
     CGSize size = [self mediaViewDisplaySize];
-    _durationLabel = [[UILabel alloc] initWithFrame:CGRectMake(size.width - 50, 0, 50, 30)];
+    _durationLabel = [[UILabel alloc] initWithFrame:CGRectMake(size.width - 40, 0, 50, 30)];
     _durationLabel.text = label_text;
     _durationLabel.textColor = [UIColor whiteColor];
     [_audioProgress addSubview:_durationLabel];
+}
+
+-(void) removeDurationLabel {
+    [_durationLabel removeFromSuperview];
 }
 
 #pragma mark - JSQMessageMediaData protocol


### PR DESCRIPTION
Earlier I tried putting in the duration of each audio message, but found this was non-trivial. Even though that's difficult, I realized it's pretty easy to let the user see how much time is left on each audio message even if they can't see how long the message is before playing it.