### PR TITLE
Load drafted message and resize inputToolbar - fixes #1185

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -231,18 +231,16 @@ typedef enum : NSUInteger {
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [self dismissKeyBoard];
+    
     [self startReadTimer];
 
     [self initializeTitleLabelGestureRecognizer];
 
     [self updateBackButtonAsync];
-
-    [self.inputToolbar.contentView.textView endEditing:YES];
-
+    //[self.inputToolbar.contentView.textView endEditing:YES];
     self.inputToolbar.contentView.textView.editable = YES;
-    
     [self loadDraftInCompose];
+    
     if (_composeOnOpen) {
         [self popKeyBoard];
     }
@@ -1895,6 +1893,9 @@ typedef enum : NSUInteger {
           dispatch_async(dispatch_get_main_queue(), ^{
             [self.inputToolbar.contentView.textView setText:placeholder];
             [self textViewDidChange:self.inputToolbar.contentView.textView];
+              if(self.inputToolbar.contentView.textView.text.length>0) {
+                  [self popKeyBoard];
+              }
           });
         }];
 }

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -144,7 +144,6 @@ typedef enum : NSUInteger {
         self.navigationItem.rightBarButtonItem = nil; // further group action disallowed
     } else {
         [self inputToolbar].hidden = NO;
-        [self loadDraftInCompose];
     }
 }
 
@@ -242,6 +241,8 @@ typedef enum : NSUInteger {
     [self.inputToolbar.contentView.textView endEditing:YES];
 
     self.inputToolbar.contentView.textView.editable = YES;
+    
+    [self loadDraftInCompose];
     if (_composeOnOpen) {
         [self popKeyBoard];
     }


### PR DESCRIPTION
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
  - iPhone 6, iOS 9.3.2
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

fixes #1185 

// FREEBIE

after opening a thread:

<img src="https://cloud.githubusercontent.com/assets/9985963/15332462/022aef06-1c66-11e6-9ba4-1437400a01bd.png" width=400>

comments:

a nicer ui behavior would be, if we load the drafted message in the viewWillAppear method, but than the resizing don't work. JSQMessagesViewController are adding observers late at viewDidAppear...
