### PR TITLE
Fix invite crashing without sms

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.3.0.5</string>
+	<string>2.3.0.6</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -342,9 +342,13 @@
     self.searchController.searchBar.text = @"";
 
     //must dismiss search controller before presenting alert.
-    [self dismissViewControllerAnimated:YES completion:^{
+    if ([self presentedViewController]) {
+        [self dismissViewControllerAnimated:YES completion:^{
+            [self presentViewController:alertController animated:YES completion:[UIUtil modalCompletionBlock]];
+        }];
+    } else {
         [self presentViewController:alertController animated:YES completion:[UIUtil modalCompletionBlock]];
-    }];
+    }
 }
 
 #pragma mark - SMS Composer Delegate

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -314,7 +314,7 @@
                   [self.searchController setActive:NO];
 
                   UIDevice *device = [UIDevice currentDevice];
-                  if ([[device model] isEqualToString:@"iPhone"]) {
+                  if ([[device model] isEqualToString:@"iPhone"] && [MFMessageComposeViewController canSendText]) {
                       MFMessageComposeViewController *picker = [[MFMessageComposeViewController alloc] init];
                       picker.messageComposeDelegate          = self;
 

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -313,8 +313,7 @@
                 handler:^(UIAlertAction *action) {
                   [self.searchController setActive:NO];
 
-                  UIDevice *device = [UIDevice currentDevice];
-                  if ([[device model] isEqualToString:@"iPhone"] && [MFMessageComposeViewController canSendText]) {
+                  if ([MFMessageComposeViewController canSendText]) {
                       MFMessageComposeViewController *picker = [[MFMessageComposeViewController alloc] init];
                       picker.messageComposeDelegate          = self;
 
@@ -325,7 +324,6 @@
                               @" https://itunes.apple.com/us/app/signal-private-messenger/id874139669?mt=8"];
                       [self presentViewController:picker animated:YES completion:[UIUtil modalCompletionBlock]];
                   } else {
-                      // TODO: better backup for iPods (just don't support on)
                       UIAlertView *notPermitted =
                           [[UIAlertView alloc] initWithTitle:@""
                                                      message:NSLocalizedString(@"UNSUPPORTED_FEATURE_ERROR", @"")

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -301,7 +301,7 @@
                                             message:confirmMessage
                                      preferredStyle:UIAlertControllerStyleAlert];
 
-    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"")
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"TXT_CANCEL_TITLE", @"")
                                                            style:UIAlertActionStyleCancel
                                                          handler:^(UIAlertAction *action) {
                                                            DDLogDebug(@"Cancel action");


### PR DESCRIPTION
Fix SMS Invite edge cases

- Fix SMS invite on empty inbox. This was broken with https://github.com/WhisperSystems/Signal-iOS/commit/da6597118ae8336aab0ce546fe431d8338013577
- Fix SMS invite when device *can* send SMS but is not iPhone
- Don't allow SMS invite when device *is* iPhone but can't send SMS (otherwise crashing)
- Use existing localizable text for Cancel button.

closes #1191 