### PR TITLE
Added Cocoapods install to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ xcode_sdk: iphonesimulator9.1
 before_install:
     - brew update
     - brew uninstall xctool && brew install --HEAD xctool
-install: true
+install: pod install
 
 xcode_workspace: Signal.xcworkspace
 xcode_scheme: Signal


### PR DESCRIPTION
I created a pull request (#995) that modified the Podsfile and passed all validations. It seems to me (see additional comment in #995) that changing a version in the Podsfile should cause something to fail since the build seems to be using **Precompiled-Signal-Dependencies** instead of ```pod install```.

If this is the case, the test should validate that the expectations are not out of sync between the two repositories.

* Adding it as the 'install' step because that seems to be the way to do it - example on Travis site was 'npm install' which would be a similar step in Node.js

**Caution**: I don't have experience with Travis or Pods, so please only merge after appropriate validations.

FREEBIE