### PR TITLE
Narrow the bubbles a bit.

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -194,7 +194,6 @@ typedef enum : NSUInteger {
         UIEdgeInsetsMake(JSQ_IMAGE_INSET, JSQ_IMAGE_INSET, JSQ_IMAGE_INSET, JSQ_IMAGE_INSET);
     [_attachButton setImage:[UIImage imageNamed:@"btnAttachments--blue"] forState:UIControlStateNormal];
 
-    [self initializeBubbles];
     [self initializeTextView];
 
     [JSQMessagesCollectionViewCell registerMenuAction:@selector(delete:)];
@@ -532,28 +531,33 @@ typedef enum : NSUInteger {
     }
 }
 
-- (void)initializeBubbles
+// Overiding JSQMVC layout defaults
+- (void)initializeCollectionViewLayout
 {
+    [self.collectionView.collectionViewLayout setMessageBubbleFont:[UIFont ows_dynamicTypeBodyFont]];
+
+    self.collectionView.showsVerticalScrollIndicator = NO;
+    self.collectionView.showsHorizontalScrollIndicator = NO;
+
+    [self updateLoadEarlierVisible];
+
+    self.collectionView.collectionViewLayout.incomingAvatarViewSize = CGSizeZero;
+    self.collectionView.collectionViewLayout.outgoingAvatarViewSize = CGSizeZero;
+
+    if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPad) {
+        // Narrow the bubbles a bit to create more white space in the messages view
+        // Since we're not using avatars it gets a bit crowded otherwise.
+        self.collectionView.collectionViewLayout.messageBubbleLeftRightMargin = 80.0f;
+    }
+
+    // Bubbles
     self.collectionView.collectionViewLayout.bubbleSizeCalculator = [[OWSMessagesBubblesSizeCalculator alloc] init];
     JSQMessagesBubbleImageFactory *bubbleFactory = [[JSQMessagesBubbleImageFactory alloc] init];
     self.incomingBubbleImageData = [bubbleFactory incomingMessagesBubbleImageWithColor:[UIColor jsq_messageBubbleLightGrayColor]];
     self.outgoingBubbleImageData = [bubbleFactory outgoingMessagesBubbleImageWithColor:[UIColor ows_materialBlueColor]];
     self.currentlyOutgoingBubbleImageData = [bubbleFactory outgoingMessagesBubbleImageWithColor:[UIColor ows_fadedBlueColor]];
     self.outgoingMessageFailedImageData = [bubbleFactory outgoingMessagesBubbleImageWithColor:[UIColor grayColor]];
-}
 
-- (void)initializeCollectionViewLayout {
-    if (self.collectionView) {
-        [self.collectionView.collectionViewLayout setMessageBubbleFont:[UIFont ows_dynamicTypeBodyFont]];
-
-        self.collectionView.showsVerticalScrollIndicator   = NO;
-        self.collectionView.showsHorizontalScrollIndicator = NO;
-
-        [self updateLoadEarlierVisible];
-
-        self.collectionView.collectionViewLayout.incomingAvatarViewSize = CGSizeZero;
-        self.collectionView.collectionViewLayout.outgoingAvatarViewSize = CGSizeZero;
-    }
 }
 
 #pragma mark - Fingerprints


### PR DESCRIPTION
This is closer to the 2.3 version.

Seems like upstream sizing has changed since our upgrade. This wider size calculation makes sense if you're losing space to the avatar, but since we're not using avatars the full width bubbles can make the whole view seem a bit crowded when you have large blobs of text.

Previously this:
![image](https://cloud.githubusercontent.com/assets/217057/16999385/8fd1b90a-4e72-11e6-98ac-420dbf76a0cd.png)

Has been changed to this:
![image](https://cloud.githubusercontent.com/assets/217057/16999398/9934b6dc-4e72-11e6-8487-e587c1e99ff6.png)


// FREEBIE