### PR TITLE
If you get a textsecure message from an unknown number, allow TextSecure interactions

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -143,6 +143,16 @@ typedef enum : NSUInteger {
         self.navigationItem.rightBarButtonItem = nil;
     }
     else if(![self isTextSecureReachable] ){
+        // If someone has sent us a TextSecure message we know they are a TextSecure user even if they aren't in our contacts. This avoids a network call or additional storage hack.
+        JSQMessagesCollectionView *collectionView = self.collectionView;
+        for (NSInteger i=0; i<[self collectionView:collectionView numberOfItemsInSection:0]; i++) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:i inSection:0];
+            TSMessageAdapter *msgAdapter = [collectionView.dataSource collectionView:collectionView messageDataForItemAtIndexPath:indexPath];
+            if (msgAdapter.messageType == TSIncomingMessageAdapter && !(msgAdapter.messageType==TSCallAdapter)) {
+                return;
+            }
+        }
+        // Otherwise they are a RedPhone user only 
         [self inputToolbar].hidden= YES; // only RedPhone
         self.navigationItem.rightBarButtonItem =  [[UIBarButtonItem alloc] initWithImage:[[UIImage imageNamed:@"btnPhone--white"] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal] style:UIBarButtonItemStylePlain target:self action:@selector(callAction)];;
     }


### PR DESCRIPTION
I decided to just check if a sender isn't a text secure user and there's an incoming message that isn't a call in a thread => that means you can reply. More complicated methods of handling would be to do the network call to check if a sender is a user (this isn't robust offline/poor network-so should probably be done in addition to the below anyway as a sanity check) and additionally cache that result somehow. This works for most cases, with the edge case that if you get a TextSecure message from an unknown contact and delete all incoming messages on the thread but leave the thread open, you will no longer be able to reply. Happy to tweak incorporating these ideas. 