### PR TITLE
Alternative solution for requiring direct taps for launching media vi…

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -1030,23 +1030,6 @@ typedef enum : NSUInteger {
 
 #pragma mark - Actions
 
-- (void)collectionView:(JSQMessagesCollectionView *)collectionView didTapCellAtIndexPath:(NSIndexPath *)indexPath touchLocation:(CGPoint)touchLocation
-{
-    TSMessageAdapter *messageItem = [collectionView.dataSource collectionView:collectionView messageDataForItemAtIndexPath:indexPath];
-    TSInteraction *interaction = [self interactionAtIndexPath:indexPath];
-
-    switch (messageItem.messageType) {
-        case TSErrorMessageAdapter:
-            [self handleErrorMessageTap:(TSErrorMessage *)interaction];
-            break;
-        case TSInfoMessageAdapter:
-            [self handleWarningTap:interaction];
-            break;
-        default:
-            DDLogDebug(@"Not handling cell tap for message: %@", messageItem);
-    }
-}
-
 - (void)collectionView:(JSQMessagesCollectionView *)collectionView
     didTapMessageBubbleAtIndexPath:(NSIndexPath *)indexPath
 {
@@ -1231,6 +1214,12 @@ typedef enum : NSUInteger {
                 }
             }
         } break;
+        case TSErrorMessageAdapter:
+            [self handleErrorMessageTap:(TSErrorMessage *)interaction];
+            break;
+        case TSInfoMessageAdapter:
+            [self handleWarningTap:interaction];
+            break;
         case TSCallAdapter:
             break;
         default:

--- a/Signal/src/views/OWSDisplayedMessageCollectionViewCell.m
+++ b/Signal/src/views/OWSDisplayedMessageCollectionViewCell.m
@@ -55,4 +55,13 @@
     self.cellLabel.text = nil;
 }
 
+// This subclass does not have a messageBubbleContainerView, so superclass
+// touch calculations will be incorrect. Since this view spans the entire
+// frame, we can override the touch handler to respond to user actions by
+// default.
+- (void)jsq_handleTapGesture:(UITapGestureRecognizer *)tap
+{
+    [self.delegate messagesCollectionViewCellDidTapMessageBubble:self];
+}
+
 @end


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPad Pro 9.7", iOS 9.3.3
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Michael beat me to the solution for issue #1257. Although I wasn't able to get `messageBubbleContainerView` to properly instantiate, I think overriding the subclass's touch input method is a cleaner solution than the workaround in the message collection view controller. This is an alternative fix to the issue with images opening when clicking the white space horizontal to it, and allows info/error messages to be clickable.

I would not be offended if the other hack was used instead due to time constraints with the next Signal release. :)