### PR TITLE
Closes #680 Inbox timestamp bug

### DIFF
--- a/Signal/src/util/DateUtil.h
+++ b/Signal/src/util/DateUtil.h
@@ -7,5 +7,6 @@
 + (NSDateFormatter *)timeFormatter;
 + (BOOL)dateIsOlderThanOneDay:(NSDate *)date;
 + (BOOL)dateIsOlderThanOneWeek:(NSDate *)date;
++ (BOOL)dateIsToday:(NSDate *)date;
 
 @end

--- a/Signal/src/util/DateUtil.m
+++ b/Signal/src/util/DateUtil.m
@@ -6,25 +6,29 @@
 #define ONE_WEEK_TIME_INTERVAL (double)60*60*24*7
 
 static NSString *const DATE_FORMAT_WEEKDAY = @"EEEE";
-static NSString *const DATE_FORMAT_HOUR_MINUTE = @"h:mm a   ";
 
 @implementation DateUtil
 
 + (NSDateFormatter *)dateFormatter {
     NSDateFormatter *formatter = [NSDateFormatter new];
+    [formatter setLocale:[NSLocale currentLocale]];
+    [formatter setTimeStyle:NSDateFormatterNoStyle];
     [formatter setDateStyle:NSDateFormatterShortStyle];
     return formatter;
 }
 
 + (NSDateFormatter *)weekdayFormatter {
     NSDateFormatter *formatter = [NSDateFormatter new];
+    [formatter setLocale:[NSLocale currentLocale]];
     [formatter setDateFormat:DATE_FORMAT_WEEKDAY];
     return formatter;
 }
 
 + (NSDateFormatter *)timeFormatter {
     NSDateFormatter *formatter = [NSDateFormatter new];
-    [formatter setDateFormat:DATE_FORMAT_HOUR_MINUTE];
+    [formatter setLocale:[NSLocale currentLocale]];
+    [formatter setTimeStyle:NSDateFormatterShortStyle];
+    [formatter setDateStyle:NSDateFormatterNoStyle];
     return formatter;
 }
 
@@ -34,6 +38,19 @@ static NSString *const DATE_FORMAT_HOUR_MINUTE = @"h:mm a   ";
 
 + (BOOL)dateIsOlderThanOneWeek:(NSDate *)date {
     return [[NSDate date] timeIntervalSinceDate:date] > ONE_WEEK_TIME_INTERVAL;
+}
+
++ (BOOL)date:(NSDate *)date isEqualToDateIgnoringTime:(NSDate *)anotherDate{
+    static const unsigned componentFlags = (NSCalendarUnitYear| NSCalendarUnitMonth | NSCalendarUnitDay);
+    NSDateComponents *components1 = [[NSCalendar autoupdatingCurrentCalendar] components:componentFlags fromDate:date];
+    NSDateComponents *components2 = [[NSCalendar autoupdatingCurrentCalendar] components:componentFlags fromDate:anotherDate];
+    return ((components1.year == components2.year) &&
+            (components1.month == components2.month) &&
+            (components1.day == components2.day));
+}
+
++ (BOOL)dateIsToday:(NSDate *)date{
+    return [self date:[NSDate date] isEqualToDateIgnoringTime:date];
 }
 
 @end

--- a/Signal/src/view controllers/InboxTableViewCell.m
+++ b/Signal/src/view controllers/InboxTableViewCell.m
@@ -118,7 +118,7 @@
 - (NSAttributedString *)dateAttributedString:(NSDate *)date {
     NSString *timeString;
     
-    if ([date timeIntervalSinceNow] > (- 60 * 60 * 24)) {
+    if ([DateUtil dateIsToday:date]) {
         timeString = [[DateUtil timeFormatter] stringFromDate:date];
     } else {
         


### PR DESCRIPTION
Hour format was set to static “h:mm a” leading to localization issues. #680 
Current locale will now be respected in every formatting.
Adjusted the decision when to label the message with a date from
“more then 24 hours ago” to “not today”.