### PR TITLE
hide UI element must happen on main thread

### DIFF
--- a/Signal/src/view controllers/InboxTableViewCell.m
+++ b/Signal/src/view controllers/InboxTableViewCell.m
@@ -50,7 +50,9 @@
 
 - (void)configureWithThread:(TSThread *)thread {
     if (!_threadId || ![_threadId isEqualToString:thread.uniqueId]) {
-        self.hidden = YES;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.hidden = YES;
+        });
     }
 
     NSString *name                     = thread.name;


### PR DESCRIPTION
This seems to be responsible for about 3% of crashes.