### PR TITLE
Return immutable data from generateSecureRandomData:length and use OS…

### DIFF
--- a/Signal/src/crypto/CryptoTools.m
+++ b/Signal/src/crypto/CryptoTools.m
@@ -10,11 +10,11 @@
 
 + (NSData *)generateSecureRandomData:(NSUInteger)length {
     NSMutableData *d = [NSMutableData dataWithLength:length];
-    int err          = SecRandomCopyBytes(kSecRandomDefault, length, [d mutableBytes]);
-    if (err != 0) {
+    OSStatus status  = SecRandomCopyBytes(kSecRandomDefault, length, [d mutableBytes]);
+    if (status != noErr) {
         [SecurityFailure raise:@"SecRandomCopyBytes failed"];
     }
-    return d;
+    return [d copy];
 }
 
 + (uint16_t)generateSecureRandomUInt16 {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6, iOS 9.3.4
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Return immutable data from generateSecureRandomData:length and use OSStatus to check the status of SecRandomCopyBytes.