### PR TITLE
Improve debug log hint in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -35,5 +35,4 @@ Describe here the issue that you are experiencing.
 **Signal version:** Z.Y
 
 ### Link to debug log
-<!-- immediately after the bug has happened capture a debug log via Signal's advanced settings and paste the link below -->
-
+<!-- ensure that "Enable Debug Log" is on in Signal's settings then make the bug happen and immediately after that tap "Submit Debug Log" from settings and paste the link below -->


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these ~~devices~~ browsers:
 * Firefox 46.0.1
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Looks like someone just blindly copied the debug log hint from the Android repo's template.
This makes it more clear for iOS users.