### PR TITLE
Update README to remove a mention of old software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Signal for iOS [![Build Status](https://travis-ci.org/WhisperSystems/Signal-iOS.svg?branch=master)](https://travis-ci.org/WhisperSystems/Signal-iOS)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/WhisperSystems/Signal-iOS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Signal allows you to make private phone calls ([RedPhone protocol](https://github.com/WhisperSystems/RedPhone/wiki)) and private text messaging ([TextSecure protocol](https://github.com/WhisperSystems/TextSecure/wiki)).
+Signal allows you to make private phone calls ([RedPhone protocol](https://github.com/WhisperSystems/RedPhone/wiki)) and private text messaging ([TextSecure protocol](https://github.com/WhisperSystems/Signal-Android/wiki)).
 
 [![Available on the AppStore](http://cl.ly/WouG/Download_on_the_App_Store_Badge_US-UK_135x40.svg)](https://itunes.apple.com/app/id874139669)
 
@@ -11,7 +11,7 @@ Help us translate Signal! The translation effort happens on [Transifex](https://
 
 ## Interoperability 
 
-Signal works with [RedPhone](https://github.com/WhisperSystems/Redphone) and [TextSecure](https://github.com/WhisperSystems/TextSecure) on Android.
+Signal for iOS works with [Signal](https://github.com/WhisperSystems/Signal-Android) on Android.
 
 ## Contributing Code
 Instructions on how to setup your development environment and build Signal-iOS can be found in  [BUILDING.md](https://github.com/WhisperSystems/Signal-iOS/blob/master/BUILDING.md).


### PR DESCRIPTION
Update README.md to remove one mention of RedPhone and TextSecure. 

The README needs a further update to remove the mentions of RedPhone and TextSecure on line 3 and 4. I would have made this change but I am not sure what those lines should link to now that the RedPhone repository has been removed.