### PR TITLE
Switched JSQMessagagesViewController fork adding Copy Image, Location etc feature

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,10 +3,10 @@ source 'https://github.com/CocoaPods/Specs.git'
 link_with ["Signal", "SignalTests"]
 
 pod 'TextSecureKit',              :git => 'https://github.com/WhisperSystems/TextSecureKit', :branch => 'master'
-pod 'OpenSSL',                    '~> 1.0.205'
+pod 'OpenSSL',                    '~> 1.0.206’
 pod 'PastelogKit',                '~> 1.3'
 pod 'FFCircularProgressView',     '~> 0.5'
 pod 'SCWaveformView',             '~> 1.0'
 pod 'DJWActionSheet'
 
-pod 'JSQMessagesViewController',  :git => 'https://github.com/WhisperSystems/JSQMessagesViewController', :commit => 'e5582fef8a6b3e35f8070361ef37237222da712b'
+pod 'JSQMessagesViewController',  :git => 'https://github.com/pstasiak/JSQMessagesViewController', :commit => 'f32a95e8e7b4231616d40199812a9a3a680d0c4c'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,14 +30,14 @@ PODS:
   - DJWActionSheet (1.0.4)
   - FFCircularProgressView (0.5)
   - HKDFKit (0.0.3)
-  - JSQMessagesViewController (7.1.0):
+  - JSQMessagesViewController (7.2.0):
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
   - libPhoneNumber-iOS (0.8.10)
   - Mantle (2.0.6):
     - Mantle/extobjc (= 2.0.6)
   - Mantle/extobjc (2.0.6)
-  - OpenSSL (1.0.205)
+  - OpenSSL (1.0.206)
   - PastelogKit (1.3):
     - CocoaLumberjack (~> 2.0)
   - ProtocolBuffers (1.9.9.2)
@@ -68,9 +68,9 @@ PODS:
 DEPENDENCIES:
   - DJWActionSheet
   - FFCircularProgressView (~> 0.5)
-  - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController`,
-    commit `e5582fef8a6b3e35f8070361ef37237222da712b`)
-  - OpenSSL (~> 1.0.205)
+  - JSQMessagesViewController (from `https://github.com/pstasiak/JSQMessagesViewController`,
+    commit `f32a95e8e7b4231616d40199812a9a3a680d0c4c`)
+  - OpenSSL (~> 1.0.206)
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
   - TextSecureKit (from `https://github.com/WhisperSystems/TextSecureKit`, branch
@@ -78,16 +78,16 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   JSQMessagesViewController:
-    :commit: e5582fef8a6b3e35f8070361ef37237222da712b
-    :git: https://github.com/WhisperSystems/JSQMessagesViewController
+    :commit: f32a95e8e7b4231616d40199812a9a3a680d0c4c
+    :git: https://github.com/pstasiak/JSQMessagesViewController
   TextSecureKit:
     :branch: master
     :git: https://github.com/WhisperSystems/TextSecureKit
 
 CHECKOUT OPTIONS:
   JSQMessagesViewController:
-    :commit: e5582fef8a6b3e35f8070361ef37237222da712b
-    :git: https://github.com/WhisperSystems/JSQMessagesViewController
+    :commit: f32a95e8e7b4231616d40199812a9a3a680d0c4c
+    :git: https://github.com/pstasiak/JSQMessagesViewController
   TextSecureKit:
     :commit: f6f6133498661a7c406097970d152b4acea9099e
     :git: https://github.com/WhisperSystems/TextSecureKit
@@ -100,11 +100,11 @@ SPEC CHECKSUMS:
   DJWActionSheet: 2fe54b1298a7f0fe44462233752c76a530e0cd80
   FFCircularProgressView: 683a4ab1e1bd613246a3dffa61503ffdebcde8d8
   HKDFKit: c058305d6f64b84f28c50bd7aa89574625bcb62a
-  JSQMessagesViewController: ca11f86fa68ca70835f05e169df9244147c1dc40
+  JSQMessagesViewController: 51ccd1c097da546b51054e21db9bff9322242ef5
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   libPhoneNumber-iOS: 7bfd00f843fdcd82b5182b463e8eb3b27579f41d
   Mantle: 299966b00759634931699f69cb6a30b9239b944d
-  OpenSSL: 162687d7e96a3edeb4cf443ca6ce7cdb2912df7b
+  OpenSSL: 0de82ee7d57a219bcc22a3e2cce78ae159c8fbea
   PastelogKit: 7b475be4cf577713506a943dd940bcc0499c8bca
   ProtocolBuffers: 7111461618460961e6b7469177ec45ee551b4f0e
   SCWaveformView: 52a96750255d817e300565a80c81fb643e233e07

--- a/Signal/src/view controllers/TSMessageAdapter.m
+++ b/Signal/src/view controllers/TSMessageAdapter.m
@@ -158,7 +158,7 @@
                                             callerDisplayName:adapter.messageBody
                                                          date:nil
                                                        status:status
-                                                displayString:@""];
+                                                 detailString:@""];
             call.useThumbnail = NO; // disables use of iconography to represent group update actions
             return call;
         }
@@ -214,7 +214,7 @@
                                        callerDisplayName:thread.name
                                                     date:call.date
                                                   status:status
-                                           displayString:detailString];
+                                            detailString:detailString];
     return jsqCall;
 }
 


### PR DESCRIPTION
This is somehow connected with #825. 
I created pull request to WhisperSystems' fork https://github.com/WhisperSystems/JSQMessagesViewController/pull/6, so after merging we could change address of repo in `Podfile`.