### PR TITLE
Stop the spinner when registration fails on a RegistrationVC

### DIFF
--- a/Signal/src/view controllers/RegistrationViewController.m
+++ b/Signal/src/view controllers/RegistrationViewController.m
@@ -103,7 +103,7 @@ static NSString *const kCodeSentSegue = @"codeSent";
         [registrationErrorAV show];
         
         [_sendCodeButton setEnabled:YES];
-        [_spinnerView startAnimating];
+        [_spinnerView stopAnimating];
     }];
     
 }


### PR DESCRIPTION
Currently when you fail to register, which I seem to be doing ATM, the spinner doesn't stop spinning. Also signed the contributor agreement.