### PR TITLE
Fix UX Issues Discussed in Issue #1025

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -1766,37 +1766,20 @@ typedef enum : NSUInteger {
 - (void)didPressAccessoryButton:(UIButton *)sender {
     [self dismissKeyBoard];
 
-    UIView *presenter = self.parentViewController.view;
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NULL message:NULL preferredStyle: UIAlertControllerStyleAlert];
+    
+    UIAlertAction *takeMedia = [UIAlertAction actionWithTitle:NSLocalizedString(@"TAKE_MEDIA_BUTTON", @"") style:UIAlertControllerStyleAlert handler:^(UIAlertAction * _Nonnull action) {
+        [self takePictureOrVideo];
+    }];
 
-    [DJWActionSheet showInView:presenter
-                     withTitle:nil
-             cancelButtonTitle:NSLocalizedString(@"TXT_CANCEL_TITLE", @"")
-        destructiveButtonTitle:nil
-             otherButtonTitles:@[
-                 NSLocalizedString(@"TAKE_MEDIA_BUTTON", @""),
-                 NSLocalizedString(@"CHOOSE_MEDIA_BUTTON", @"")
-             ] //,@"Record audio"]
-                      tapBlock:^(DJWActionSheet *actionSheet, NSInteger tappedButtonIndex) {
-                        if (tappedButtonIndex == actionSheet.cancelButtonIndex) {
-                            DDLogVerbose(@"User Cancelled");
-                        } else if (tappedButtonIndex == actionSheet.destructiveButtonIndex) {
-                            DDLogVerbose(@"Destructive button tapped");
-                        } else {
-                            switch (tappedButtonIndex) {
-                                case 0:
-                                    [self takePictureOrVideo];
-                                    break;
-                                case 1:
-                                    [self chooseFromLibrary];
-                                    break;
-                                case 2:
-                                    [self recordAudio];
-                                    break;
-                                default:
-                                    break;
-                            }
-                        }
-                      }];
+    UIAlertAction *chooseMedia = [UIAlertAction actionWithTitle:NSLocalizedString(@"CHOOSE_MEDIA_BUTTON", @"") style:UIAlertControllerStyleAlert handler:^(UIAlertAction * _Nonnull action) {
+        [self chooseFromLibrary];
+    }];
+    
+    [alertController addAction:takeMedia];
+    [alertController addAction:chooseMedia];
+    
+    [self presentViewController:alertController animated:true completion:nil];
 }
 
 - (void)markAllMessagesAsRead {

--- a/Signal/src/view controllers/SettingsTableViewController.m
+++ b/Signal/src/view controllers/SettingsTableViewController.m
@@ -156,6 +156,9 @@ typedef enum {
         }
 
         case kNetworkStatusSection: {
+            UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+            [cell setSelectionStyle: UITableViewCellSelectionStyleNone];
+            
             break;
         }
 


### PR DESCRIPTION
Filed this PR to discuss the UX issues discussed in my issue request #1025 


1. Made cells of message groups larger
2. Extend Cell Insets to far right
3. Round the corners more on the message text field
4. Make the send button the same blue the app uses which would imply that it could be tapped and leads to nicer ui
5. Use standard system Alert View Controller and just change the color when picking images
6. Add back button to settings VC so it is more consistent and less confusing than having it segue back when the X is tapped.
7. Make Network Status Not animate when tapped

3,4 are fixed in PR #884 

## Completed (Need Testing)  
5, 7

1, 2, & 6 need to be discussed 