### PR TITLE
Cocoapods needs latest openssl - 1.0.205

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 inhibit_all_warnings!
 link_with ["Signal", "SignalTests"]
 
-pod 'OpenSSL',                    '~> 1.0.204.1'
+pod 'OpenSSL',                    '~> 1.0.205'
 pod 'libPhoneNumber-iOS',         '~> 0.8.7'
 pod 'AxolotlKit'               
 pod 'PastelogKit',                '~> 1.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
   - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - AxolotlKit (0.8):
+  - AxolotlKit (0.7):
     - 25519 (~> 2.0.1)
     - HKDFKit (~> 0.0.3)
     - ProtocolBuffers (~> 1.9.8)
@@ -41,10 +41,10 @@ PODS:
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
   - libPhoneNumber-iOS (0.8.10)
-  - Mantle (2.0.6):
-    - Mantle/extobjc (= 2.0.6)
-  - Mantle/extobjc (2.0.6)
-  - OpenSSL (1.0.205)
+  - Mantle (2.0.5):
+    - Mantle/extobjc (= 2.0.5)
+  - Mantle/extobjc (2.0.5)
+  - OpenSSL (1.0.204.1)
   - PastelogKit (1.3):
     - CocoaLumberjack (~> 2.0)
   - ProtocolBuffers (1.9.9.2)
@@ -57,7 +57,7 @@ PODS:
   - TwistedOakCollapsingFutures (1.0.0):
     - UnionFind (~> 1.0)
   - UnionFind (1.0.1)
-  - YapDatabase/SQLCipher (2.7.7):
+  - YapDatabase/SQLCipher (2.7.6):
     - CocoaLumberjack (~> 2)
     - SQLCipher/fts
 
@@ -71,7 +71,7 @@ DEPENDENCIES:
     commit `e5582fef8a6b3e35f8070361ef37237222da712b`)
   - libPhoneNumber-iOS (~> 0.8.7)
   - Mantle (~> 2.0.4)
-  - OpenSSL (~> 1.0.205)
+  - OpenSSL (~> 1.0.204.1)
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
   - SocketRocket (from `https://github.com/FredericJacobs/SocketRocket.git`, commit
@@ -99,7 +99,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   '25519': dc4bad7e2dbcbf1efa121068a705a44cd98c80fc
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  AxolotlKit: a33962f26943990e5d69d05b30470cea18caeed0
+  AxolotlKit: 8652fca51f4bc8225cbda791b0026c21e912b694
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   DJWActionSheet: 2fe54b1298a7f0fe44462233752c76a530e0cd80
   FFCircularProgressView: 683a4ab1e1bd613246a3dffa61503ffdebcde8d8
@@ -108,8 +108,8 @@ SPEC CHECKSUMS:
   JSQMessagesViewController: ca11f86fa68ca70835f05e169df9244147c1dc40
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   libPhoneNumber-iOS: 7bfd00f843fdcd82b5182b463e8eb3b27579f41d
-  Mantle: 299966b00759634931699f69cb6a30b9239b944d
-  OpenSSL: 162687d7e96a3edeb4cf443ca6ce7cdb2912df7b
+  Mantle: 1912395033f601de5adc8ee91e48f46e4c7051ad
+  OpenSSL: 7f853fcada78e5162c2183b4d90ebbd0aa02f5ac
   PastelogKit: 7b475be4cf577713506a943dd940bcc0499c8bca
   ProtocolBuffers: 7111461618460961e6b7469177ec45ee551b4f0e
   SCWaveformView: 52a96750255d817e300565a80c81fb643e233e07
@@ -118,6 +118,6 @@ SPEC CHECKSUMS:
   SSKeychain: 3f42991739c6c60a9cf1bbd4dff6c0d3694bcf3d
   TwistedOakCollapsingFutures: f359b90f203e9ab13dfb92c9ff41842a7fe1cd0c
   UnionFind: c33be5adb12983981d6e827ea94fc7f9e370f52d
-  YapDatabase: a7a1ae3e0f89c319e3b22615c2351987fbbdbded
+  YapDatabase: 00e5a5d1b5dba1bd540ef644576233b5612e6122
 
 COCOAPODS: 0.39.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
   - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - AxolotlKit (0.7):
+  - AxolotlKit (0.8):
     - 25519 (~> 2.0.1)
     - HKDFKit (~> 0.0.3)
     - ProtocolBuffers (~> 1.9.8)
@@ -41,10 +41,10 @@ PODS:
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
   - libPhoneNumber-iOS (0.8.10)
-  - Mantle (2.0.5):
-    - Mantle/extobjc (= 2.0.5)
-  - Mantle/extobjc (2.0.5)
-  - OpenSSL (1.0.204.1)
+  - Mantle (2.0.6):
+    - Mantle/extobjc (= 2.0.6)
+  - Mantle/extobjc (2.0.6)
+  - OpenSSL (1.0.205)
   - PastelogKit (1.3):
     - CocoaLumberjack (~> 2.0)
   - ProtocolBuffers (1.9.9.2)
@@ -57,7 +57,7 @@ PODS:
   - TwistedOakCollapsingFutures (1.0.0):
     - UnionFind (~> 1.0)
   - UnionFind (1.0.1)
-  - YapDatabase/SQLCipher (2.7.6):
+  - YapDatabase/SQLCipher (2.7.7):
     - CocoaLumberjack (~> 2)
     - SQLCipher/fts
 
@@ -71,7 +71,7 @@ DEPENDENCIES:
     commit `e5582fef8a6b3e35f8070361ef37237222da712b`)
   - libPhoneNumber-iOS (~> 0.8.7)
   - Mantle (~> 2.0.4)
-  - OpenSSL (~> 1.0.204.1)
+  - OpenSSL (~> 1.0.205)
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
   - SocketRocket (from `https://github.com/FredericJacobs/SocketRocket.git`, commit
@@ -99,7 +99,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   '25519': dc4bad7e2dbcbf1efa121068a705a44cd98c80fc
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  AxolotlKit: 8652fca51f4bc8225cbda791b0026c21e912b694
+  AxolotlKit: a33962f26943990e5d69d05b30470cea18caeed0
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   DJWActionSheet: 2fe54b1298a7f0fe44462233752c76a530e0cd80
   FFCircularProgressView: 683a4ab1e1bd613246a3dffa61503ffdebcde8d8
@@ -108,8 +108,8 @@ SPEC CHECKSUMS:
   JSQMessagesViewController: ca11f86fa68ca70835f05e169df9244147c1dc40
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   libPhoneNumber-iOS: 7bfd00f843fdcd82b5182b463e8eb3b27579f41d
-  Mantle: 1912395033f601de5adc8ee91e48f46e4c7051ad
-  OpenSSL: 7f853fcada78e5162c2183b4d90ebbd0aa02f5ac
+  Mantle: 299966b00759634931699f69cb6a30b9239b944d
+  OpenSSL: 162687d7e96a3edeb4cf443ca6ce7cdb2912df7b
   PastelogKit: 7b475be4cf577713506a943dd940bcc0499c8bca
   ProtocolBuffers: 7111461618460961e6b7469177ec45ee551b4f0e
   SCWaveformView: 52a96750255d817e300565a80c81fb643e233e07
@@ -118,6 +118,6 @@ SPEC CHECKSUMS:
   SSKeychain: 3f42991739c6c60a9cf1bbd4dff6c0d3694bcf3d
   TwistedOakCollapsingFutures: f359b90f203e9ab13dfb92c9ff41842a7fe1cd0c
   UnionFind: c33be5adb12983981d6e827ea94fc7f9e370f52d
-  YapDatabase: 00e5a5d1b5dba1bd540ef644576233b5612e6122
+  YapDatabase: a7a1ae3e0f89c319e3b22615c2351987fbbdbded
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
OpenSSL to 1.0.205
*  ```pods install``` failed because https://openssl.org/source/openssl-1.0.2d.tar.gz has been moved to it's long term storage and replaced by 1.0.2.e
* Retrieved the new version by looking at changes made on December 3, 2015, to https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/OpenSSL/1.0.205/OpenSSL.podspec.json

FREEBIE