### PR TITLE
Fix unable to send invite via sms

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -40,7 +38,9 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.3.0.4</string>
+	<string>2.3.0.5</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LOGS_EMAIL</key>
 	<string>support@whispersystems.org</string>
 	<key>LOGS_URL</key>

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -341,7 +341,10 @@
     sendTextButton.hidden                = YES;
     self.searchController.searchBar.text = @"";
 
-    [self presentViewController:alertController animated:YES completion:[UIUtil modalCompletionBlock]];
+    //must dismiss search controller before presenting alert.
+    [self dismissViewControllerAnimated:YES completion:^{
+        [self presentViewController:alertController animated:YES completion:[UIUtil modalCompletionBlock]];
+    }];
 }
 
 #pragma mark - SMS Composer Delegate


### PR DESCRIPTION
### Description
FIXES: #1182 (unable unable to send invite via sms)

Could not present the sms invite alert controller because we were already presenting the UISearchController.

//FREEBIE