### PR TITLE
Get back on upstream SocketRocket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
 language: objective-c
 cache: cocoapods # pod install somtimes takes >20 minutes, so lets cache this
 
-osx_image: xcode7.1
-xcode_sdk: iphonesimulator9.1
+osx_image: xcode7.3
 
 before_install:
     - brew update # we may not be running the latest version so always update
     - brew outdated xctool || brew upgrade xctool # only upgrade if outdated (saves 2 minutes)
     - gem install cocoapods # get the latest cocoapods
+    - gem install xcpretty
     - pod repo update --silent # log output is too long without --silent
 
 install: travis_wait 30 pod install # OpenSSL takes a long time to compile
 
-xcode_workspace: Signal.xcworkspace
-xcode_scheme: Signal
+script:
+- |
+  set -o pipefail
+  # default xctool was hanging. see https://github.com/travis-ci/travis-ci/issues/3986
+  xcodebuild -workspace Signal.xcworkspace -scheme Signal -sdk iphonesimulator build test | xcpretty
+

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '8.0'
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Signal' do
-    pod 'SocketRocket',               :git => 'https://github.com/WhisperSystems/SocketRocket.git', :branch => 'signal-ios'
+    pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git'
     pod 'SignalServiceKit',           :git => 'https://github.com/WhisperSystems/SignalServiceKit.git'
     pod 'OpenSSL',                    '~> 1.0.208'
     pod 'PastelogKit',                '~> 1.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - JSQMessagesViewController (7.1.0):
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
-  - libPhoneNumber-iOS (0.8.13)
+  - libPhoneNumber-iOS (0.8.14)
   - Mantle (2.0.7):
     - Mantle/extobjc (= 2.0.7)
   - Mantle/extobjc (2.0.7)
@@ -43,7 +43,7 @@ PODS:
   - ProtocolBuffers (1.9.10)
   - Reachability (3.2)
   - SCWaveformView (1.0.0)
-  - SignalServiceKit (0.0.5):
+  - SignalServiceKit (0.0.6):
     - '25519'
     - AFNetworking
     - AxolotlKit
@@ -120,7 +120,7 @@ DEPENDENCIES:
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
   - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`)
-  - SocketRocket (from `https://github.com/WhisperSystems/SocketRocket.git`, branch `signal-ios`)
+  - SocketRocket (from `https://github.com/facebook/SocketRocket.git`)
 
 EXTERNAL SOURCES:
   JSQMessagesViewController:
@@ -129,19 +129,18 @@ EXTERNAL SOURCES:
   SignalServiceKit:
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
-    :branch: signal-ios
-    :git: https://github.com/WhisperSystems/SocketRocket.git
+    :git: https://github.com/facebook/SocketRocket.git
 
 CHECKOUT OPTIONS:
   JSQMessagesViewController:
     :commit: 225b1baa11125ea84d4b960d700834b5b0a40ee1
     :git: https://github.com/WhisperSystems/JSQMessagesViewController
   SignalServiceKit:
-    :commit: 80671b247f616c3bd6264eccce5f806a4a538e68
+    :commit: 664162fe243ca4f2ec76ccb1e72752be8ee47596
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
-    :commit: 587ad297eb63eb0d64d4caeb32a7da646ad1132b
-    :git: https://github.com/WhisperSystems/SocketRocket.git
+    :commit: 8096fef47d582bff8ae3758c9ae7af1d55ea53d6
+    :git: https://github.com/facebook/SocketRocket.git
 
 SPEC CHECKSUMS:
   '25519': dc4bad7e2dbcbf1efa121068a705a44cd98c80fc
@@ -153,14 +152,14 @@ SPEC CHECKSUMS:
   HKDFKit: c058305d6f64b84f28c50bd7aa89574625bcb62a
   JSQMessagesViewController: ca11f86fa68ca70835f05e169df9244147c1dc40
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
-  libPhoneNumber-iOS: 3a37004baf779b4262ab29a31a87d2ae668159d4
+  libPhoneNumber-iOS: fb165271ebe7fb32e55da97b83219382f2f9d409
   Mantle: bc40bb061d8c2c6fb48d5083e04d928c3b7f73d9
   OpenSSL: b187269d386b07452f56af273764ea0636dd5da8
   PastelogKit: 7b475be4cf577713506a943dd940bcc0499c8bca
   ProtocolBuffers: d088180c10072b3d24a9939a6314b7b9bcc2340b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SCWaveformView: 52a96750255d817e300565a80c81fb643e233e07
-  SignalServiceKit: f52bc6e17f717540d93b4247a93246648bf4085e
+  SignalServiceKit: 850620cd1535f8628474121e7ea142ff1fe236a6
   SocketRocket: 3f77ec2104cc113add553f817ad90a77114f5d43
   SQLCipher: 4c768761421736a247ed6cf412d9045615d53dff
   SSKeychain: c71293fa57216a40ab06c23f4085387583293de4
@@ -168,6 +167,6 @@ SPEC CHECKSUMS:
   UnionFind: c33be5adb12983981d6e827ea94fc7f9e370f52d
   YapDatabase: 713d4018cfacbd6e77dd430710ca84730e450980
 
-PODFILE CHECKSUM: ab4ae2b002e53f49ff0b90778217bcc43fd30773
+PODFILE CHECKSUM: 860bce87f11d7ce3a8a80c10f8d35ef83699531e
 
 COCOAPODS: 1.0.1

--- a/Signal/src/network/http/RPServerRequestsManager.m
+++ b/Signal/src/network/http/RPServerRequestsManager.m
@@ -9,7 +9,7 @@
 #import "RPServerRequestsManager.h"
 
 #import "AFHTTPSessionManager+SignalMethods.h"
-#import "AFSecurityOWSPolicy.h"
+#import <SignalServiceKit/OWSHTTPSecurityPolicy.h>
 
 @interface RPServerRequestsManager ()
 
@@ -38,7 +38,7 @@
         NSURL *endPointURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://%@:%d", endpoint.hostname, 443]];
         self.operationManager =
             [[AFHTTPSessionManager alloc] initWithBaseURL:endPointURL sessionConfiguration:sessionConfig];
-        self.operationManager.securityPolicy = [AFSecurityOWSPolicy OWS_PinningPolicy];
+        self.operationManager.securityPolicy = [OWSHTTPSecurityPolicy sharedPolicy];
     }
     return self;
 }


### PR DESCRIPTION
So long forked version of SocketRocket!

We got our security policy needs merged upstream at: https://github.com/facebook/SocketRocket/pull/429. 🎉 

The real impetus is a bunch of crashes we're seeing in SocketRocket. Not as many as with <2.3.2, but still our most popular source of crashes. As crash fixes get incorporated into SocketRocket now keeping up to date will be much easier.