### PR TITLE
Attempt to reset the keyboard back to the default

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -574,6 +574,14 @@ typedef enum : NSUInteger {
         TSOutgoingMessage *message = [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp] inThread:self.thread messageBody:text attachments:nil];
         
         [[TSMessagesManager sharedManager] sendMessage:message inThread:self.thread];
+
+        // Reset the keyboard from special characters to Default
+        [self.keyboardController endListeningForKeyboard];
+        [self.inputToolbar.contentView.textView resignFirstResponder];
+        [self.inputToolbar.contentView.textView setKeyboardType:UIKeyboardTypeDefault];
+        [self.inputToolbar.contentView.textView becomeFirstResponder];
+        [self.keyboardController beginListeningForKeyboard];
+
         [self finishSendingMessage];
     }
 }


### PR DESCRIPTION
This should reset the keyboard after sending a message back to the default keyboard from the Emoji or the number/special characters keyboard.

I can't get it to install on my iPhone due to no Apple iOS Developer account, but it looks like it should do the trick. At least according to: https://github.com/jessesquires/JSQMessagesViewController/issues/971