### PR TITLE
Fix for issue #957 (quit button not displaying when scanning fingerprint)

### DIFF
--- a/Signal/src/view controllers/ScanIdentityBarcodeViewController.m
+++ b/Signal/src/view controllers/ScanIdentityBarcodeViewController.m
@@ -45,7 +45,7 @@
     self.prevLayer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
     self.prevLayer.frame = self.view.bounds;
     self.prevLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
-    [self.view.layer addSublayer:self.prevLayer];
+    [self.view.layer insertSublayer:self.prevLayer atIndex:0];
     
     [self.session startRunning];
     


### PR DESCRIPTION
The AVCaptureVideoPreviewLayer was being inserted as the topmost layer, therefore the quit button wouldn't show up when ScanIdentityBarcodeViewController is presented.