### PR TITLE
Orphan-data cleanup no longer causes timeout

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.4.1.0</string>
+	<string>2.4.1.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>


### PR DESCRIPTION
### Description

On older devices with lots of data, the orphan data cleaner can time
out. Here we're trading certainty that the migration completed for
confidence that the boot process doesn't time out.

// FREEBIE