### PR TITLE
Prevent freeze when swiping back twice.

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -192,9 +192,6 @@ typedef enum : NSUInteger {
                                              selector:@selector(cancelReadTimer)
                                                  name:UIApplicationDidEnterBackgroundNotification
                                                object:nil];
-
-    self.navigationController.interactivePopGestureRecognizer.delegate = self; // Swipe back to inbox fix. See
-    // http://stackoverflow.com/questions/19054625/changing-back-button-in-ios-7-disables-swipe-to-navigate-back
 }
 
 - (void)initializeTextView {


### PR DESCRIPTION
FIXES #1222

Maybe this code was a vestige of a former way we were customizing the
back button. In any case, it's no longer required for swipe-to-pop
functionality.

Thanks for the good reproduction steps @big-r81! 

// FREEBIE