### PR TITLE
Fix extra tall error messages by rendering timestamp

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.4.0.1</string>
+	<string>2.4.0.2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -852,33 +852,38 @@ typedef enum : NSUInteger {
     return callCell;
 }
 
+- (OWSDisplayedMessageCollectionViewCell *)loadDisplayedMessageCollectionViewCellForIndexPath:(NSIndexPath *)indexPath
+{
+    OWSDisplayedMessageCollectionViewCell *messageCell = [self.collectionView dequeueReusableCellWithReuseIdentifier:[OWSDisplayedMessageCollectionViewCell cellReuseIdentifier]
+                                                                                                        forIndexPath:indexPath];
+    messageCell.layer.shouldRasterize = YES;
+    messageCell.layer.rasterizationScale = [UIScreen mainScreen].scale;
+    messageCell.cellTopLabel.attributedText = [self.collectionView.dataSource collectionView:self.collectionView attributedTextForCellTopLabelAtIndexPath:indexPath];
+
+    return messageCell;
+}
+
 - (OWSDisplayedMessageCollectionViewCell *)loadInfoMessageCellForMessage:(OWSInfoMessage *)infoMessage
                                                              atIndexPath:(NSIndexPath *)indexPath
 {
-    OWSDisplayedMessageCollectionViewCell *infoCell = [self.collectionView dequeueReusableCellWithReuseIdentifier:[OWSDisplayedMessageCollectionViewCell cellReuseIdentifier]
-                                                                                                     forIndexPath:indexPath];
+    OWSDisplayedMessageCollectionViewCell *infoCell = [self loadDisplayedMessageCollectionViewCellForIndexPath:indexPath];
     infoCell.cellLabel.text = [infoMessage text];
     infoCell.cellLabel.textColor = [UIColor darkGrayColor];
-
     infoCell.textContainer.layer.borderColor = infoCell.textContainer.layer.borderColor = [[UIColor ows_infoMessageBorderColor] CGColor];
     infoCell.headerImageView.image = [UIImage imageNamed:@"warning_white"];
-    infoCell.layer.shouldRasterize = YES;
-    infoCell.layer.rasterizationScale = [UIScreen mainScreen].scale;
+
     return infoCell;
 }
 
 - (OWSDisplayedMessageCollectionViewCell *)loadErrorMessageCellForMessage:(OWSErrorMessage *)errorMessage
                                                               atIndexPath:(NSIndexPath *)indexPath
 {
-    OWSDisplayedMessageCollectionViewCell *errorCell = [self.collectionView dequeueReusableCellWithReuseIdentifier:[OWSDisplayedMessageCollectionViewCell cellReuseIdentifier]
-                                                                                                     forIndexPath:indexPath];
+    OWSDisplayedMessageCollectionViewCell *errorCell = [self loadDisplayedMessageCollectionViewCellForIndexPath:indexPath];
     errorCell.cellLabel.text = [errorMessage text];
     errorCell.cellLabel.textColor = [UIColor darkGrayColor];
-
     errorCell.textContainer.layer.borderColor = [[UIColor ows_errorMessageBorderColor] CGColor];
     errorCell.headerImageView.image = [UIImage imageNamed:@"error_white"];
-    errorCell.layer.shouldRasterize = YES;
-    errorCell.layer.rasterizationScale = [UIScreen mainScreen].scale;
+
     return errorCell;
 }
 

--- a/Signal/src/views/OWSDisplayedMessageCollectionViewCell.m
+++ b/Signal/src/views/OWSDisplayedMessageCollectionViewCell.m
@@ -9,6 +9,7 @@
 @interface OWSDisplayedMessageCollectionViewCell ()
 
 @property (weak, nonatomic) IBOutlet JSQMessagesLabel *cellLabel;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *cellTopLabelHeightConstraint;
 @property (weak, nonatomic) IBOutlet UIImageView *headerImageView;
 @property (strong, nonatomic) IBOutlet UIView *textContainer;
 

--- a/Signal/src/views/OWSDisplayedMessageCollectionViewCell.xib
+++ b/Signal/src/views/OWSDisplayedMessageCollectionViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -9,14 +9,24 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="eMU-z2-CzM" customClass="OWSDisplayedMessageCollectionViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="90"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="90"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="cell top label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gcR-Rk-KDC" userLabel="Cell top label" customClass="JSQMessagesLabel">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="ckj-xD-FJI"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qCf-bs-dBd" userLabel="textContainer">
-                        <rect key="frame" x="0.0" y="22" width="320" height="48"/>
+                        <rect key="frame" x="0.0" y="42" width="320" height="48"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Info Message" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="OVa-Xw-5vl" customClass="JSQMessagesLabel">
                                 <rect key="frame" x="8" y="12" width="304" height="28"/>
@@ -37,7 +47,7 @@
                         </constraints>
                     </view>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="warning_white.png" translatesAutoresizingMaskIntoConstraints="NO" id="ePO-Cy-jUE">
-                        <rect key="frame" x="143" y="0.0" width="35" height="35"/>
+                        <rect key="frame" x="143" y="20" width="35" height="35"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="35" id="Llx-81-oyV"/>
                             <constraint firstAttribute="width" constant="35" id="Nth-3D-Wo9"/>
@@ -47,16 +57,21 @@
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
             <constraints>
-                <constraint firstItem="ePO-Cy-jUE" firstAttribute="top" secondItem="eMU-z2-CzM" secondAttribute="top" id="D28-BQ-Qam"/>
+                <constraint firstItem="ePO-Cy-jUE" firstAttribute="top" secondItem="gcR-Rk-KDC" secondAttribute="bottom" id="1yH-xH-np2"/>
                 <constraint firstAttribute="trailing" secondItem="qCf-bs-dBd" secondAttribute="trailing" id="F3T-1l-nCg"/>
+                <constraint firstItem="gcR-Rk-KDC" firstAttribute="leading" secondItem="eMU-z2-CzM" secondAttribute="leading" id="Jfv-yk-atD"/>
                 <constraint firstItem="qCf-bs-dBd" firstAttribute="leading" secondItem="eMU-z2-CzM" secondAttribute="leading" id="OzF-VM-85V"/>
                 <constraint firstAttribute="bottom" secondItem="qCf-bs-dBd" secondAttribute="bottom" id="PNq-zm-usq"/>
                 <constraint firstItem="qCf-bs-dBd" firstAttribute="top" secondItem="ePO-Cy-jUE" secondAttribute="centerY" constant="4" id="UzU-DS-8WZ"/>
+                <constraint firstAttribute="trailing" secondItem="gcR-Rk-KDC" secondAttribute="trailing" id="ba7-8G-AEb"/>
                 <constraint firstItem="ePO-Cy-jUE" firstAttribute="centerX" secondItem="eMU-z2-CzM" secondAttribute="centerX" id="qtQ-mS-o6z"/>
+                <constraint firstItem="gcR-Rk-KDC" firstAttribute="top" secondItem="eMU-z2-CzM" secondAttribute="top" id="u1D-wy-0VO"/>
             </constraints>
             <size key="customSize" width="320" height="55"/>
             <connections>
                 <outlet property="cellLabel" destination="OVa-Xw-5vl" id="7PC-oj-dQZ"/>
+                <outlet property="cellTopLabel" destination="gcR-Rk-KDC" id="Ogk-hD-ge8"/>
+                <outlet property="cellTopLabelHeightConstraint" destination="ckj-xD-FJI" id="wBH-pQ-Wc7"/>
                 <outlet property="headerImageView" destination="ePO-Cy-jUE" id="4uq-2C-V7U"/>
                 <outlet property="textContainer" destination="qCf-bs-dBd" id="fL7-LO-El1"/>
             </connections>


### PR DESCRIPTION
FIXES #1266 

We were occasionally seeing extra tall error messages. This is because,
when appropriate, we were adding the space for a timestamp, but then
never actually rendering the timestamp.

So now:
- Error Messages get a printed timestamp when appropriate
- Which means Error Messages aren't rendered too-tall

// FREEBIE