### PR TITLE
Alert before deleting a thread + show remaining duration of audio message left

### DIFF
--- a/Signal/src/view controllers/InboxTableViewCell.h
+++ b/Signal/src/view controllers/InboxTableViewCell.h
@@ -24,7 +24,7 @@ typedef enum : NSUInteger {
 
 @end
 
-@interface InboxTableViewCell : UITableViewCell  <UIScrollViewDelegate>
+@interface InboxTableViewCell : UITableViewCell  <UIScrollViewDelegate, UIAlertViewDelegate>
 
 
 @property (nonatomic, strong) IBOutlet UIImageView* lastActionImageView;

--- a/Signal/src/view controllers/InboxTableViewCell.m
+++ b/Signal/src/view controllers/InboxTableViewCell.m
@@ -14,7 +14,8 @@
 #define ARCHIVE_IMAGE_VIEW_WIDTH 22.0f
 #define DELETE_IMAGE_VIEW_WIDTH 19.0f
 #define TIME_LABEL_SIZE 11
-#define DATE_LABEL_SIZE 13
+#define DATE_LABEL_SIZE 13tableViewCellTappedDelete
+#define SWIPE_ARCHIVE_OFFSET -50
 
 
 @implementation InboxTableViewCell
@@ -219,16 +220,26 @@
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
     
-    if (_scrollView.contentOffset.x < 0) {
+    if (_scrollView.contentOffset.x < SWIPE_ARCHIVE_OFFSET) {
         [_delegate tableViewCellTappedArchive:self];
+    } else if (scrollView.contentOffset.x > CGRectGetWidth(_archiveView.frame)/4) {
+        *targetContentOffset = scrollView.contentOffset;
+        
+        UIAlertView *warnBeforeDelete = [[UIAlertView alloc] initWithTitle:@"Warning" message:@"Are you sure you want to delete this entire thread permanently?" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles:@"Delete", nil];
+        [warnBeforeDelete show];
     } else {
         *targetContentOffset = CGPointMake(CGRectGetWidth(_archiveView.frame), 0);
     }
-    
-    if (scrollView.contentOffset.x > CGRectGetWidth(_archiveView.frame)/4) {
-        [_delegate tableViewCellTappedDelete:self];
+}
+
+#pragma mark - UIAlertView Delegate
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+{
+    if (buttonIndex == 0) {
+        self.scrollView.contentOffset = CGPointMake(0,0);
     } else {
-        *targetContentOffset = CGPointMake(CGRectGetWidth(_archiveView.frame), 0);
+        [_delegate tableViewCellTappedDelete:self];
     }
 }
 

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -1311,6 +1311,8 @@ typedef enum : NSUInteger {
     TSVideoAttachmentAdapter *messageMedia = dict[@"adapter"];
     double current = [_audioPlayer currentTime]/[_audioPlayer duration];
     [messageMedia setAudioProgressFromFloat:(float)current];
+    NSTimeInterval duration = ([_audioPlayer duration] - [_audioPlayer currentTime]);
+    [messageMedia setDurationOfAudio:duration];
 }
 
 - (void) audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag{
@@ -1328,6 +1330,7 @@ typedef enum : NSUInteger {
             if ([msgMedia isAudio]) {
                 [msgMedia setAudioProgressFromFloat:0];
                 [msgMedia setAudioIconToPlay];
+                [msgMedia removeDurationLabel];
             }
         }
     }

--- a/Signal/src/view controllers/TSVideoAttachmentAdapter.h
+++ b/Signal/src/view controllers/TSVideoAttachmentAdapter.h
@@ -26,5 +26,6 @@
 - (void)setAudioIconToPlay;
 - (void)setAudioIconToPause;
 - (void)setDurationOfAudio:(NSTimeInterval)duration;
+- (void)removeDurationLabel;
 
 @end

--- a/Signal/src/view controllers/TSVideoAttachmentAdapter.m
+++ b/Signal/src/view controllers/TSVideoAttachmentAdapter.m
@@ -80,6 +80,7 @@
 }
 
 -(void) setDurationOfAudio:(NSTimeInterval)duration {
+    [_durationLabel removeFromSuperview];
     double dur = duration;
     int minutes = (int) (dur/60);
     int seconds = (int) (dur - minutes*60);
@@ -88,10 +89,14 @@
     NSString *label_text = [NSString stringWithFormat:@"%@:%@", minutes_str, seconds_str];
 
     CGSize size = [self mediaViewDisplaySize];
-    _durationLabel = [[UILabel alloc] initWithFrame:CGRectMake(size.width - 50, 0, 50, 30)];
+    _durationLabel = [[UILabel alloc] initWithFrame:CGRectMake(size.width - 40, 0, 50, 30)];
     _durationLabel.text = label_text;
     _durationLabel.textColor = [UIColor whiteColor];
     [_audioProgress addSubview:_durationLabel];
+}
+
+-(void) removeDurationLabel {
+    [_durationLabel removeFromSuperview];
 }
 
 #pragma mark - JSQMessageMediaData protocol


### PR DESCRIPTION
Before swiping to delete a thread, a UIAlertView pops up and warns the user. They can choose to cancel or proceed with permanent deletion of the thread. The wording could maybe be improved, but currently the title of the alert is "Warning" and the message is "Are you sure you want to delete this entire thread permanently?"

The minor changes to audio-related stuff is just letting the user know how much time is left in the audio message they're currently playing.