### PR TITLE
OpenSSL dependency update.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 link_with ["Signal", "SignalTests"]
 
 pod 'SignalServiceKit',           :git => 'https://github.com/WhisperSystems/SignalServiceKit.git'
-pod 'OpenSSL',                    '~> 1.0.205'
+pod 'OpenSSL',                    '~> 1.0.208'
 pod 'PastelogKit',                '~> 1.3'
 pod 'FFCircularProgressView',     '~> 0.5'
 pod 'SCWaveformView',             '~> 1.0'


### PR DESCRIPTION
Following security advisory
(https://www.openssl.org/news/secadv/20160503.txt), OpenSSL removed
sources of previous version.

//FREEBIE