### PR TITLE
SignalUITests added

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		AD83FF441A73426500B5C81A /* audio_pause_button.png in Resources */ = {isa = PBXBuildFile; fileRef = AD83FF3D1A73426500B5C81A /* audio_pause_button.png */; };
 		AD83FF451A73426500B5C81A /* audio_pause_button@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AD83FF3E1A73426500B5C81A /* audio_pause_button@2x.png */; };
 		AD83FF471A73428300B5C81A /* audio_play_button_blue.png in Resources */ = {isa = PBXBuildFile; fileRef = AD83FF461A73428300B5C81A /* audio_play_button_blue.png */; };
+		ADCD2DCF1C4E16DC0096B04D /* SignalUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCD2DCE1C4E16DC0096B04D /* SignalUITests.swift */; };
 		B10C9B5F1A7049EC00ECA2BF /* pause_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = B10C9B5B1A7049EC00ECA2BF /* pause_icon.png */; };
 		B10C9B601A7049EC00ECA2BF /* pause_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B10C9B5C1A7049EC00ECA2BF /* pause_icon@2x.png */; };
 		B10C9B611A7049EC00ECA2BF /* play_icon.png in Resources */ = {isa = PBXBuildFile; fileRef = B10C9B5D1A7049EC00ECA2BF /* play_icon.png */; };
@@ -476,6 +477,13 @@
 			remoteGlobalIDString = A1FDCBF916DBC57D00868894;
 			remoteInfo = speex;
 		};
+		ADCD2DD11C4E16DC0096B04D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D221A080169C9E5E00537ABF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D221A088169C9E5E00537ABF;
+			remoteInfo = Signal;
+		};
 		B6AFCEBA19A93DA60098CFCB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D221A080169C9E5E00537ABF /* Project object */;
@@ -728,6 +736,9 @@
 		AD83FF3D1A73426500B5C81A /* audio_pause_button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = audio_pause_button.png; sourceTree = "<group>"; };
 		AD83FF3E1A73426500B5C81A /* audio_pause_button@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "audio_pause_button@2x.png"; sourceTree = "<group>"; };
 		AD83FF461A73428300B5C81A /* audio_play_button_blue.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = audio_play_button_blue.png; sourceTree = "<group>"; };
+		ADCD2DCC1C4E16DC0096B04D /* SignalUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SignalUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		ADCD2DCE1C4E16DC0096B04D /* SignalUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalUITests.swift; sourceTree = "<group>"; };
+		ADCD2DD01C4E16DC0096B04D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B10C9B5B1A7049EC00ECA2BF /* pause_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = pause_icon.png; sourceTree = "<group>"; };
 		B10C9B5C1A7049EC00ECA2BF /* pause_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "pause_icon@2x.png"; sourceTree = "<group>"; };
 		B10C9B5D1A7049EC00ECA2BF /* play_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = play_icon.png; sourceTree = "<group>"; };
@@ -1015,6 +1026,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		ADCD2DC91C4E16DC0096B04D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D221A086169C9E5E00537ABF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1637,6 +1655,15 @@
 			path = xibs;
 			sourceTree = "<group>";
 		};
+		ADCD2DCD1C4E16DC0096B04D /* SignalUITests */ = {
+			isa = PBXGroup;
+			children = (
+				ADCD2DCE1C4E16DC0096B04D /* SignalUITests.swift */,
+				ADCD2DD01C4E16DC0096B04D /* Info.plist */,
+			);
+			path = SignalUITests;
+			sourceTree = "<group>";
+		};
 		B60959791C2C0FA9004E8797 /* rating */ = {
 			isa = PBXGroup;
 			children = (
@@ -1954,6 +1981,7 @@
 			isa = PBXGroup;
 			children = (
 				D221A093169C9E5E00537ABF /* Signal */,
+				ADCD2DCD1C4E16DC0096B04D /* SignalUITests */,
 				D221A08C169C9E5E00537ABF /* Frameworks */,
 				D221A08A169C9E5E00537ABF /* Products */,
 				70B8009E190C529C0042E3F0 /* spandsp.xcodeproj */,
@@ -1967,6 +1995,7 @@
 			children = (
 				D221A089169C9E5E00537ABF /* Signal.app */,
 				D221A0AA169C9E5F00537ABF /* SignalTests.xctest */,
+				ADCD2DCC1C4E16DC0096B04D /* SignalUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2193,6 +2222,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		ADCD2DCB1C4E16DC0096B04D /* SignalUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ADCD2DD51C4E16DC0096B04D /* Build configuration list for PBXNativeTarget "SignalUITests" */;
+			buildPhases = (
+				ADCD2DC81C4E16DC0096B04D /* Sources */,
+				ADCD2DC91C4E16DC0096B04D /* Frameworks */,
+				ADCD2DCA1C4E16DC0096B04D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ADCD2DD21C4E16DC0096B04D /* PBXTargetDependency */,
+			);
+			name = SignalUITests;
+			productName = SignalUITests;
+			productReference = ADCD2DCC1C4E16DC0096B04D /* SignalUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		D221A088169C9E5E00537ABF /* Signal */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D221A0BC169C9E5F00537ABF /* Build configuration list for PBXNativeTarget "Signal" */;
@@ -2242,11 +2289,15 @@
 		D221A080169C9E5E00537ABF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0720;
+				LastSwiftUpdateCheck = 0730;
 				LastTestingUpgradeCheck = 0600;
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Open Whisper Systems";
 				TargetAttributes = {
+					ADCD2DCB1C4E16DC0096B04D = {
+						CreatedOnToolsVersion = 7.3;
+						TestTargetID = D221A088169C9E5E00537ABF;
+					};
 					D221A088169C9E5E00537ABF = {
 						SystemCapabilities = {
 							com.apple.DataProtection = {
@@ -2326,6 +2377,7 @@
 			targets = (
 				D221A088169C9E5E00537ABF /* Signal */,
 				D221A0A9169C9E5F00537ABF /* SignalTests */,
+				ADCD2DCB1C4E16DC0096B04D /* SignalUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -2348,6 +2400,13 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		ADCD2DCA1C4E16DC0096B04D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D221A087169C9E5E00537ABF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2499,6 +2558,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		ADCD2DC81C4E16DC0096B04D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ADCD2DCF1C4E16DC0096B04D /* SignalUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D221A085169C9E5E00537ABF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2885,6 +2952,11 @@
 			name = speex;
 			targetProxy = 70B800AD190C54870042E3F0 /* PBXContainerItemProxy */;
 		};
+		ADCD2DD21C4E16DC0096B04D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D221A088169C9E5E00537ABF /* Signal */;
+			targetProxy = ADCD2DD11C4E16DC0096B04D /* PBXContainerItemProxy */;
+		};
 		B6AFCEBB19A93DA60098CFCB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D221A088169C9E5E00537ABF /* Signal */;
@@ -2934,6 +3006,77 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		ADCD2DD31C4E16DC0096B04D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = SignalUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.whispersystems.signal.SignalUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TEST_TARGET_NAME = Signal;
+			};
+			name = Debug;
+		};
+		ADCD2DD41C4E16DC0096B04D /* App Store Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = SignalUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.whispersystems.signal.SignalUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_TARGET_NAME = Signal;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "App Store Release";
+		};
 		D221A0BA169C9E5F00537ABF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3269,6 +3412,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		ADCD2DD51C4E16DC0096B04D /* Build configuration list for PBXNativeTarget "SignalUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ADCD2DD31C4E16DC0096B04D /* Debug */,
+				ADCD2DD41C4E16DC0096B04D /* App Store Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		D221A083169C9E5E00537ABF /* Build configuration list for PBXProject "Signal" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Signal.xcodeproj/xcshareddata/xcschemes/Signal.xcscheme
+++ b/Signal.xcodeproj/xcshareddata/xcschemes/Signal.xcscheme
@@ -11,7 +11,8 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D221A088169C9E5E00537ABF"
@@ -35,6 +36,16 @@
                BlueprintIdentifier = "D221A0A9169C9E5F00537ABF"
                BuildableName = "SignalTests.xctest"
                BlueprintName = "SignalTests"
+               ReferencedContainer = "container:Signal.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ADCD2DCB1C4E16DC0096B04D"
+               BuildableName = "SignalUITests.xctest"
+               BlueprintName = "SignalUITests"
                ReferencedContainer = "container:Signal.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Signal/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Signal/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -77,6 +77,11 @@
       "idiom" : "ipad",
       "filename" : "launch-icon-ipad@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/SignalUITests/Info.plist
+++ b/SignalUITests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/SignalUITests/SignalUITests.swift
+++ b/SignalUITests/SignalUITests.swift
@@ -1,0 +1,737 @@
+//
+//  SignalUITests.swift
+//  SignalUITests
+//
+//  Created by Matthew Kotila on 1/13/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+
+import XCTest
+
+class SignalUITests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    // requires unverified app
+    func testCountryCodeSelectionScreenNavigation() {
+        
+        let app = XCUIApplication()
+        app.buttons["Country Code"].tap()
+        
+        XCTAssert(app.staticTexts["Select Country Code"].exists)
+        
+    }
+    
+    // requires unverified app
+    func testCountryCodeSelectionScreenBackNavigation() {
+        
+        let app = XCUIApplication()
+        app.buttons["Country Code"].tap()
+        app.navigationBars["Select Country Code"].buttons["btnCancel  white"].tap()
+        
+        XCTAssert(app.staticTexts["Your Phone Number"].exists)
+        
+    }
+    
+    // requires unverified app
+    func testCountryCodeSelectionScreenSearch() {
+        
+        let app = XCUIApplication()
+        app.buttons["Country Code"].tap()
+        let searchField = app.tables.childrenMatchingType(.SearchField).element
+        searchField.tap()
+        searchField.typeText("Fran")
+        
+        XCTAssert(app.staticTexts["France"].exists)
+        
+    }
+    
+    // requires unverified app
+    func testCountryCodeSelectionScreenStandardSelect() {
+        
+        let app = XCUIApplication()
+        app.buttons["Country Code"].tap()
+        app.tables.staticTexts["France"].tap()
+        
+        XCTAssert(app.buttons["France"].exists)
+        XCTAssert(app.buttons["+33"].exists)
+        
+    }
+    
+    // requires unverified app
+    func testCountryCodeSelectionScreenSearchSelect() {
+        
+        let app = XCUIApplication()
+        app.buttons["Country Code"].tap()
+        let searchField = app.tables.childrenMatchingType(.SearchField).element
+        searchField.tap()
+        searchField.typeText("Fran")
+        app.tables.staticTexts["France"].tap()
+        
+        XCTAssert(app.buttons["France"].exists)
+        XCTAssert(app.buttons["+33"].exists)
+        
+    }
+    
+    // requires unverified app
+    func testVerifyUnsupportedPhoneNumberAlert() {
+        
+        let app = XCUIApplication()
+        app.buttons["Verify This Device"].tap()
+        
+        XCTAssert(app.alerts["Registration Error"].exists)
+        
+    }
+    
+    // requires unverified app
+    func testVerifySupportedPhoneNumberChangeNumberNavigation() {
+        
+        let app = XCUIApplication()
+        app.textFields["Enter Number"].typeText("5555555555")
+        app.buttons["Verify This Device"].tap()
+        app.buttons["     Change Number"].tap()
+        
+        XCTAssert(app.staticTexts["Your Phone Number"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        
+        XCTAssert(app.staticTexts["Settings"].exists)
+        
+        app.navigationBars["Settings"].buttons["Done"].tap()
+        
+        XCTAssert(app.buttons["Inbox"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsPrivacyNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        app.tables.staticTexts["Privacy"].tap()
+        
+        XCTAssert(app.navigationBars["Privacy"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsPrivacyClearHistoryLogAlert() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        let tablesQuery = app.tables
+        tablesQuery.staticTexts["Privacy"].tap()
+        tablesQuery.staticTexts["Clear History Logs"].tap()
+        
+        
+        XCTAssert(app.staticTexts["Are you sure you want to delete all your history (messages, attachments, call history ...) ? This action cannot be reverted."].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsNotificationsNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        app.tables.staticTexts["Notifications"].tap()
+        
+        XCTAssert(app.navigationBars["Notifications"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsNotificationsOptionsNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        app.tables.staticTexts["Notifications"].tap()
+        app.tables.staticTexts["Show"].tap()
+        
+        XCTAssert(app.navigationBars["NotificationSettingsOptionsView"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsAdvancedNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        app.tables.staticTexts["Advanced"].tap()
+        
+        XCTAssert(app.navigationBars["Advanced"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsAboutNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        app.tables.staticTexts["About"].tap()
+        
+        XCTAssert(app.navigationBars["About"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsDeleteAccountAlert() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["settings"].tap()
+        app.tables.buttons["Delete Account"].tap()
+        
+        XCTAssert(app.alerts["Are you sure you want to delete your account?"].exists)
+        
+    }
+    
+    // requires verified app
+    func testComposeNewMessageNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        
+        XCTAssert(app.navigationBars["New Message"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageSelectNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        
+        XCTAssert(app.navigationBars["Test"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageSend() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).typeText("1")
+        app.toolbars.buttons["Send"].tap()
+        
+        XCTAssert(app.textViews["1"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageSendImage() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        let oldImagesCount = app.images.count
+        app.toolbars.buttons["btnAttachments  blue"].tap()
+        app.buttons["Choose from Library..."].tap()
+        app.buttons["Camera Roll"].tap()
+        app.cells.elementBoundByIndex(0).tap()
+        
+        XCTAssert(app.images.count > oldImagesCount)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageSendImageOptions() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        app.toolbars.buttons["btnAttachments  blue"].tap()
+        app.buttons["Choose from Library..."].tap()
+        app.buttons["Camera Roll"].tap()
+        app.cells.elementBoundByIndex(0).tap()
+        app.collectionViews.cells.otherElements.childrenMatchingType(.Other).elementBoundByIndex(0).childrenMatchingType(.Image).element.tap()
+        app.buttons["savephoto"].tap()
+        sleep(1)
+        
+        XCTAssert(app.buttons["Save to Camera Roll"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageSendVideo() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        let oldImagesCount = app.images.count
+        app.toolbars.buttons["btnAttachments  blue"].tap()
+        app.buttons["Choose from Library..."].tap()
+        app.buttons["Videos"].tap()
+        app.cells.elementBoundByIndex(0).tap()
+        app.buttons["Choose"].tap()
+        sleep(2)
+        
+        XCTAssert(app.images.count > oldImagesCount)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageSelectSendConversationsTimestamp() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).typeText("1")
+        app.toolbars.buttons["Send"].tap()
+        
+        let dateFormatter = NSDateFormatter.init()
+        dateFormatter.dateStyle = .NoStyle
+        dateFormatter.timeStyle = .ShortStyle
+        let timestamp = dateFormatter.stringFromDate(NSDate.init())
+        
+        app.buttons.elementBoundByIndex(0).tap()
+        
+        XCTAssert(app.tables.staticTexts[timestamp].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageSelectDisplayContactPhoneNumber() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        
+        app.navigationBars.staticTexts["Test"].tap()
+        
+        XCTAssert(app.navigationBars.staticTexts["+x xxx-xxx-xxxx"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageAttachmentAlert() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        sleep(2)
+        app.toolbars.buttons["btnAttachments  blue"].tap()
+        
+        print(XCUIApplication().debugDescription)
+        
+        XCTAssert(app.buttons["Take Photo or Video"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageFingerprintNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        app.navigationBars["Test"].staticTexts["Test"].pressForDuration(1.0)
+        
+        XCTAssert(app.staticTexts["Your Fingerprint"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageFingerprintExitNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        app.navigationBars["Test"].staticTexts["Test"].pressForDuration(1.0)
+        app.buttons["×"].tap()
+        
+        XCTAssert(!app.staticTexts["Your Fingerprint"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageFingerprintSessionAlert() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        app.navigationBars["Test"].staticTexts["Test"].pressForDuration(1.0)
+        app.staticTexts["Your Fingerprint"].pressForDuration(1.5)
+        
+        XCTAssert(app.buttons["Reset this session."].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageFingerprintDisplayNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        app.navigationBars["Test"].staticTexts["Test"].pressForDuration(1.0)
+        app.staticTexts["Your Fingerprint"].tap()
+        
+        XCTAssert(app.buttons["quit"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageFingerprintDisplayExitNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.staticTexts["Test"].tap()
+        app.navigationBars["Test"].staticTexts["Test"].pressForDuration(1.0)
+        app.staticTexts["Your Fingerprint"].tap()
+        app.buttons["quit"].tap()
+        
+        XCTAssert(!app.buttons["quit"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testConversationExitNavigation() {
+        
+        let app = XCUIApplication()
+        app.staticTexts["Test"].tap()
+        app.buttons.elementBoundByIndex(0).tap()
+        
+        XCTAssert(app.buttons["Inbox"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testConversationsSwipe() {
+        
+        let app = XCUIApplication()
+        app.staticTexts["Test"].swipeLeft()
+        
+        XCTAssert(app.buttons["Delete"].exists)
+        XCTAssert(app.buttons["Archive"].exists)
+        
+    }
+    
+    // requires verified app
+    func testComposeMessageNewGroupNavigation() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        
+        XCTAssert(app.navigationBars["New Group"].exists)
+        
+    }
+    
+    // requires verified app
+    func testComposeMessagNewGroupPictureAlert() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        app.buttons["empty group avatar"].tap()
+        
+        XCTAssert(app.buttons["Take a Picture"].exists)
+        
+    }
+    
+    // requires verified app
+    // THIS TEST SOMETIMES CRASHES MIDWAY DUE TO INHERENT ISSUE WITH SIGNAL'S
+    // GROUP CREATION
+    func testComposeMessageNewGroupCreate() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        app.buttons["add conversation"].tap()
+        
+        XCTAssert(app.alerts["Creating group"].exists)
+        
+        XCTAssert(app.tables.staticTexts["New Group"].exists)
+        
+    }
+    
+    // requires verified app
+    // THIS TEST SOMETIMES CRASHES MIDWAY DUE TO INHERENT ISSUE WITH SIGNAL'S
+    // GROUP CREATION
+    func testComposeMessageNewGroupCreateDelete() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        app.buttons["add conversation"].tap()
+        app.buttons.elementBoundByIndex(0).tap()
+        app.staticTexts["New Group"].swipeLeft()
+        app.tables.buttons["Delete"].tap()
+        
+        XCTAssert(app.staticTexts["Leaving group"].exists)
+        
+    }
+    
+    // requires verified app
+    func testGroupContactOptionsAction() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        app.buttons["add conversation"].tap()
+        app.tables.staticTexts["New Group"].tap()
+        app.navigationBars["New Group"].buttons["contact options action"].tap()
+        
+        XCTAssert(app.buttons["Update"].exists)
+        XCTAssert(app.buttons["Leave"].exists)
+        XCTAssert(app.buttons["Members"].exists)
+        
+    }
+    
+    // requires verified app
+    func testGroupContactOptionsUpdateAction() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        app.buttons["add conversation"].tap()
+        app.tables.staticTexts["New Group"].tap()
+        app.navigationBars["New Group"].buttons["contact options action"].tap()
+        app.toolbars.buttons["Update"].tap()
+        
+        XCTAssert(app.tables["Add people"].exists)
+        
+    }
+    
+    // requires verified app
+    func testGroupContactOptionsMembersAction() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        app.buttons["add conversation"].tap()
+        app.tables.staticTexts["New Group"].tap()
+        app.navigationBars["New Group"].buttons["contact options action"].tap()
+        app.toolbars.buttons["Members"].tap()
+        
+        XCTAssert(app.tables.staticTexts["Group Members:"].exists)
+        
+    }
+    
+    // requires verified app
+    func testGroupContactOptionsLeaveAction() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.navigationBars["New Message"].buttons["btnGroup  white"].tap()
+        app.buttons["add conversation"].tap()
+        app.tables.staticTexts["New Group"].tap()
+        app.navigationBars["New Group"].buttons["contact options action"].tap()
+        app.toolbars.buttons["Leave"].tap()
+        
+        XCTAssert(app.staticTexts["You have left the group."].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageContactSearch() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        let searchField = app.tables.searchFields["Search by name or number"]
+        searchField.tap()
+        app.typeText("Tes")
+        
+        XCTAssert(app.tables.staticTexts["Test"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testComposeMessageContactSearchSelect() {
+        
+        let app = XCUIApplication()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.tables.searchFields["Search by name or number"].tap()
+        app.typeText("Tes")
+        
+        app.tables.staticTexts["Test"].coordinateWithNormalizedOffset(CGVectorMake(0.0, 0.0)).tap()
+        
+        XCTAssert(app.navigationBars["Test"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testInboxConversationArchive() {
+        
+        let app = XCUIApplication()
+        app.buttons["Inbox"].tap()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.staticTexts["Test"].tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).typeText("1")
+        app.toolbars.buttons["Send"].tap()
+        app.buttons.elementBoundByIndex(0).tap()
+        app.staticTexts["Test"].swipeLeft()
+        app.tables.buttons["Archive"].tap()
+        
+        XCTAssert(!app.tables.cells["Test"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testInboxConversationDelete() {
+        
+        let app = XCUIApplication()
+        app.buttons["Inbox"].tap()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.staticTexts["Test"].tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).typeText("1")
+        app.toolbars.buttons["Send"].tap()
+        app.buttons.elementBoundByIndex(0).tap()
+        app.staticTexts["Test"].swipeLeft()
+        app.tables.buttons["Delete"].tap()
+        
+        XCTAssert(!app.tables.cells["Test"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testArchiveConversationUnarchive() {
+        
+        let app = XCUIApplication()
+        app.buttons["Inbox"].tap()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.staticTexts["Test"].tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).typeText("1")
+        app.toolbars.buttons["Send"].tap()
+        app.buttons.elementBoundByIndex(0).tap()
+        app.staticTexts["Test"].swipeLeft()
+        app.tables.buttons["Archive"].tap()
+        app.buttons["Archive"].tap()
+        app.staticTexts["Test"].swipeLeft()
+        app.tables.buttons["Unarchive"].tap()
+        
+        XCTAssert(!app.tables.cells["Test"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testArchiveConversationDelete() {
+        
+        let app = XCUIApplication()
+        app.buttons["Inbox"].tap()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.staticTexts["Test"].tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).typeText("1")
+        app.toolbars.buttons["Send"].tap()
+        app.buttons.elementBoundByIndex(0).tap()
+        app.staticTexts["Test"].swipeLeft()
+        app.tables.buttons["Archive"].tap()
+        app.buttons["Archive"].tap()
+        app.staticTexts["Test"].swipeLeft()
+        app.tables.buttons["Delete"].tap()
+        
+        XCTAssert(!app.tables.cells["Test"].exists)
+        
+    }
+    
+    // requires verified app AND valid contact with name "Test"
+    func testSettingsPrivacyClearHistory() {
+        
+        let app = XCUIApplication()
+        app.buttons["Inbox"].tap()
+        app.navigationBars["Conversations"].buttons["Compose"].tap()
+        app.staticTexts["Test"].tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).tap()
+        app.textViews.elementBoundByIndex(app.textViews.count - 1).typeText("1")
+        app.toolbars.buttons["Send"].tap()
+        app.buttons.elementBoundByIndex(0).tap()
+        app.buttons["settings"].tap()
+        app.tables.staticTexts["Privacy"].tap()
+        app.tables.staticTexts["Clear History Logs"].tap()
+        app.buttons["I'm sure."].tap()
+        app.buttons["Settings"].tap()
+        app.buttons["Done"].tap()
+        
+        XCTAssert(!app.staticTexts["Test"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsAdvancedEnableDebugLog() {
+        
+        let app = XCUIApplication()
+        app.buttons["settings"].tap()
+        app.tables.staticTexts["Advanced"].tap()
+        app.switches.elementBoundByIndex(0).coordinateWithNormalizedOffset(CGVectorMake(0, 0)).pressForDuration(0, thenDragToCoordinate: app.switches.elementBoundByIndex(0).coordinateWithNormalizedOffset(CGVectorMake(1, 0)))
+        
+        XCTAssert(app.tables.staticTexts["Submit Debug Log"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsAdvancedDisableDebugLog() {
+        
+        let app = XCUIApplication()
+        app.buttons["settings"].tap()
+        app.tables.staticTexts["Advanced"].tap()
+        app.switches.elementBoundByIndex(0).coordinateWithNormalizedOffset(CGVectorMake(0, 0)).pressForDuration(0, thenDragToCoordinate: app.switches.elementBoundByIndex(0).coordinateWithNormalizedOffset(CGVectorMake(-1, 0)))
+        
+        XCTAssert(!app.tables.staticTexts["Submit Debug Log"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsAdvancedSubmitDebugLog() {
+        
+        let app = XCUIApplication()
+        app.buttons["settings"].tap()
+        app.tables.staticTexts["Advanced"].tap()
+        app.switches["Enable Debug Log"].swipeLeft()
+        app.tables.staticTexts["Submit Debug Log"].tap()
+        
+        XCTAssert(app.staticTexts["Sending debug log ..."].exists)
+        
+        expectationForPredicate(NSPredicate(format: "exists == true"), evaluatedWithObject: app.alerts["Submit Debug Log"], handler: nil)
+        waitForExpectationsWithTimeout(5, handler: nil)
+        
+        XCTAssert(app.alerts["Submit Debug Log"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsAdvancedReRegisterForPushNotifications() {
+        
+        let app = XCUIApplication()
+        app.buttons["settings"].tap()
+        app.tables.staticTexts["Advanced"].tap()
+        app.tables.staticTexts["Re-register for push notifications"].tap()
+        
+        XCTAssert(app.alerts["Push Notifications"].exists)
+        
+    }
+    
+    // requires verified app
+    func testSettingsNotificationsOptionsPreview() {
+        
+        let app = XCUIApplication()
+        app.buttons["settings"].tap()
+        app.tables.staticTexts["Notifications"].tap()
+        app.tables.staticTexts["Show"].tap()
+        app.tables.staticTexts["Sender name & message"].tap()
+        
+        XCTAssert(app.staticTexts["Sender name & message"].exists)
+        
+    }
+    
+}


### PR DESCRIPTION
Added UI tests to Signal in Swift. Some tests require the app to be
verified with a real number, and some require a “Test” contact that is
verified with Signal (can be self).
