### PR TITLE
Network Signal and deactivate account row don't highlight

### DIFF
--- a/Signal/src/view controllers/SettingsTableViewController.m
+++ b/Signal/src/view controllers/SettingsTableViewController.m
@@ -170,6 +170,22 @@ typedef enum {
 }
 
 
+- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+    switch (indexPath.section) {
+        case kNetworkStatusSection: {
+            return NO;
+        }
+
+        case kUnregisterSection: {
+            return NO;
+        }
+
+        default:
+            return YES;
+    }
+}
+
+
 - (IBAction)unregisterUser:(id)sender {
     UIAlertController *alertController =
         [UIAlertController alertControllerWithTitle:NSLocalizedString(@"CONFIRM_ACCOUNT_DESTRUCTION_TITLE", @"")


### PR DESCRIPTION
Fixes 7 of https://github.com/WhisperSystems/Signal-iOS/issues/1025

This is actually a better way of doing it as opposed to what @jaredStef implemented in https://github.com/WhisperSystems/Signal-iOS/pull/1026
Using his approach, the table cell is highlighted the first time and is disabled for the subsequent times.