### PR TITLE
Add templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!-- This is a bug report template. By following the instructions below and filling out the sections with your information, you will help the developers to get all the necessary data to fix your issue.
+You can also preview your report before submitting it. You may remove sections that aren't relevant to your particular case.
+
+Before we begin, please note that this tracker is only for issues, not questions or comments.
+
+If you are looking for support, please see our support center instead:
+http://support.whispersystems.org/
+or email support@whispersystems.org
+
+Let's begin with a checklist: please replace the empty checkbox [ ] below with a checked one [x] to indicate that you have searched for existing issues -->
+
+- [ ] I have searched open and closed issues for duplicates
+
+----------------------------------------
+
+### Bug description
+Describe here the issue that you are experiencing.
+
+### Steps to reproduce
+- using hyphens as bullet points
+- list the steps
+- that reproduce the bug
+
+**Actual result:** Describe here what happens after you run the steps above (i.e. the buggy behaviour)
+**Expected result:** Describe here what should happen after you run the steps above (i.e. what would be the correct behaviour)
+
+### Screenshots
+<!-- you can drag and drop images below -->
+
+
+### Device info
+<!-- replace the examples with your info -->
+**Device**: iDevice X
+**iOS version**: X.Y.Z
+**Signal version:** Z.Y
+
+### Link to debug log
+<!-- immediately after the bug has happened capture a debug log via Signal's advanced settings and paste the link below -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- You can remove this first section if you have contributed before -->
+### First time contributor checklist
+<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
+- [ ] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
+- [ ] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
+
+### Contributor checklist
+<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
+- [ ] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
+- [ ] My commits are rebased on the latest master branch
+- [ ] My commits are in nice logical chunks
+- [ ] My contribution is fully baked and is ready to be merged as is
+- [ ] I have tested my contribution on these devices:
+ * iDevice A, iOS X.Y.Z
+ * iDevice B, iOS Z.Y
+- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message
+
+- - - - - - - - - -
+
+### Description
+<!--
+Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
+Also, please describe shortly how you tested that your fix actually works.
+-->


### PR DESCRIPTION
GitHub recently [introduced](https://github.com/blog/2111-issue-and-pull-request-templates) templates for issues and PRs.

The issue template will hopefully guide the submitter to give all the necessary information in the first post.
See [an example](https://github.com/WhisperSystems/Signal-Android/issues/5264) at the Android repository.

The PR template will remind the contributor with checklists. I based it on the info available in [README.md](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md), [CONTRIBUTING.md](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md), [corbett's tutorial](https://gist.github.com/corbett/ef9fd5f1abbef3b02f3b) and related parts in the other repositories.
See [an example](https://github.com/WhisperSystems/Signal-Android/pull/5260) of a PR that uses a template at the Android repository.

Both templates are in `.github/` directory to avoid cluttering the root directory.