### PR TITLE
[UI] smaller group action menu icon, revert edit divider to neutral color

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -37,7 +37,7 @@ PODS:
   - Mantle (2.0.6):
     - Mantle/extobjc (= 2.0.6)
   - Mantle/extobjc (2.0.6)
-  - OpenSSL (1.0.207)
+  - OpenSSL (1.0.208)
   - PastelogKit (1.3):
     - CocoaLumberjack (~> 2.0)
   - ProtocolBuffers (1.9.10)
@@ -109,7 +109,7 @@ DEPENDENCIES:
   - FFCircularProgressView (~> 0.5)
   - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController`,
     commit `e5582fef8a6b3e35f8070361ef37237222da712b`)
-  - OpenSSL (~> 1.0.205)
+  - OpenSSL (~> 1.0.208)
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
   - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`)
@@ -141,7 +141,7 @@ SPEC CHECKSUMS:
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   libPhoneNumber-iOS: ded33fab2c51ee847979556aa504c9e70f32d703
   Mantle: 299966b00759634931699f69cb6a30b9239b944d
-  OpenSSL: 26eb46b2836c0dade24fa53276b552f14c6eece1
+  OpenSSL: b187269d386b07452f56af273764ea0636dd5da8
   PastelogKit: 7b475be4cf577713506a943dd940bcc0499c8bca
   ProtocolBuffers: d088180c10072b3d24a9939a6314b7b9bcc2340b
   SCWaveformView: 52a96750255d817e300565a80c81fb643e233e07

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -430,6 +430,7 @@ typedef enum : NSUInteger {
                                              style:UIBarButtonItemStylePlain
                                             target:self
                                             action:@selector(didSelectShow:)];
+        self.navigationItem.rightBarButtonItem.imageInsets = UIEdgeInsetsMake(10, 20, 10, 0);
     }
 
     [self hideInputIfNeeded];

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -203,13 +203,6 @@ typedef enum : NSUInteger {
     self.inputToolbar.contentView.leftBarButtonItem           = _attachButton;
     self.inputToolbar.contentView.rightBarButtonItem          = _messageButton;
     self.inputToolbar.contentView.textView.layer.cornerRadius = 4.f;
-
-    CGFloat one_px = 1.0 / [UIScreen mainScreen].scale;
-    UIView *line =
-        [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.inputToolbar.contentView.bounds.size.width, one_px)];
-    line.backgroundColor  = [UIColor ows_materialBlueColor];
-    line.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    [self.inputToolbar.contentView addSubview:line];
 }
 
 - (void)viewWillAppear:(BOOL)animated {


### PR DESCRIPTION
### Resized Group Menu
Before (this was introduced since last release, so you won't see it in app store version):

![image](https://cloud.githubusercontent.com/assets/217057/15088329/03b2546c-13a7-11e6-880f-8bcb53ecb8d8.png)

After:

![image](https://cloud.githubusercontent.com/assets/217057/15088324/f7b84414-13a6-11e6-8811-6ad572eca7d4.png)

### Divider Line

Before (this was introduced since last release, so you won't see it in app store version):

Judged to be too jarring for a part of the interface which shouldn't be attention grabbing.
![image](https://cloud.githubusercontent.com/assets/217057/15093063/b3173c5e-1430-11e6-8821-d15eec2c7fbf.png)


After:
![image](https://cloud.githubusercontent.com/assets/217057/15093060/98f7988c-1430-11e6-992b-efdd11bd0313.png)





// FREEBIE