### PR TITLE
Fix runtime warnings

### DIFF
--- a/Signal/src/Storyboard/Storyboard.storyboard
+++ b/Signal/src/Storyboard/Storyboard.storyboard
@@ -606,9 +606,6 @@ A0 09 9A FF A8 8A 09 99</string>
                                         <color key="textColor" red="0.30192413926124573" green="0.30198189616203308" blue="0.30192050337791443" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits" keyboardType="phonePad" keyboardAppearance="light"/>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="keyPath" value="YES"/>
-                                        </userDefinedRuntimeAttributes>
                                     </textField>
                                     <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AbN-AU-yk7">
                                         <rect key="frame" x="20" y="18" width="152" height="26"/>

--- a/Signal/src/view controllers/UITests/SignalsViewController.m
+++ b/Signal/src/view controllers/UITests/SignalsViewController.m
@@ -137,13 +137,15 @@ static NSString *const kShowSignupFlowSegue = @"showSignupFlow";
     [super viewWillAppear:animated];
     [self checkIfEmptyView];
 
-    if (![TSAccountManager isRegistered]) {
-        [self performSegueWithIdentifier:kShowSignupFlowSegue sender:self];
-        return;
-    }
-
     [self updateInboxCountLabel];
     [[self tableView] reloadData];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    if (![TSAccountManager isRegistered]) {
+        [self performSegueWithIdentifier:kShowSignupFlowSegue sender:self];
+    }
 }
 
 - (void)tableViewSetUp {


### PR DESCRIPTION
Fixing a couple of things based on run time warnings. I'm not clear if these were causing crashes, but we don't want the noise in our run log.