### PR TITLE
After removing launch image, we need to update screen security

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '8.0'
 source 'https://github.com/CocoaPods/Specs.git'
 link_with ["Signal", "SignalTests"]
 
-pod 'SignalServiceKit',              :git => 'https://github.com/WhisperSystems/SignalServiceKit.git', :branch => 'test'
+pod 'SignalServiceKit',           :git => 'https://github.com/WhisperSystems/SignalServiceKit.git'
 pod 'OpenSSL',                    '~> 1.0.205'
 pod 'PastelogKit',                '~> 1.3'
 pod 'FFCircularProgressView',     '~> 0.5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -112,15 +112,13 @@ DEPENDENCIES:
   - OpenSSL (~> 1.0.205)
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
-  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`,
-    branch `test`)
+  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`)
 
 EXTERNAL SOURCES:
   JSQMessagesViewController:
     :commit: e5582fef8a6b3e35f8070361ef37237222da712b
     :git: https://github.com/WhisperSystems/JSQMessagesViewController
   SignalServiceKit:
-    :branch: test
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
 
 CHECKOUT OPTIONS:
@@ -128,7 +126,7 @@ CHECKOUT OPTIONS:
     :commit: e5582fef8a6b3e35f8070361ef37237222da712b
     :git: https://github.com/WhisperSystems/JSQMessagesViewController
   SignalServiceKit:
-    :commit: 518c44ce9ad3b005146669972d84e8d4c4477005
+    :commit: a0c147722e3a07412cb356c7712f42ba086a3fa0
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
 
 SPEC CHECKSUMS:

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -236,27 +236,11 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
         window.opaque                 = YES;
         window.userInteractionEnabled = NO;
         window.windowLevel            = CGFLOAT_MAX;
+        window.backgroundColor        = UIColor.ows_materialBlueColor;
 
-        // There appears to be no more reliable way to get the launchscreen image from an asset bundle
-        NSDictionary *dict = @{
-            @"320x480" : @"LaunchImage-700",
-            @"320x568" : @"LaunchImage-700-568h",
-            @"375x667" : @"LaunchImage-800-667h",
-            @"414x736" : @"LaunchImage-800-Portrait-736h"
-        };
+        UIViewController *vc = [[UIStoryboard storyboardWithName:@"Launch Screen" bundle:nil] instantiateInitialViewController];
 
-        NSString *key = [NSString stringWithFormat:@"%dx%d",
-                                                   (int)[UIScreen mainScreen].bounds.size.width,
-                                                   (int)[UIScreen mainScreen].bounds.size.height];
-        UIImage *launchImage = [UIImage imageNamed:dict[key]];
-        UIImageView *imgView = [[UIImageView alloc] initWithImage:launchImage];
-        UIViewController *vc = [[UIViewController alloc] initWithNibName:nil bundle:nil];
-        vc.view.frame        = [[UIScreen mainScreen] bounds];
-        imgView.frame        = [[UIScreen mainScreen] bounds];
-        [vc.view addSubview:imgView];
-        [vc.view setBackgroundColor:[UIColor ows_blackColor]];
         window.rootViewController = vc;
-
         window;
     });
 }


### PR DESCRIPTION
### Contributor checklist
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iphone 6 device
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description

Fixup of https://github.com/WhisperSystems/Signal-iOS/commit/199ce4926566d59f6733e996d804572bb98da748

Else we just see a black screen instead of the signal branding when switching screens.

Also gave the window a solid background color in case, for some reason,
the view controller can't be instantiated, because an opaque window doesn't do any good if its "clear color".

![image](https://cloud.githubusercontent.com/assets/217057/14392418/3e395726-fd8f-11e5-9f90-9e7378b35b63.png)