### PR TITLE
reset "Load Earlier Messages" when switching threads

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -128,6 +128,7 @@ typedef enum : NSUInteger {
       [self markAllMessagesAsRead];
       [self.collectionView reloadData];
     }];
+    [self updateLoadEarlierVisible];
 }
 
 - (void)hideInputIfNeeded {


### PR DESCRIPTION
Since we're now re-using the message controller across threads, we have
to reset some elements to their initial state when switching threads.
Missed this one.

Fixes: #1150

// FREEBIE