### PR TITLE
Ios10 crash on attaching media

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -73,6 +73,10 @@
 	<string>Signal uses your contacts to find users you know. We do not store your contacts on the server.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Signal needs access to your microphone to make and receive phone calls.</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Signal will let you choose which media from your library to send.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Signal will let you choose which photos from your library to send.</string>
 	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -1334,29 +1334,30 @@ typedef enum : NSUInteger {
  */
 
 - (void)takePictureOrVideo {
-    UIImagePickerController *picker = [[UIImagePickerController alloc] init];
-    picker.delegate                 = self;
-    picker.allowsEditing            = NO;
-    picker.sourceType               = UIImagePickerControllerSourceTypeCamera;
-
-    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
-        picker.mediaTypes = @[ (NSString *)kUTTypeImage, (NSString *)kUTTypeMovie ];
-        [self presentViewController:picker animated:YES completion:[UIUtil modalCompletionBlock]];
+    if (![UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+        DDLogError(@"Camera ImagePicker source not available");
+        return;
     }
+
+    UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+    picker.sourceType = UIImagePickerControllerSourceTypeCamera;
+    picker.mediaTypes = @[ (__bridge NSString *)kUTTypeImage, (__bridge NSString *)kUTTypeMovie ];
+    picker.allowsEditing = NO;
+    picker.delegate = self;
+    [self presentViewController:picker animated:YES completion:[UIUtil modalCompletionBlock]];
 }
 
 - (void)chooseFromLibrary {
-    UIImagePickerController *picker = [[UIImagePickerController alloc] init];
-    picker.delegate                 = self;
-    picker.sourceType               = UIImagePickerControllerSourceTypePhotoLibrary;
-
-    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary]) {
-        NSArray *photoOrVideoTypeArray = [[NSArray alloc]
-            initWithObjects:(NSString *)kUTTypeImage, (NSString *)kUTTypeMovie, (NSString *)kUTTypeVideo, nil];
-
-        picker.mediaTypes = photoOrVideoTypeArray;
-        [self presentViewController:picker animated:YES completion:[UIUtil modalCompletionBlock]];
+    if (![UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary]) {
+        DDLogError(@"PhotoLibrary ImagePicker source not available");
+        return;
     }
+
+    UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+    picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+    picker.delegate = self;
+    picker.mediaTypes = @[ (__bridge NSString *)kUTTypeImage, (__bridge NSString *)kUTTypeMovie ];
+    [self presentViewController:picker animated:YES completion:[UIUtil modalCompletionBlock]];
 }
 
 /*


### PR DESCRIPTION
Fixes #1245 

There is a new string required, explaining *why* we need access to a users media library.

Since this is the result of a user pressing "Choose from Library..." it shouldn't be a big surprise.