### PR TITLE
Adding support for animated gifs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -14,6 +14,7 @@ pod 'FFCircularProgressView',     '~> 0.5'
 pod 'SCWaveformView',             '~> 1.0'
 pod 'YapDatabase/SQLCipher',      '~> 2.7.2'
 pod 'iRate',                      '~> 1.11'
+pod 'FLAnimatedImage',            '~> 1.0'
 pod 'SSKeychain'
 pod 'DJWActionSheet'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,6 +35,7 @@ PODS:
     - CocoaLumberjack/Default
   - DJWActionSheet (1.0.4)
   - FFCircularProgressView (0.5)
+  - FLAnimatedImage (1.0.8)
   - HKDFKit (0.0.3)
   - iRate (1.11.4)
   - JSQMessagesViewController (7.1.0):
@@ -66,6 +67,7 @@ DEPENDENCIES:
   - AxolotlKit
   - DJWActionSheet
   - FFCircularProgressView (~> 0.5)
+  - FLAnimatedImage (~> 1.0)
   - iRate (~> 1.11)
   - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController`,
     commit `e5582fef8a6b3e35f8070361ef37237222da712b`)
@@ -103,6 +105,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   DJWActionSheet: 2fe54b1298a7f0fe44462233752c76a530e0cd80
   FFCircularProgressView: 683a4ab1e1bd613246a3dffa61503ffdebcde8d8
+  FLAnimatedImage: f9422f796135aff80d8c00b2afc48015bb746e24
   HKDFKit: c058305d6f64b84f28c50bd7aa89574625bcb62a
   iRate: 599ed07c854e0695f3c605d1b2a64c67d912acb7
   JSQMessagesViewController: ca11f86fa68ca70835f05e169df9244147c1dc40

--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		057B54FA6208D8269CFE6146 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D488327B732CFBE8349C7024 /* libPods.a */; };
 		28508611F3DF531CEDF5103D /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D488327B732CFBE8349C7024 /* libPods.a */; };
 		53EF5134D8FB5FCBDEDE2A35 /* (null) in Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (Weak, ); }; };
+		4CE0E3771B954546007210CF /* TSAnimatedAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0E3761B954546007210CF /* TSAnimatedAdapter.m */; };
 		701231B518ECAA4500D456C4 /* EvpMessageDigest.m in Sources */ = {isa = PBXBuildFile; fileRef = 701231B418ECAA4500D456C4 /* EvpMessageDigest.m */; };
 		70377AAB1918450100CAF501 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70377AAA1918450100CAF501 /* MobileCoreServices.framework */; };
 		7038632718F70C0700D4A43F /* CryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 7038632418F70C0700D4A43F /* CryptoTools.m */; };
@@ -539,6 +540,8 @@
 
 /* Begin PBXFileReference section */
 		14DDBCE302E19644A773D119 /* Pods.app store release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods.app store release.xcconfig"; path = "Pods/Target Support Files/Pods/Pods.app store release.xcconfig"; sourceTree = "<group>"; };
+		4CE0E3751B95453C007210CF /* TSAnimatedAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSAnimatedAdapter.h; sourceTree = "<group>"; };
+		4CE0E3761B954546007210CF /* TSAnimatedAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSAnimatedAdapter.m; sourceTree = "<group>"; };
 		701231B318ECAA4500D456C4 /* EvpMessageDigest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EvpMessageDigest.h; sourceTree = "<group>"; };
 		701231B418ECAA4500D456C4 /* EvpMessageDigest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EvpMessageDigest.m; sourceTree = "<group>"; };
 		70377AAA1918450100CAF501 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
@@ -2097,6 +2100,8 @@
 				A5E9D4B91A65FAD800E4481C /* TSVideoAttachmentAdapter.m */,
 				B6A3EB491A423B3800B2236B /* TSPhotoAdapter.h */,
 				B6A3EB4A1A423B3800B2236B /* TSPhotoAdapter.m */,
+				4CE0E3751B95453C007210CF /* TSAnimatedAdapter.h */,
+				4CE0E3761B954546007210CF /* TSAnimatedAdapter.m */,
 				B62D53F51A23CCAD009AAF82 /* TSMessageAdapter.h */,
 				B62D53F61A23CCAD009AAF82 /* TSMessageAdapter.m */,
 			);
@@ -2992,6 +2997,7 @@
 				76EB062A18170B33006006FC /* BadState.m in Sources */,
 				B97940271832BD2400BD66CB /* UIUtil.m in Sources */,
 				B62EFBEC1A91352F0072ADD3 /* TSInvalidIdentityKeyErrorMessage.m in Sources */,
+				4CE0E3771B954546007210CF /* TSAnimatedAdapter.m in Sources */,
 				B6B096861A1D25ED008BFAA6 /* SecurityUtils.m in Sources */,
 				76EB05BE18170B33006006FC /* ConfirmPacket.m in Sources */,
 				76EB058618170B33006006FC /* PreferencesUtil.m in Sources */,

--- a/Signal/src/textsecure/Messages/Attachements/TSAttachmentStream.h
+++ b/Signal/src/textsecure/Messages/Attachements/TSAttachmentStream.h
@@ -19,6 +19,7 @@
 
 - (UIImage *)image;
 
+- (BOOL)isAnimated;
 - (BOOL)isImage;
 - (BOOL)isVideo;
 -(NSURL*)mediaURL;

--- a/Signal/src/textsecure/Messages/Attachements/TSAttachmentStream.m
+++ b/Signal/src/textsecure/Messages/Attachements/TSAttachmentStream.m
@@ -59,6 +59,10 @@ NSString * const TSAttachementFileRelationshipEdge = @"TSAttachementFileEdge";
     return [NSURL fileURLWithPath:[self filePath]];
 }
 
+- (BOOL)isAnimated {
+    return [MIMETypeUtil isAnimated:self.contentType];
+}
+
 - (BOOL)isImage {
     return [MIMETypeUtil isImage:self.contentType];
 }
@@ -72,11 +76,13 @@ NSString * const TSAttachementFileRelationshipEdge = @"TSAttachementFileEdge";
 }
 
 - (UIImage*)image {
-    if (![self isImage]) {
+    if ([self isVideo] || [self isAudio]) {
         return [self videoThumbnail];
     }
-
-    return [UIImage imageWithContentsOfFile:self.filePath];
+    else {
+        // [self isAnimated] || [self isImage]
+        return [UIImage imageWithData:[NSData dataWithContentsOfURL:[self mediaURL]]];
+    }
 }
 
 

--- a/Signal/src/util/MIMETypeUtil.h
+++ b/Signal/src/util/MIMETypeUtil.h
@@ -6,22 +6,27 @@
 +(BOOL)isSupportedVideoMIMEType:(NSString*)contentType;
 +(BOOL)isSupportedAudioMIMEType:(NSString*)contentType;
 +(BOOL)isSupportedImageMIMEType:(NSString*)contentType;
++(BOOL)isSupportedAnimatedMIMEType:(NSString*)contentType;
 
 +(BOOL)isSupportedVideoFile:(NSString*)filePath;
 +(BOOL)isSupportedAudioFile:(NSString*)filePath;
 +(BOOL)isSupportedImageFile:(NSString*)filePath;
++(BOOL)isSupportedAnimatedFile:(NSString*)filePath;
 
 +(NSString*)getSupportedExtensionFromVideoMIMEType:(NSString*)supportedMIMEType;
 +(NSString*)getSupportedExtensionFromAudioMIMEType:(NSString*)supportedMIMEType;
 +(NSString*)getSupportedExtensionFromImageMIMEType:(NSString*)supportedMIMEType;
++(NSString*)getSupportedExtensionFromAnimatedMIMEType:(NSString*)supportedMIMEType;
 
 +(NSString*)getSupportedMIMETypeFromVideoFile:(NSString*)supportedVideoFile;
 +(NSString*)getSupportedMIMETypeFromAudioFile:(NSString*)supportedAudioFile;
 +(NSString*)getSupportedMIMETypeFromImageFile:(NSString*)supportedImageFile;
++(NSString*)getSupportedMIMETypeFromAnimatedFile:(NSString*)supportedImageFile;
 
 +(NSString*)getSupportedImageMIMETypeFromImage:(UIImage*)image;
 +(BOOL)getIsSupportedTypeFromImage:(UIImage*)image;
 
++(BOOL)isAnimated:(NSString*)contentType;
 +(BOOL)isImage:(NSString*)contentType;
 +(BOOL)isVideo:(NSString*)contentType;
 +(BOOL)isAudio:(NSString*)contentType;
@@ -30,6 +35,7 @@
 +(NSString*)filePathForImage:(NSString*)uniqueId ofMIMEType:(NSString*)contentType inFolder:(NSString*)folder;
 +(NSString*)filePathForVideo:(NSString*)uniqueId ofMIMEType:(NSString*)contentType inFolder:(NSString*)folder;
 +(NSString*)filePathForAudio:(NSString*)uniqueId ofMIMEType:(NSString*)contentType inFolder:(NSString*)folder;
++(NSString*)filePathForAnimated:(NSString*)uniqueId ofMIMEType:(NSString*)contentType inFolder:(NSString*)folder;
 
 +(NSURL*)simLinkCorrectExtensionOfFile:(NSURL*)mediaURL ofMIMEType:(NSString*)contentType;
 

--- a/Signal/src/util/MIMETypeUtil.m
+++ b/Signal/src/util/MIMETypeUtil.m
@@ -37,11 +37,15 @@
     return @{@"image/jpeg":@"jpeg",
              @"image/pjpeg":@"jpeg",
              @"image/png":@"png",
-             @"image/gif":@"gif",
              @"image/tiff":@"tif",
              @"image/x-tiff":@"tif",
              @"image/bmp":@"bmp",
              @"image/x-windows-bmp":@"bmp"
+             };
+}
+
++ (NSDictionary*)supportedAnimatedMIMETypesToExtensionTypes{
+    return @{@"image/gif":@"gif",
              };
 }
 
@@ -89,9 +93,13 @@
               @"jpe":@"image/pjpeg",
               @"jpeg":@"image/jpeg",
               @"jpg":@"image/jpeg",
-              @"gif":@"image/gif",
               @"tif":@"image/tiff",
               @"tiff":@"image/tiff"
+              };
+}
+
++ (NSDictionary*)supportedAnimatedExtensionTypesToMIMETypes{
+    return  @{@"gif":@"image/gif",
               };
 }
 
@@ -107,8 +115,12 @@
     return [[self supportedImageMIMETypesToExtensionTypes] objectForKey:contentType]!=nil;
 }
 
++(BOOL) isSupportedAnimatedMIMEType:(NSString*)contentType {
+    return [[self supportedAnimatedMIMETypesToExtensionTypes] objectForKey:contentType]!=nil;
+}
+
 +(BOOL) isSupportedMIMEType:(NSString*)contentType {
-    return [self isSupportedImageMIMEType:contentType] || [self isSupportedAudioMIMEType:contentType] || [self isSupportedVideoMIMEType:contentType];
+    return [self isSupportedImageMIMEType:contentType] || [self isSupportedAudioMIMEType:contentType] || [self isSupportedVideoMIMEType:contentType] || [self isSupportedAnimatedMIMEType:contentType];
 }
 
 +(BOOL) isSupportedVideoFile:(NSString*) filePath {
@@ -123,6 +135,10 @@
     return [[self supportedImageExtensionTypesToMIMETypes] objectForKey:[filePath pathExtension]]!=nil;
 }
 
++(BOOL) isSupportedAnimatedFile:(NSString*) filePath  {
+    return [[self supportedAnimatedExtensionTypesToMIMETypes] objectForKey:[filePath pathExtension]]!=nil;
+}
+
 +(NSString*) getSupportedExtensionFromVideoMIMEType:(NSString*)supportedMIMEType {
     return [[self supportedVideoMIMETypesToExtensionTypes] objectForKey:supportedMIMEType];
 }
@@ -133,6 +149,10 @@
 
 +(NSString*) getSupportedExtensionFromImageMIMEType:(NSString*)supportedMIMEType {
     return [[self supportedImageMIMETypesToExtensionTypes] objectForKey:supportedMIMEType];
+}
+
++(NSString*) getSupportedExtensionFromAnimatedMIMEType:(NSString*)supportedMIMEType {
+    return [[self supportedAnimatedMIMETypesToExtensionTypes] objectForKey:supportedMIMEType];
 }
 
 +(NSString*) getSupportedMIMETypeFromVideoFile:(NSString*)supportedVideoFile {
@@ -147,6 +167,10 @@
     return [[self supportedImageExtensionTypesToMIMETypes] objectForKey:[supportedImageFile pathExtension]];
 }
 
++(NSString*) getSupportedMIMETypeFromAnimatedFile:(NSString*)supportedAnimatedFile {
+    return [[self supportedAnimatedExtensionTypesToMIMETypes] objectForKey:[supportedAnimatedFile pathExtension]];
+}
+
 #pragma mark uses bytes
 +(NSString*) getSupportedImageMIMETypeFromImage:(UIImage*)image {
     return [image contentType];
@@ -157,6 +181,9 @@
 }
 
 #pragma mark full attachment utilities
++ (BOOL)isAnimated:(NSString *)contentType {
+    return [MIMETypeUtil isSupportedAnimatedMIMEType:contentType];
+}
 + (BOOL)isImage:(NSString*)contentType {
     return [MIMETypeUtil isSupportedImageMIMEType:contentType];
 }
@@ -179,7 +206,10 @@
     else if([self isImage:contentType]){
         return [MIMETypeUtil filePathForImage:uniqueId ofMIMEType:contentType inFolder:folder];
     }
-    
+    else if([self isAnimated:contentType]){
+        return [MIMETypeUtil filePathForAnimated:uniqueId ofMIMEType:contentType inFolder:folder];
+    }
+
     DDLogError(@"Got asked for path of file %@ which is unsupported", contentType);
     return nil;
 }
@@ -213,6 +243,10 @@
 
 + (NSString*)filePathForAudio:(NSString*)uniqueId ofMIMEType:(NSString*)contentType inFolder:(NSString*)folder{
     return [[folder stringByAppendingFormat:@"/%@",uniqueId] stringByAppendingPathExtension:[self getSupportedExtensionFromAudioMIMEType:contentType]];
+}
+
++ (NSString*)filePathForAnimated:(NSString*)uniqueId ofMIMEType:(NSString*)contentType inFolder:(NSString*)folder{
+    return [[folder stringByAppendingFormat:@"/%@",uniqueId] stringByAppendingPathExtension:[self getSupportedExtensionFromAnimatedMIMEType:contentType]];
 }
 
 @end

--- a/Signal/src/view controllers/FullImageViewController.h
+++ b/Signal/src/view controllers/FullImageViewController.h
@@ -12,7 +12,10 @@
 
 @interface FullImageViewController : UIViewController
 
-- (instancetype)initWithAttachment:(TSAttachmentStream*)attachment fromRect:(CGRect)rect forInteraction:(TSInteraction*)interaction;
+- (instancetype)initWithAttachment:(TSAttachmentStream*)attachment
+                          fromRect:(CGRect)rect
+                    forInteraction:(TSInteraction*)interaction
+                        isAnimated:(BOOL)animated;
 
 - (void)presentFromViewController:(UIViewController*)viewController;
 

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -36,6 +36,7 @@
 #import "TSIncomingMessage.h"
 #import "TSAttachmentPointer.h"
 #import "TSVideoAttachmentAdapter.h"
+#import <AssetsLibrary/AssetsLibrary.h>
 
 #import "TSMessagesManager+sendMessages.h"
 #import "TSMessagesManager+attachments.h"
@@ -1268,11 +1269,44 @@ typedef enum : NSUInteger {
         [self sendQualityAdjustedAttachment:videoURL];
     }
     else {
-        UIImage *picture_camera = [[info objectForKey:UIImagePickerControllerOriginalImage] normalizedImage];
-        if(picture_camera) {
-            DDLogVerbose(@"Sending picture attachement ...");
-            [self sendMessageAttachment:[self qualityAdjustedAttachmentForImage:picture_camera] ofType:@"image/jpeg"];
-        }
+        // Send image as NSData to accommodate both static and animated images
+        ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+        [library assetForURL:[info objectForKey:UIImagePickerControllerReferenceURL]
+                 resultBlock:^(ALAsset *asset)
+         {
+             ALAssetRepresentation *representation = [asset defaultRepresentation];
+             Byte *img_buffer = (Byte*)malloc(representation.size);
+             NSUInteger length_buffered = [representation getBytes:img_buffer fromOffset:0 length:representation.size error:nil];
+             NSData *img_data = [NSData dataWithBytesNoCopy:img_buffer length:length_buffered];
+             NSString *file_type;
+             switch (img_buffer[0])
+             {
+                 case 0x89:
+                     file_type = @"image/png";
+                     break;
+                 case 0x47:
+                     file_type = @"image/gif";
+                     break;
+                 case 0x49:
+                 case 0x4D:
+                     file_type = @"image/tiff";
+                     break;
+                 case 0x42:
+                     file_type = @"@image/bmp";
+                     break;
+                 case 0xFF:
+                 default:
+                     file_type = @"image/jpeg";
+                     break;
+             }
+             DDLogVerbose(@"Sending image. Size in bytes: %lu; first byte: %02x (%c); detected filetype: %@", (unsigned long)length_buffered, img_buffer[0], img_buffer[0], file_type);
+             [self sendMessageAttachment:img_data ofType:file_type];
+         }
+                failureBlock:^(NSError *error)
+         {
+             DDLogVerbose(@"Couldn't get image asset: %@", error);
+         }
+        ];
     }
     
 }

--- a/Signal/src/view controllers/TSAnimatedAdapter.h
+++ b/Signal/src/view controllers/TSAnimatedAdapter.h
@@ -1,0 +1,23 @@
+//
+//  TSAnimatedAdapter.h
+//  Signal
+//
+//  Created by Mike Okner (@mikeokner) on 2015-09-01.
+//  Copyright (c) 2015 Open Whisper Systems. All rights reserved.
+//
+
+#import <JSQMessagesViewController/JSQPhotoMediaItem.h>
+#import "TSAttachmentStream.h"
+#import <Foundation/Foundation.h>
+
+@interface TSAnimatedAdapter : JSQMediaItem
+
+- (instancetype)initWithAttachment:(TSAttachmentStream*)attachment;
+
+- (BOOL)isImage;
+- (BOOL)isAudio;
+- (BOOL)isVideo;
+
+@property NSString *attachmentId;
+
+@end

--- a/Signal/src/view controllers/TSAnimatedAdapter.m
+++ b/Signal/src/view controllers/TSAnimatedAdapter.m
@@ -29,6 +29,7 @@
     if (self) {
         _cachedImageView = nil;
         _attachment      = attachment;
+        _attachmentId    = attachment.uniqueId;
         _image           = [attachment image];
         _fileData        = [NSData dataWithContentsOfURL:[attachment mediaURL]];
     }
@@ -40,6 +41,7 @@
 {
     _cachedImageView = nil;
     _attachment = nil;
+    _attachmentId = nil;
     _image = nil;
     _fileData = nil;
 }

--- a/Signal/src/view controllers/TSAnimatedAdapter.m
+++ b/Signal/src/view controllers/TSAnimatedAdapter.m
@@ -1,0 +1,142 @@
+//
+//  TSAnimatedAdapter.m
+//  Signal
+//
+//  Created by Mike Okner (@mikeokner) on 2015-09-01.
+//  Copyright (c) 2015 Open Whisper Systems. All rights reserved.
+//
+
+#import "TSAnimatedAdapter.h"
+
+#import "UIDevice+TSHardwareVersion.h"
+#import "JSQMessagesMediaViewBubbleImageMasker.h"
+#import "FLAnimatedImage.h"
+
+@interface TSAnimatedAdapter ()
+
+@property (strong, nonatomic) UIImageView *cachedImageView;
+@property (strong, nonatomic) NSData *fileData;
+@property (strong, nonatomic) UIImage *image;
+@property (strong, nonatomic) TSAttachmentStream *attachment;
+
+@end
+
+@implementation TSAnimatedAdapter
+
+- (instancetype)initWithAttachment:(TSAttachmentStream *)attachment {
+    self = [super init];
+
+    if (self) {
+        _cachedImageView = nil;
+        _attachment      = attachment;
+        _image           = [attachment image];
+        _fileData        = [NSData dataWithContentsOfURL:[attachment mediaURL]];
+    }
+
+    return self;
+}
+
+- (void)dealloc
+{
+    _cachedImageView = nil;
+    _attachment = nil;
+    _image = nil;
+    _fileData = nil;
+}
+
+- (void)clearCachedMediaViews
+{
+    [super clearCachedMediaViews];
+    _cachedImageView = nil;
+}
+
+- (void)setAppliesMediaViewMaskAsOutgoing:(BOOL)appliesMediaViewMaskAsOutgoing
+{
+    [super setAppliesMediaViewMaskAsOutgoing:appliesMediaViewMaskAsOutgoing];
+    _cachedImageView = nil;
+}
+
+#pragma mark - JSQMessageMediaData protocol
+
+- (UIView *)mediaView
+{
+    if (self.cachedImageView == nil) {
+        // Use Flipboard FLAnimatedImage library to display gifs
+        FLAnimatedImage *animatedGif = [FLAnimatedImage animatedImageWithGIFData:self.fileData];
+        FLAnimatedImageView *imageView = [[FLAnimatedImageView alloc] init];
+        imageView.animatedImage = animatedGif;
+        CGSize size = [self mediaViewDisplaySize];
+        imageView.frame = CGRectMake(0.0, 0.0, size.width, size.height);
+        imageView.contentMode = UIViewContentModeScaleAspectFill;
+        imageView.clipsToBounds = YES;
+        [JSQMessagesMediaViewBubbleImageMasker applyBubbleImageMaskToMediaView:imageView isOutgoing:self.appliesMediaViewMaskAsOutgoing];
+        self.cachedImageView = imageView;
+    }
+
+    return self.cachedImageView;
+}
+
+- (CGSize)mediaViewDisplaySize
+{
+    return [self getBubbleSizeForImage:self.image];
+}
+
+-(BOOL)isImage {
+    return YES;
+}
+
+
+-(BOOL) isAudio {
+    return NO;
+}
+
+
+-(BOOL) isVideo {
+    return NO;
+}
+
+#pragma mark - Utility
+
+-(CGSize)getBubbleSizeForImage:(UIImage*)image
+{
+    CGFloat aspectRatio = image.size.height / image.size.width ;
+
+    if ([[UIDevice currentDevice] isiPhoneVersionSixOrMore])
+    {
+        return [self getLargeSizeForAspectRatio:aspectRatio];
+    } else {
+        return [self getSmallSizeForAspectRatio:aspectRatio];
+    }
+}
+
+-(CGSize)getLargeSizeForAspectRatio:(CGFloat)ratio
+{
+    return ratio > 1.0f ? [self largePortraitSize] : [self largeLandscapeSize];
+}
+
+-(CGSize)getSmallSizeForAspectRatio:(CGFloat)ratio
+{
+    return ratio > 1.0f ? [self smallPortraitSize] : [self smallLandscapeSize];
+}
+
+- (CGSize)largePortraitSize
+{
+    return CGSizeMake(220.0f, 310.0f);
+}
+
+- (CGSize)smallPortraitSize
+{
+    return CGSizeMake(150.0f, 210.0f);
+}
+
+- (CGSize)largeLandscapeSize
+{
+    return CGSizeMake(310.0f, 220.0f);
+}
+
+- (CGSize)smallLandscapeSize
+{
+    return CGSizeMake(210.0f, 150.0f);
+}
+
+@end

--- a/Signal/src/view controllers/TSMessageAdapter.m
+++ b/Signal/src/view controllers/TSMessageAdapter.m
@@ -16,6 +16,7 @@
 #import "TSErrorMessage.h"
 #import "TSAttachmentPointer.h"
 #import "TSVideoAttachmentAdapter.h"
+#import "TSAnimatedAdapter.h"
 
 
 @interface TSMessageAdapter ()
@@ -99,7 +100,12 @@
                 
                 if ([attachment isKindOfClass:[TSAttachmentStream class]]) {
                     TSAttachmentStream *stream = (TSAttachmentStream*)attachment;
-                    if ([stream isImage]) {
+                    if ([stream isAnimated]) {
+                        adapter.mediaItem = [[TSAnimatedAdapter alloc] initWithAttachment:stream];
+                        adapter.mediaItem.appliesMediaViewMaskAsOutgoing = [interaction isKindOfClass:[TSOutgoingMessage class]];
+                        break;
+                    }
+                    else if ([stream isImage]) {
                         adapter.mediaItem = [[TSPhotoAdapter alloc] initWithAttachment:stream];
                         adapter.mediaItem.appliesMediaViewMaskAsOutgoing = [interaction isKindOfClass:[TSOutgoingMessage class]];
                         break;


### PR DESCRIPTION
Implemented using @corbett's suggestion in issue WhisperSystems/Signal-iOS#525. Uses Flipboard/FLAnimatedImage in an AttachmentAdapter. Detects gifs using new Animated category in MIMETypeUtil.

Backwards-compatible with previous versions of Signal on iOS for both sending and receiving gifs, though they are sent/received in older versions as `UIImage` and won't animate (tested with live user running latest release). Gifs also animate on both ends of conversations with TextSecure users on Android (tested with live user running latest release).

Considerations:
- ~~Tap to enlarge isn't supported. They are only displayed within the message bubble and tapping has no effect.~~
- Images are no longer compressed before sending since they aren't run through `UIImageJPEGRepresentation`.

![Example](http://i.imgur.com/5DOiJSz.gif)