### PR TITLE
Useless didReceiveMemoryWarning methods removed from view controllers

### DIFF
--- a/Signal/src/view controllers/APNavigationController.m
+++ b/Signal/src/view controllers/APNavigationController.m
@@ -35,11 +35,6 @@
     self.originalNavigationBarTitle = self.navigationBar.topItem.title;
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
 - (void)toggleDropDown:(id)sender {
     if (self.isDropDownVisible) {
         [self hideDropDown:sender];

--- a/Signal/src/view controllers/AdvancedSettingsTableViewController.m
+++ b/Signal/src/view controllers/AdvancedSettingsTableViewController.m
@@ -41,10 +41,6 @@
     return [super initWithStyle:UITableViewStyleGrouped];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 - (void)loadView {
     [super loadView];
 

--- a/Signal/src/view controllers/CodeVerificationViewController.m
+++ b/Signal/src/view controllers/CodeVerificationViewController.m
@@ -49,11 +49,6 @@
     [self adjustScreenSizes];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
-
 - (IBAction)verifyChallengeAction:(id)sender {
     [self enableServerActions:NO];
     [_challengeTextField resignFirstResponder];

--- a/Signal/src/view controllers/FingerprintViewController.m
+++ b/Signal/src/view controllers/FingerprintViewController.m
@@ -67,10 +67,6 @@ static NSString *const kScanIdentityBarcodeViewSegue   = @"ScanIdentityBarcodeVi
                      completion:nil];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 - (void)setTheirKeyInformation {
     self.contactFingerprintTitleLabel.text = self.thread.name;
     NSData *identityKey = [[TSStorageManager sharedManager] identityKeyForRecipientId:self.thread.contactIdentifier];

--- a/Signal/src/view controllers/FullImageViewController.m
+++ b/Signal/src/view controllers/FullImageViewController.m
@@ -79,12 +79,6 @@
     [self populateImageView:self.image];
 }
 
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
-
 #pragma mark - Initializers
 
 - (void)initializeBackground {

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -51,11 +51,6 @@
     self.title = NSLocalizedString(@"MESSAGE_COMPOSEVIEW_TITLE", @"");
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
-
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -302,10 +302,6 @@ typedef enum : NSUInteger {
     self.inputToolbar.contentView.textView.editable = NO;
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 #pragma mark - Initiliazers
 
 

--- a/Signal/src/view controllers/NewGroupViewController.m
+++ b/Signal/src/view controllers/NewGroupViewController.m
@@ -90,10 +90,6 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
     _addPeopleLabel.text            = NSLocalizedString(@"NEW_GROUP_REQUEST_ADDPEOPLE", @"");
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 #pragma mark - Initializers
 
 - (void)initializeDelegates {

--- a/Signal/src/view controllers/PresentIdentityQRCodeViewController.m
+++ b/Signal/src/view controllers/PresentIdentityQRCodeViewController.m
@@ -13,12 +13,6 @@
 
 @implementation PresentIdentityQRCodeViewController
 
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
-
 - (void)viewDidLoad {
     [super viewDidLoad];
 

--- a/Signal/src/view controllers/RegistrationViewController.m
+++ b/Signal/src/view controllers/RegistrationViewController.m
@@ -58,12 +58,6 @@ static NSString *const kCodeSentSegue = @"codeSent";
     [_phoneNumberTextField becomeFirstResponder];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
-
 #pragma mark - Locale
 
 - (void)populateDefaultCountryNameAndCode {

--- a/Signal/src/view controllers/ShowGroupMembersViewController.m
+++ b/Signal/src/view controllers/ShowGroupMembersViewController.m
@@ -55,10 +55,6 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
                                      untilCancelled:nil];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 #pragma mark - Initializers
 
 

--- a/Signal/src/view controllers/SignalsNavigationController.m
+++ b/Signal/src/view controllers/SignalsNavigationController.m
@@ -25,11 +25,6 @@ static double const STALLED_PROGRESS = 0.9;
     [TSSocketManager sendNotification];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
 - (void)initializeSocketStatusBar {
     if (!_socketStatusView) {
         _socketStatusView = [[UIProgressView alloc] initWithProgressViewStyle:UIProgressViewStyleDefault];


### PR DESCRIPTION
During code review I've found few useless didReceiveMemoryWarning methods in view controllers. I've decided to remove is. 
Less is better :)