### PR TITLE
FIX: Leaving group should dismiss keyboard #1274

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -151,6 +151,7 @@ typedef enum : NSUInteger {
 - (void)hideInputIfNeeded {
     if (_peek) {
         [self inputToolbar].hidden = YES;
+        [self.inputToolbar endEditing:TRUE];
         return;
     }
 
@@ -158,6 +159,7 @@ typedef enum : NSUInteger {
         ![((TSGroupThread *)_thread).groupModel.groupMemberIds containsObject:[TSAccountManager localNumber]]) {
 
         [self inputToolbar].hidden = YES; // user has requested they leave the group. further sends disallowed
+        [self.inputToolbar endEditing:TRUE];
         self.navigationItem.rightBarButtonItem = nil; // further group action disallowed
     } else {
         [self inputToolbar].hidden = NO;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6, iOS 9.3.3
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

If we hide the input toolbar, we should hide the keyboard too

//FREEBIE