### PR TITLE
Fix Issue #649

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -616,7 +616,6 @@ typedef enum : NSUInteger {
     JSQMessagesCollectionViewCell *cell = (JSQMessagesCollectionViewCell *)[super collectionView:self.collectionView cellForItemAtIndexPath:indexPath];
     if (!message.isMediaMessage) {
         cell.textView.textColor          = [UIColor ows_blackColor];
-        cell.textView.selectable         = NO;
         cell.textView.linkTextAttributes = @{ NSForegroundColorAttributeName : cell.textView.textColor,
                                               NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
     }
@@ -630,7 +629,6 @@ typedef enum : NSUInteger {
     if (!message.isMediaMessage)
     {
         cell.textView.textColor          = [UIColor whiteColor];
-        cell.textView.selectable         = NO;
         cell.textView.linkTextAttributes = @{ NSForegroundColorAttributeName : cell.textView.textColor,
                                               NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
     }


### PR DESCRIPTION
Data detectors are connected to if a textview is selectable. For some reason their selectability was disabled, so re-enabling fixes issue #649 

It doesn't appear to have any knock on effects? I think it was introduced by accident in 402df723 

Images still appear to be viewable. 