### PR TITLE
explictly add delete action which became "opt-in" upstream

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -173,6 +173,8 @@ typedef enum : NSUInteger {
     [self initializeBubbles];
     [self initializeTextView];
 
+    [JSQMessagesCollectionViewCell registerMenuAction:@selector(delete:)];
+
     [self initializeCollectionViewLayout];
 
     self.senderId          = ME_MESSAGE_IDENTIFIER;


### PR DESCRIPTION
Note: This will fail until #1076 is merged.

#913: There is currently no way to delete individual messages in Signal-iOS.

The delete action was made opt-in as of upstream: https://github.com/jessesquires/JSQMessagesViewController/issues/970

With this fix, when you long press on a text message you see:

![image](https://cloud.githubusercontent.com/assets/217057/13710961/f7777c2a-e770-11e5-97e4-9c5a6c46815f.png)

Note that this doesn't fix the broken media messages delete actions described in #1103 