### PR TITLE
show alert must happen in main thread

### DIFF
--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -479,14 +479,14 @@
           });
         }
         failure:^(NSError *error) {
-          UIAlertView *alert = [[UIAlertView alloc] initWithTitle:TIMEOUT
-                                                          message:TIMEOUT_CONTACTS_DETAIL
-                                                         delegate:nil
-                                                cancelButtonTitle:NSLocalizedString(@"OK", @"")
-                                                otherButtonTitles:nil];
-          [alert show];
-          dispatch_async(dispatch_get_main_queue(), ^{
-            [self updateAfterRefreshTry];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                UIAlertView *alert = [[UIAlertView alloc] initWithTitle:TIMEOUT
+                                                                message:TIMEOUT_CONTACTS_DETAIL
+                                                               delegate:nil
+                                                      cancelButtonTitle:NSLocalizedString(@"OK", @"")
+                                                      otherButtonTitles:nil];
+                [alert show];
+                [self updateAfterRefreshTry];
           });
         }];
 


### PR DESCRIPTION
All UI updates must happen on the main thread.

This will crash if it happens off main thread (as it intermittently does for me locally).