### PR TITLE
Fix incorrect GIF message bubble sizing

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSAnimatedAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSAnimatedAdapter.m
@@ -56,6 +56,13 @@
     _cachedImageView = nil;
 }
 
+#pragma mark - NSObject
+
+- (NSUInteger)hash
+{
+    return super.hash ^ self.image.hash;
+}
+
 #pragma mark - JSQMessageMediaData protocol
 
 - (UIView *)mediaView {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6, iOS 9.3.3
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

TSAnimatedAdapter is used when rendering GIFs. TSAnimatedAdapter
inherits from JSQMediaItem but does not provide a custom implementation
of the hash method. The default implementation of hash in JSQMediaItem
results in all messages of a given interaction type (incoming,
outgoing) sharing a cached bubble size. For this reason, JSQMediaItem
subclasses are required to implement hash (see
https://github.com/jessesquires/JSQMessagesViewController/issues/631).

This commit fixes #1275 by implementing hash in TSAnimatedAdapter
the same way TSPhotoAdapter does.