### PR TITLE
Fix delete attachments

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - JSQMessagesViewController (7.3.4):
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
-  - libPhoneNumber-iOS (0.8.14)
+  - libPhoneNumber-iOS (0.8.15)
   - Mantle (2.0.7):
     - Mantle/extobjc (= 2.0.7)
   - Mantle/extobjc (2.0.7)
@@ -43,7 +43,7 @@ PODS:
   - ProtocolBuffers (1.9.10)
   - Reachability (3.2)
   - SCWaveformView (1.0.0)
-  - SignalServiceKit (0.0.6):
+  - SignalServiceKit (0.0.7):
     - '25519'
     - AFNetworking
     - AxolotlKit
@@ -130,7 +130,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   SignalServiceKit:
-    :commit: 36cab4691cce4962220f2bfbcc19413c5a7964a1
+    :commit: c14e4bb7b372a8277860f27ebd7eed7637828395
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 8096fef47d582bff8ae3758c9ae7af1d55ea53d6
@@ -146,14 +146,14 @@ SPEC CHECKSUMS:
   HKDFKit: c058305d6f64b84f28c50bd7aa89574625bcb62a
   JSQMessagesViewController: 39fed975e3c9f8eba7292071e29eeb541d105e66
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
-  libPhoneNumber-iOS: fb165271ebe7fb32e55da97b83219382f2f9d409
+  libPhoneNumber-iOS: 62a740e1ea5741060f5cec0f788b52071115cf31
   Mantle: bc40bb061d8c2c6fb48d5083e04d928c3b7f73d9
   OpenSSL: b187269d386b07452f56af273764ea0636dd5da8
   PastelogKit: 7b475be4cf577713506a943dd940bcc0499c8bca
   ProtocolBuffers: d088180c10072b3d24a9939a6314b7b9bcc2340b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SCWaveformView: 52a96750255d817e300565a80c81fb643e233e07
-  SignalServiceKit: 850620cd1535f8628474121e7ea142ff1fe236a6
+  SignalServiceKit: e0bc81d12cef07b621403ff49e1c9c6f64d96109
   SocketRocket: 3f77ec2104cc113add553f817ad90a77114f5d43
   SQLCipher: 4c768761421736a247ed6cf412d9045615d53dff
   SSKeychain: c71293fa57216a40ab06c23f4085387583293de4

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.4.0.4</string>
+	<string>2.4.1.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
@@ -10,8 +10,10 @@
 #import "TSAttachmentPointer.h"
 #import "TSAttachmentStream.h"
 #import "TSCall.h"
+#import "TSContactThread.h"
 #import "TSContentAdapters.h"
 #import "TSErrorMessage.h"
+#import "TSGroupThread.h"
 #import "TSIncomingMessage.h"
 #import "TSInfoMessage.h"
 #import "TSOutgoingMessage.h"
@@ -57,7 +59,8 @@
 
 @implementation TSMessageAdapter
 
-+ (id<JSQMessageData>)messageViewDataWithInteraction:(TSInteraction *)interaction inThread:(TSThread *)thread {
++ (id<JSQMessageData>)messageViewDataWithInteraction:(TSInteraction *)interaction inThread:(TSThread *)thread
+{
     TSMessageAdapter *adapter = [[TSMessageAdapter alloc] init];
     adapter.interaction = interaction;
     adapter.messageDate       = interaction.date;
@@ -94,8 +97,8 @@
         TSMessage *message  = (TSMessage *)interaction;
         adapter.messageBody = message.body;
 
-        if ([message.attachments count] > 0) {
-            for (NSString *attachmentID in message.attachments) {
+        if ([message hasAttachments]) {
+            for (NSString *attachmentID in message.attachmentIds) {
                 TSAttachment *attachment = [TSAttachment fetchObjectWithUniqueID:attachmentID];
 
                 if ([attachment isKindOfClass:[TSAttachmentStream class]]) {

--- a/Signal/src/call/RecentCallManager.m
+++ b/Signal/src/call/RecentCallManager.m
@@ -1,9 +1,10 @@
-#import <SignalServiceKit/TextSecureKitEnv.h>
-#import "NotificationsManager.h"
 #import "RecentCallManager.h"
+#import "NotificationsManager.h"
 #import "TSCall.h"
+#import "TSContactThread.h"
 #import "TSMessagesManager.h"
 #import "TSStorageManager.h"
+#import <SignalServiceKit/TextSecureKitEnv.h>
 
 @interface RecentCallManager ()
 @property YapDatabaseConnection *dbConnection;

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -174,7 +174,8 @@
     handleActionWithIdentifier:(NSString *)identifier
           forLocalNotification:(UILocalNotification *)notification
               withResponseInfo:(NSDictionary *)responseInfo
-             completionHandler:(void (^)())completionHandler {
+             completionHandler:(void (^)())completionHandler
+{
     if ([identifier isEqualToString:Signal_Message_Reply_Identifier]) {
         NSString *threadId = notification.userInfo[Signal_Thread_UserInfo_Key];
 
@@ -184,7 +185,7 @@
                 [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                     inThread:thread
                                                  messageBody:responseInfo[UIUserNotificationActionResponseTypedTextKey]
-                                                 attachments:nil];
+                                               attachmentIds:nil];
             [[TSMessagesManager sharedManager] sendMessage:message
                 inThread:thread
                 success:^{

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -710,14 +710,15 @@ typedef enum : NSUInteger {
            withMessageText:(NSString *)text
                   senderId:(NSString *)senderId
          senderDisplayName:(NSString *)senderDisplayName
-                      date:(NSDate *)date {
+                      date:(NSDate *)date
+{
     if (text.length > 0) {
         [JSQSystemSoundPlayer jsq_playMessageSentSound];
 
         TSOutgoingMessage *message = [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                                          inThread:self.thread
                                                                       messageBody:text
-                                                                      attachments:nil];
+                                                                    attachmentIds:nil];
 
         [[TSMessagesManager sharedManager] sendMessage:message inThread:self.thread success:nil failure:nil];
         [self finishSendingMessage];
@@ -1257,7 +1258,7 @@ typedef enum : NSUInteger {
     if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
         TSIncomingMessage *message = (TSIncomingMessage *)interaction;
 
-        for (NSString *attachmentId in message.attachments) {
+        for (NSString *attachmentId in message.attachmentIds) {
             __block TSAttachment *attachment;
 
             [self.editingDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
@@ -1587,11 +1588,12 @@ typedef enum : NSUInteger {
     }
 }
 
-- (void)sendMessageAttachment:(NSData *)attachmentData ofType:(NSString *)attachmentType {
+- (void)sendMessageAttachment:(NSData *)attachmentData ofType:(NSString *)attachmentType
+{
     TSOutgoingMessage *message = [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                                      inThread:self.thread
                                                                   messageBody:nil
-                                                                  attachments:[NSMutableArray array]];
+                                                                attachmentIds:[NSMutableArray new]];
 
     [self dismissViewControllerAnimated:YES
                              completion:^{
@@ -1980,14 +1982,15 @@ typedef enum : NSUInteger {
     [self performSegueWithIdentifier:kUpdateGroupSegueIdentifier sender:self];
 }
 
-- (void)leaveGroup {
+- (void)leaveGroup
+{
     [self.navController hideDropDown:self];
 
     TSGroupThread *gThread     = (TSGroupThread *)_thread;
     TSOutgoingMessage *message = [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                                      inThread:gThread
                                                                   messageBody:@""
-                                                                  attachments:[[NSMutableArray alloc] init]];
+                                                                attachmentIds:[NSMutableArray new]];
     message.groupMetaMessage = TSGroupMessageQuit;
     [[TSMessagesManager sharedManager] sendMessage:message inThread:gThread success:nil failure:nil];
     [self.editingDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
@@ -1999,10 +2002,10 @@ typedef enum : NSUInteger {
     [self hideInputIfNeeded];
 }
 
-- (void)updateGroupModelTo:(TSGroupModel *)newGroupModel {
+- (void)updateGroupModelTo:(TSGroupModel *)newGroupModel
+{
     __block TSGroupThread *groupThread;
     __block TSOutgoingMessage *message;
-
 
     [self.editingDatabaseConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
       groupThread            = [TSGroupThread getOrCreateThreadWithGroupModel:newGroupModel transaction:transaction];
@@ -2011,7 +2014,7 @@ typedef enum : NSUInteger {
       message = [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                     inThread:groupThread
                                                  messageBody:@""
-                                                 attachments:[[NSMutableArray alloc] init]];
+                                               attachmentIds:[NSMutableArray new]];
       message.groupMetaMessage = TSGroupMessageUpdate;
     }];
 

--- a/Signal/src/view controllers/NewGroupViewController.m
+++ b/Signal/src/view controllers/NewGroupViewController.m
@@ -114,7 +114,8 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
 
 
 #pragma mark - Actions
-- (void)createGroup {
+- (void)createGroup
+{
     TSGroupModel *model = [self makeGroup];
 
     [[TSStorageManager sharedManager]
@@ -130,29 +131,30 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
         presentViewController:alertController
                      animated:YES
                    completion:^{
-                     TSOutgoingMessage *message =
-                         [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
-                                                             inThread:self.thread
-                                                          messageBody:@""
-                                                          attachments:[[NSMutableArray alloc] init]];
-                     message.groupMetaMessage = TSGroupMessageNew;
-                     if (model.groupImage != nil) {
-                         [[TSMessagesManager sharedManager] sendAttachment:UIImagePNGRepresentation(model.groupImage)
-                             contentType:@"image/png"
-                             inMessage:message
-                             thread:self.thread
-                             success:^{
-                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                     [self dismissViewControllerAnimated:YES
-                                                              completion:^{
-                                                                  [Environment messageGroup:self.thread];
-                                                              }];
+                       TSOutgoingMessage *message =
+                           [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
+                                                               inThread:self.thread
+                                                            messageBody:@""
+                                                          attachmentIds:[NSMutableArray new]];
+                       message.groupMetaMessage = TSGroupMessageNew;
+                       if (model.groupImage != nil) {
+                           [[TSMessagesManager sharedManager] sendAttachment:UIImagePNGRepresentation(model.groupImage)
+                               contentType:@"image/png"
+                               inMessage:message
+                               thread:self.thread
+                               success:^{
+                                   dispatch_async(dispatch_get_main_queue(), ^{
+                                       [self dismissViewControllerAnimated:YES
+                                                                completion:^{
+                                                                    [Environment messageGroup:self.thread];
+                                                                }];
 
-                                 });
-                             }
-                             failure:^{
-                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                     [self dismissViewControllerAnimated:YES
+                                   });
+                               }
+                               failure:^{
+                                   dispatch_async(dispatch_get_main_queue(), ^{
+                                       [self
+                                           dismissViewControllerAnimated:YES
                                                               completion:^{
                                                                   [TSStorageManager.sharedManager.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction){
                                                                        [self.thread removeWithTransaction:transaction];
@@ -160,44 +162,41 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
 
                                                                   SignalAlertView(NSLocalizedString(@"GROUP_CREATING_FAILED", nil),
                                                                                   NSLocalizedString(@"NETWORK_ERROR_RECOVERY", nil));
-                                                              }
-                                      ];
-                                 });
-                             }
-                          ];
-                     } else {
-                         [[TSMessagesManager sharedManager] sendMessage:message
-                             inThread:self.thread
-                             success:^{
-                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                     [self dismissViewControllerAnimated:YES
-                                                              completion:^{
-                                                                  [Environment messageGroup:self.thread];
-                                                              }
-                                      ];
-                                 });
-                             }
-                             failure:^{
-                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                     [self dismissViewControllerAnimated:YES
+                                                              }];
+                                   });
+                               }];
+                       } else {
+                           [[TSMessagesManager sharedManager] sendMessage:message
+                               inThread:self.thread
+                               success:^{
+                                   dispatch_async(dispatch_get_main_queue(), ^{
+                                       [self dismissViewControllerAnimated:YES
+                                                                completion:^{
+                                                                    [Environment messageGroup:self.thread];
+                                                                }];
+                                   });
+                               }
+                               failure:^{
+                                   dispatch_async(dispatch_get_main_queue(), ^{
+                                       [self
+                                           dismissViewControllerAnimated:YES
                                                               completion:^{
                                                                   [TSStorageManager.sharedManager.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction){
                                                                       [self.thread removeWithTransaction:transaction];
                                                                   }];
                                                                   SignalAlertView(NSLocalizedString(@"GROUP_CREATING_FAILED", nil),
                                                                                   NSLocalizedString(@"NETWORK_ERROR_RECOVERY", nil));
-                                                              }
-                                      ];
-                                 });
+                                                              }];
+                                   });
 
-                             }
-                          ];
-                     }
+                               }];
+                       }
                    }];
 }
 
 
-- (void)updateGroup {
+- (void)updateGroup
+{
     NSMutableArray *mut = [[NSMutableArray alloc] init];
     for (NSIndexPath *idx in _tableView.indexPathsForSelectedRows) {
         [mut addObjectsFromArray:[[contacts objectAtIndex:(NSUInteger)idx.row] textSecureIdentifiers]];
@@ -207,8 +206,7 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
     _groupModel = [[TSGroupModel alloc] initWithTitle:_nameGroupTextField.text
                                             memberIds:[[[NSSet setWithArray:mut] allObjects] mutableCopy]
                                                 image:_thread.groupModel.groupImage
-                                              groupId:_thread.groupModel.groupId
-                               associatedAttachmentId:nil];
+                                              groupId:_thread.groupModel.groupId];
 
     [self.nameGroupTextField resignFirstResponder];
 
@@ -216,7 +214,8 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
 }
 
 
-- (TSGroupModel *)makeGroup {
+- (TSGroupModel *)makeGroup
+{
     NSString *title     = _nameGroupTextField.text;
     NSMutableArray *mut = [[NSMutableArray alloc] init];
 
@@ -226,11 +225,7 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
     [mut addObject:[TSAccountManager localNumber]];
     NSData *groupId = [SecurityUtils generateRandomBytes:16];
 
-    return [[TSGroupModel alloc] initWithTitle:title
-                                     memberIds:mut
-                                         image:_groupImage
-                                       groupId:groupId
-                        associatedAttachmentId:nil];
+    return [[TSGroupModel alloc] initWithTitle:title memberIds:mut image:_groupImage groupId:groupId];
 }
 
 - (IBAction)addGroupPhoto:(id)sender {

--- a/Signal/src/view controllers/SignalsViewController.m
+++ b/Signal/src/view controllers/SignalsViewController.m
@@ -9,14 +9,15 @@
 #import "InboxTableViewCell.h"
 #import "UIUtil.h"
 
-#import "OWSContactsManager.h"
 #import "InCallViewController.h"
 #import "MessagesViewController.h"
 #import "NSDate+millisecondTimeStamp.h"
+#import "OWSContactsManager.h"
 #import "PreferencesUtil.h"
 #import "SignalsViewController.h"
 #import "TSAccountManager.h"
 #import "TSDatabaseView.h"
+#import "TSGroupThread.h"
 #import "TSMessagesManager+sendMessages.h"
 #import "TSStorageManager.h"
 #import "VersionMigrations.h"
@@ -254,7 +255,7 @@ static NSString *const kShowSignupFlowSegue = @"showSignupFlow";
         TSOutgoingMessage *message = [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                                          inThread:thread
                                                                       messageBody:@""
-                                                                      attachments:[[NSMutableArray alloc] init]];
+                                                                    attachmentIds:[NSMutableArray new]];
         message.groupMetaMessage = TSGroupMessageQuit;
         [[TSMessagesManager sharedManager] sendMessage:message
             inThread:thread


### PR DESCRIPTION
Incorporating https://github.com/WhisperSystems/SignalServiceKit/pull/20. Description/Motivation copied from there: 

Description
-----------

Ensures a deleted thread actually deletes it's interactions and attachments. Also a cleanup helper to remove any dangling interactions and attachments hanging around after their thread has been deleted.

Motivation
-----------
Occasionally we are seeing messages from deleted threads reappear in new threads. Spooky stuff. :eyes:

This is because though the thread is deleted, some of the thread's interactions are not, leaving them with a dangling reference to the thread's contact ID. When the thread is recreated, the references are no longer dangling, and they reappear in the thread.

This could also cause any large attachments associated with those lingering interactions to hang around after the thread was deleted.

Previously for this cascading delete behavior we relied on the YapDatabase "relationship" extension to build an object graph and delete objects when there weren't accessible, as inferred by reference counting edges to the object. This all sounds nice in theory, but introduces a lot of complex machinery under the covers, when what we *really* want is pretty simple:

1. Upon deleting a thread, the thread deletes all it's interactions.
2. If the deleted interaction represents media with an attachment on disk, delete the file.

In the end, it's a lot less magical to just spell those things out.