### PR TITLE
IOS9 Fixes

### DIFF
--- a/Libraries/FLAnimatedImage/FLAnimatedImage.m
+++ b/Libraries/FLAnimatedImage/FLAnimatedImage.m
@@ -649,8 +649,8 @@ static NSHashTable *allAnimatedImagesWeak;
     
     // "In iOS 4.0 and later, and OS X v10.6 and later, you can pass NULL if you want Quartz to allocate memory for the bitmap." (source: docs)
     void *data = NULL;
-    size_t width = imageToPredraw.size.width;
-    size_t height = imageToPredraw.size.height;
+    size_t width = (size_t)imageToPredraw.size.width;
+    size_t height = (size_t)imageToPredraw.size.height;
     size_t bitsPerComponent = CHAR_BIT;
     
     size_t bitsPerPixel = (bitsPerComponent * numberOfComponents);

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -74,7 +74,7 @@
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Signal needs access to your microphone to make and receive phone calls.</string>
 	<key>NSAppleMusicUsageDescription</key>
-	<string>Signal will let you choose which media from your library to send.</string>
+	<string>Signal needs to use Apple Music to play media attachments.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Signal will let you choose which photos from your library to send.</string>
 	<key>UIApplicationShortcutItems</key>

--- a/Signal/src/audio/AppAudioManager.h
+++ b/Signal/src/audio/AppAudioManager.h
@@ -8,10 +8,10 @@
 /**
  *  The AppAudioManager is a Singleton object used to control audio settings / updates
  *  for the entire application. This includes playing sounds appropriately, Initializing
- *  Audio Settings, and interfacing with the OS. The Call Audio Pipeline it self is delegated
+ *  Audio Settings, and interfacing with the OS. The Call Audio Pipeline itself is delegated
  *  to the RemoteIOAudio Class.
  *
- *  The Audio Profile determines which preset of logic to use for playing sounds, Such as
+ *  The AudioProfile determines which preset of logic to use for playing sounds, Such as
  *  which speaker to use or if all sounds should be muted.
  **/
 


### PR DESCRIPTION
* Fix compiler warnings by explicitly casting to int (CGPoint floats are being shuffled into a bitmap)
* Show a better permissions message when viewing attachments.
* Fix comment.

// FREEBIE