### PR TITLE
Fix ability to attach photos from camera

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -931,50 +931,54 @@ typedef enum : NSUInteger {
                 if ([[messageItem media] isKindOfClass:[TSPhotoAdapter class]]) {
                     TSPhotoAdapter *messageMedia = (TSPhotoAdapter *)[messageItem media];
 
-                    if ([messageMedia isImage]) {
-                        tappedImage = ((UIImageView *)[messageMedia mediaView]).image;
+                    tappedImage = ((UIImageView *)[messageMedia mediaView]).image;
+                    if(tappedImage == nil) {
+                        DDLogWarn(@"tapped TSPhotoAdapter with nil image");
+                    } else {
                         CGRect convertedRect =
-                            [self.collectionView convertRect:[collectionView cellForItemAtIndexPath:indexPath].frame
-                                                      toView:nil];
+                        [self.collectionView convertRect:[collectionView cellForItemAtIndexPath:indexPath].frame
+                                                  toView:nil];
                         __block TSAttachment *attachment = nil;
                         [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-                          attachment =
-                              [TSAttachment fetchObjectWithUniqueID:messageMedia.attachmentId transaction:transaction];
+                            attachment =
+                            [TSAttachment fetchObjectWithUniqueID:messageMedia.attachmentId transaction:transaction];
                         }];
 
                         if ([attachment isKindOfClass:[TSAttachmentStream class]]) {
                             TSAttachmentStream *attStream = (TSAttachmentStream *)attachment;
                             FullImageViewController *vc   = [[FullImageViewController alloc]
-                                initWithAttachment:attStream
-                                          fromRect:convertedRect
-                                    forInteraction:[self interactionAtIndexPath:indexPath]
-                                        isAnimated:NO];
+                                                             initWithAttachment:attStream
+                                                             fromRect:convertedRect
+                                                             forInteraction:[self interactionAtIndexPath:indexPath]
+                                                             isAnimated:NO];
 
                             [vc presentFromViewController:self.navigationController];
                         }
-                    } else {
-                        DDLogWarn(@"Currently unsupported");
                     }
                 } else if ([[messageItem media] isKindOfClass:[TSAnimatedAdapter class]]) {
                     // Show animated image full-screen
                     TSAnimatedAdapter *messageMedia = (TSAnimatedAdapter *)[messageItem media];
                     tappedImage                     = ((UIImageView *)[messageMedia mediaView]).image;
-                    CGRect convertedRect =
+                    if(tappedImage == nil) {
+                        DDLogWarn(@"tapped TSAnimatedAdapter with nil image");
+                    } else {
+                        CGRect convertedRect =
                         [self.collectionView convertRect:[collectionView cellForItemAtIndexPath:indexPath].frame
                                                   toView:nil];
-                    __block TSAttachment *attachment = nil;
-                    [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-                      attachment =
-                          [TSAttachment fetchObjectWithUniqueID:messageMedia.attachmentId transaction:transaction];
-                    }];
-                    if ([attachment isKindOfClass:[TSAttachmentStream class]]) {
-                        TSAttachmentStream *attStream = (TSAttachmentStream *)attachment;
-                        FullImageViewController *vc =
+                        __block TSAttachment *attachment = nil;
+                        [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+                            attachment =
+                            [TSAttachment fetchObjectWithUniqueID:messageMedia.attachmentId transaction:transaction];
+                        }];
+                        if ([attachment isKindOfClass:[TSAttachmentStream class]]) {
+                            TSAttachmentStream *attStream = (TSAttachmentStream *)attachment;
+                            FullImageViewController *vc =
                             [[FullImageViewController alloc] initWithAttachment:attStream
                                                                        fromRect:convertedRect
                                                                  forInteraction:[self interactionAtIndexPath:indexPath]
                                                                      isAnimated:YES];
-                        [vc presentFromViewController:self.navigationController];
+                            [vc presentFromViewController:self.navigationController];
+                        }
                     }
                 } else if ([[messageItem media] isKindOfClass:[TSVideoAttachmentAdapter class]]) {
                     // fileurl disappeared should look up in db as before. will do refactor


### PR DESCRIPTION
Fixes problem where attaching photo from camera results in uploading a 0 length attachment. Which shows this spinner forever:

![image](https://cloud.githubusercontent.com/assets/217057/13733046/c159ea7a-e94a-11e5-8034-e75edb53b092.png)


When the progress bubble is tapped (by sender or receiver), it results in a crash.

Looks like this came about with the animated GIF handling. We'll only
go down the byte-comparison-mime-type-detecting code path for attaching
existing photos, since it only exists for animated GIFs.

The [ALAssetsLibrary](https://developer.apple.com/library/ios/documentation/AssetsLibrary/Reference/ALAssetsLibrary_Class) is only for interacting with pre-existing saved assets, not for images newly captured in the image picker.

This will also revert to properly compressing our image attachements, so
long as they are taken from the camera.

Maybe fixes #1037, waiting to hear back if that user was on master or using from the app store, since the animated gif code isn't in the app store. So, could be a separate issue.

// FREEBIE