### PR TITLE
Improve audio waveform scrolling performance

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
@@ -143,14 +143,16 @@
         NSURL *url =
             [MIMETypeUtil simLinkCorrectExtensionOfFile:_attachment.mediaURL ofMIMEType:_attachment.contentType];
 
-        AVURLAsset *asset         = [[AVURLAsset alloc] initWithURL:url options:nil];
-        _waveform                 = [[SCWaveformView alloc] init];
-        _waveform.frame           = CGRectMake(42.0, 0.0, size.width - 84, size.height);
-        _waveform.asset           = asset;
-        _waveform.progressColor   = [UIColor whiteColor];
-        _waveform.backgroundColor = [UIColor colorWithRed:229 / 255.0f green:228 / 255.0f blue:234 / 255.0f alpha:1.0f];
-        [_waveform generateWaveforms];
-        _waveform.progress = 0.0;
+        if (!self.waveform) {
+            AVURLAsset *asset         = [[AVURLAsset alloc] initWithURL:url options:nil];
+            self.waveform                 = [[SCWaveformView alloc] init];
+            self.waveform.frame           = CGRectMake(42.0, 0.0, size.width - 84, size.height);
+            self.waveform.asset           = asset;
+            self.waveform.progressColor   = [UIColor whiteColor];
+            self.waveform.backgroundColor = [UIColor colorWithRed:229 / 255.0f green:228 / 255.0f blue:234 / 255.0f alpha:1.0f];
+            [self.waveform generateWaveforms];
+            self.waveform.progress = 0.0;
+        }
 
         _audioBubble = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, size.width, size.height)];
         _audioBubble.backgroundColor =


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [X] My commits are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone Simulator 6S, 9.3
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
The object is already cached & the waveform view constructed when scrolling,
so there's no need to re-create the view.

This doesn't fix the problem with the wave-form generation on the first
view of the message.  That is a more critical problem in the underlying
SCWaveformView class which renders on the main thread instead of doing
it asynchronously.

I've verified by hacking (due to being on the simulator) a large 6-minute mp3
into the chat conversation & then scrolling back & forth.  The first display still
hangs until SCWaveformView is done, but further scrolling remains smooth.

FIXES #1258