### PR TITLE
Added ability for external keyboard 'enter' keypress to send message.

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -366,6 +366,18 @@ typedef enum : NSUInteger {
     self.inputToolbar.contentView.textView.editable = NO;
 }
 
+- (NSArray *)keyCommands {
+    return @[ [UIKeyCommand keyCommandWithInput:@"\r" modifierFlags:0 action:@selector(pressSendButton)] ];
+}
+
+- (void)pressSendButton {
+    if (self.inputToolbar.sendButtonOnRight) {
+        [self.inputToolbar.contentView.rightBarButtonItem sendActionsForControlEvents:UIControlEventTouchUpInside];
+    } else {
+        [self.inputToolbar.contentView.leftBarButtonItem sendActionsForControlEvents:UIControlEventTouchUpInside];
+    }
+}
+
 #pragma mark - Initiliazers
 
 


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice A, iOS Simulator 9.3
 (tried to test it on my phone but I couldn't get past the verification code step, probably due to certificates and bundle identifier issues)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
FREEBIE

I use a bluetooth keyboard with Signal and I wanted the "return" or "enter" key to send a message as opposed to starting a new line. As in other apps including the Apple Messages app, a "enter" keypress will send a message and Opt+Enter or Shift+Enter will start a new line in the existing message (the current behavior).

I took two approaches for this change; programatically pressing the "send" button or calling didPressSendButton:withMessageText:senderId:senderDisplayName:date. I went with the former option because there is no access to jsq_currentlyComposedMessageText from outside JSQMessagesViewController.m. In JSQ currently this only confirms any autocorrect selections before sending a trimmed version of the text from the inputToolbar to the didPressSendButton: selector. As opposed to replicating this behavior (in case JSQMessagesVC changes its behavior here), I felt the programmatic press was safer. It also takes into account if the send button is on the other side (though the app doesn't seem to move it for RtL languages like Arabic currently). If you prefer the other way, I can put that together and send another PR.

