### PR TITLE
#1076 - Problem with installing openssl from pod - fixed

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 link_with ["Signal", "SignalTests"]
 
 pod 'TextSecureKit',              :git => 'https://github.com/WhisperSystems/TextSecureKit', :branch => 'master'
-pod 'OpenSSL',                    '~> 1.0.205'
+pod 'OpenSSL',                    '~> 1.0’
 pod 'PastelogKit',                '~> 1.3'
 pod 'FFCircularProgressView',     '~> 0.5'
 pod 'SCWaveformView',             '~> 1.0'

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 link_with ["Signal", "SignalTests"]
 
 pod 'TextSecureKit',              :git => 'https://github.com/WhisperSystems/TextSecureKit', :branch => 'master'
-pod 'OpenSSL',                    '~> 1.0’
+pod 'OpenSSL',                    '~> 1.0.206’
 pod 'PastelogKit',                '~> 1.3'
 pod 'FFCircularProgressView',     '~> 0.5'
 pod 'SCWaveformView',             '~> 1.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -37,7 +37,7 @@ PODS:
   - Mantle (2.0.6):
     - Mantle/extobjc (= 2.0.6)
   - Mantle/extobjc (2.0.6)
-  - OpenSSL (1.0.205)
+  - OpenSSL (1.0.206)
   - PastelogKit (1.3):
     - CocoaLumberjack (~> 2.0)
   - ProtocolBuffers (1.9.9.2)
@@ -70,7 +70,7 @@ DEPENDENCIES:
   - FFCircularProgressView (~> 0.5)
   - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController`,
     commit `e5582fef8a6b3e35f8070361ef37237222da712b`)
-  - OpenSSL (~> 1.0.205)
+  - OpenSSL (~> 1.0.206)
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
   - TextSecureKit (from `https://github.com/WhisperSystems/TextSecureKit`, branch
@@ -104,7 +104,7 @@ SPEC CHECKSUMS:
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   libPhoneNumber-iOS: 7bfd00f843fdcd82b5182b463e8eb3b27579f41d
   Mantle: 299966b00759634931699f69cb6a30b9239b944d
-  OpenSSL: 162687d7e96a3edeb4cf443ca6ce7cdb2912df7b
+  OpenSSL: 0de82ee7d57a219bcc22a3e2cce78ae159c8fbea
   PastelogKit: 7b475be4cf577713506a943dd940bcc0499c8bca
   ProtocolBuffers: 7111461618460961e6b7469177ec45ee551b4f0e
   SCWaveformView: 52a96750255d817e300565a80c81fb643e233e07


### PR DESCRIPTION
1.0.205 is not exisitng anymore.
~> sign will not work if we adding last part of version signature.
Removing last part will fix the problem.

FREEBIE