### PR TITLE
bump up travis timeout for pod install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ xcode_sdk: iphonesimulator9.1
 before_install:
     - brew update
     - brew uninstall xctool && brew install --HEAD xctool
-install: travis_wait pod install
+install: travis_wait 30 pod install
 
 xcode_workspace: Signal.xcworkspace
 xcode_scheme: Signal


### PR DESCRIPTION
### Description

Usually, a successful pod install takes 15 minutes on travis. But often enough Travis times out at 20 mins, failing the build.

```
The command "travis_wait pod install" failed and exited with 137 during.
Your build has been stopped.
```

e.g. https://travis-ci.org/WhisperSystems/Signal-iOS/builds/122349608