### PR TITLE
Initialize latestContacts to empty dict

### DIFF
--- a/Signal/src/contact/ContactsManager.m
+++ b/Signal/src/contact/ContactsManager.m
@@ -20,6 +20,7 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL *);
     if (self) {
         life                         = [TOCCancelTokenSource new];
         observableContactsController = [ObservableValueController observableValueControllerWithInitialValue:nil];
+        latestContactsById           = @{};
     }
     return self;
 }


### PR DESCRIPTION
Seeing some intermittent segfaults with latestContacts in the crash reporter.

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000eb0
Triggered by Thread:  1
```
```
Thread 1 name:
Thread 1 Crashed:
0   CoreFoundation                	0x000000018182df24 -[__NSDictionaryM getObjects:andKeys:count:] + 112 (NSDictionary.m:609)
1   CoreFoundation                	0x000000018186ffe4 -[NSDictionary allKeys] + 180 (NSDictionary.m:1165)
2   Signal                        	0x000000010003ef74 -[ContactsManager allContacts] + 124 (ContactsManager.m:406)
3   Signal                        	0x000000010003fd70 -[ContactsManager nameStringForPhoneIdentifier:] + 96 (ContactsManager.m:502)
4   Signal                        	0x000000010025d224 -[TSContactThread name] + 112 (TSContactThread.m:71)
5   Signal                        	0x0000000100075554 -[InboxTableViewCell configureWithThread:] + 160 (InboxTableViewCell.m:56)
6   libdispatch.dylib             	0x000000018138d4bc _dispatch_call_block_and_release + 24 (init.c:760)
7   libdispatch.dylib             	0x000000018138d47c _dispatch_client_callout + 16 (object.m:506)
8   libdispatch.dylib             	0x000000018139b914 _dispatch_root_queue_drain + 2140 (inline_internal.h:1063)
9   libdispatch.dylib             	0x000000018139b0b0 _dispatch_worker_thread3 + 112 (queue.c:4249)
10  libsystem_pthread.dylib       	0x00000001815a5470 _pthread_wqthread + 1092 (pthread.c:1990)
11  libsystem_pthread.dylib       	0x00000001815a5020 start_wqthread + 4 (pthread_asm.s:190)
```

Could be because we were only initializing in async.