### PR TITLE
empty states

### DIFF
--- a/Signal/src/environment/PreferencesUtil.h
+++ b/Signal/src/environment/PreferencesUtil.h
@@ -28,6 +28,12 @@ typedef NS_ENUM(NSUInteger, TSImageQuality) {
 - (BOOL) getIsMigratingToVersion2Dot0;
 - (void) setIsMigratingToVersion2Dot0:(BOOL)enabled;
 
+- (BOOL) getHasSentAMessage;
+- (void) setHasSentAMessage:(BOOL)enabled;
+
+- (BOOL) getHasArchivedAMessage;
+- (void) setHasArchivedAMessage:(BOOL)enabled;
+
 -(BOOL)loggingIsEnabled;
 -(void)setLoggingEnabled:(BOOL)flag;
 

--- a/Signal/src/environment/PreferencesUtil.m
+++ b/Signal/src/environment/PreferencesUtil.m
@@ -26,6 +26,8 @@
 #define NOTIFICATION_PREVIEW_TYPE_KEY @"Notification Preview Type Key"
 #define IMAGE_UPLOAD_QUALITY_KEY @"Image Upload Quality Key"
 #define IS_MIGRATING_FROM_1DOT0_TO_LARGER_KEY @"Migrating from 1.0 to Larger"
+#define HAS_SENT_A_MESSAGE_KEY @"User has sent a message"
+#define HAS_ARCHIVED_A_MESSAGE_KEY @"User archived a message"
 #define kSignalVersionKey @"SignalUpdateVersionKey"
 
 @implementation PropertyListPreferences (PropertyUtil)
@@ -129,6 +131,25 @@
     }
 }
 
+- (BOOL) getHasSentAMessage{
+    NSNumber *preference = [self tryGetValueForKey:HAS_SENT_A_MESSAGE_KEY];
+    if (preference) {
+        return [preference boolValue];
+    } else{
+        return NO;
+    }
+
+}
+
+- (BOOL) getHasArchivedAMessage {
+    NSNumber *preference = [self tryGetValueForKey:HAS_ARCHIVED_A_MESSAGE_KEY];
+    if (preference) {
+        return [preference boolValue];
+    } else{
+        return NO;
+    }
+
+}
 
 
 -(NotificationType)notificationPreviewType {
@@ -191,6 +212,16 @@
 - (void) setIsMigratingToVersion2Dot0:(BOOL)enabled {
     [self setValueForKey:IS_MIGRATING_FROM_1DOT0_TO_LARGER_KEY toValue:@(enabled)];
 }
+
+- (void) setHasSentAMessage:(BOOL)enabled{
+    [self setValueForKey:HAS_SENT_A_MESSAGE_KEY toValue:@(enabled)];
+}
+
+- (void) setHasArchivedAMessage:(BOOL)enabled{
+    [self setValueForKey:HAS_ARCHIVED_A_MESSAGE_KEY toValue:@(enabled)];
+}
+
+
 
 -(NSString*)setAndGetCurrentVersion{
     NSString *lastVersion = self.lastRanVersion;

--- a/Signal/src/textsecure/Messages/TSMessagesManager+sendMessages.m
+++ b/Signal/src/textsecure/Messages/TSMessagesManager+sendMessages.m
@@ -13,6 +13,8 @@
 #import <AxolotlKit/SessionBuilder.h>
 #import <Mantle/Mantle.h>
 
+#import "Environment.h"
+#import "PreferencesUtil.h"
 #import "IncomingPushMessageSignal.pb.h"
 #import "TSStorageManager.h"
 #import "TSStorageManager+SessionStore.h"
@@ -54,6 +56,7 @@ dispatch_queue_t sendingQueue() {
 }
 
 - (void)sendMessage:(TSOutgoingMessage*)message inThread:(TSThread*)thread{
+    [Environment.preferences setHasSentAMessage:YES];
     dispatch_async(sendingQueue(), ^{
         if ([thread isKindOfClass:[TSGroupThread class]]) {
             TSGroupThread* groupThread = (TSGroupThread*)thread;

--- a/Signal/src/view controllers/InboxTableViewCell.m
+++ b/Signal/src/view controllers/InboxTableViewCell.m
@@ -7,6 +7,8 @@
 //
 
 #import "InboxTableViewCell.h"
+#import "Environment.h"
+#import "PreferencesUtil.h"
 #import "Util.h"
 #import "UIImage+JSQMessages.h"
 #import "TSGroupThread.h"
@@ -211,11 +213,12 @@
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
-    
     if (_scrollView.contentOffset.x < SWIPE_ARCHIVE_OFFSET) {
         // archive the thread
         [_delegate tableViewCellTappedArchive:self];
-    } else {
+        [Environment.preferences setHasArchivedAMessage:YES];
+    }
+    else {
         // don't do anything
         *targetContentOffset = CGPointMake(CGRectGetWidth(_archiveView.frame), 0);
     }

--- a/Signal/src/view controllers/UITests/SignalsViewController.m
+++ b/Signal/src/view controllers/UITests/SignalsViewController.m
@@ -378,12 +378,10 @@ static NSString* const kShowSignupFlowSegue = @"showSignupFlow";
 - (void)checkIfEmptyView{
     [_tableView setHidden:NO];
     if (self.viewingThreadsIn == kInboxState && [self.threadMappings numberOfItemsInGroup:TSInboxGroup]==0) {
-        _emptyBoxImage.image = [UIImage imageNamed:@"uiEmptyInbox"];
         [self setEmptyBoxText];
         [_tableView setHidden:YES];
     }
     else if (self.viewingThreadsIn == kArchiveState && [self.threadMappings numberOfItemsInGroup:TSArchiveGroup]==0) {        
-        _emptyBoxImage.image = [UIImage imageNamed:@"uiEmptyArchive"];
         [self setEmptyBoxText];
         [_tableView setHidden:YES];
     }
@@ -399,13 +397,28 @@ static NSString* const kShowSignupFlowSegue = @"showSignupFlow";
     NSString* secondLine = @"";
     
     if(self.viewingThreadsIn == kInboxState) {
-        // Check if this is the first launch
-        firstLine =  @"No Messages :(";
-        secondLine = @"Tap compose to send a message or invite a friend to Signal.";
+        if([Environment.preferences getHasSentAMessage]) {
+            _emptyBoxImage.image = nil;
+            firstLine =  @"Done. Done. Done.";
+            secondLine = @"Tip: add a conversation as a reminder!";
+        }
+        else {
+            _emptyBoxImage.image = [UIImage imageNamed:@"uiEmptyInbox"];
+            firstLine = @"Start your first Signal conversation!";
+            secondLine = @"Tap on the + button.";
+        }
     }
     else {
-        firstLine = @"No archived messages.";
-        secondLine = @"Swipe right on any message in your inbox and archive it here.";
+        if([Environment.preferences getHasArchivedAMessage]) {
+            _emptyBoxImage.image = nil;
+            firstLine = @"Squeaky Freaking Clean.";
+            secondLine = @"None. Zero. Zilch. Nada.";
+        }
+        else {
+            _emptyBoxImage.image = [UIImage imageNamed:@"uiEmptyArchive"];
+            firstLine = @"Save conversations for reference.";
+            secondLine = @"You can swipe conversations into your Archive from the Inbox.";
+        }
     }
     NSMutableAttributedString *fullLabelString = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@\n%@",firstLine,secondLine]];
     


### PR DESCRIPTION
• With the exception of the first launch states, none of the empty states should include any artwork
• First Launch Inbox State should read: Start your first Signal conversation! Tap on the + button.
• Empty Inbox State should read Done. Done. Done. Tip: add a conversation as a reminder!
• First Launch Archive State [should read][first-launch-archive] Save conversations for reference. You can swipe conversations into your Archive from the Inbox
• Empty Archive State should read Squeaky Freaking Clean. None. Zero. Zilch. Nada.