### PR TITLE
verification code field: improved user experience

### DIFF
--- a/Signal/src/view controllers/CodeVerificationViewController.m
+++ b/Signal/src/view controllers/CodeVerificationViewController.m
@@ -274,12 +274,12 @@
         return NO;
     }
 
-    if (range.length == 0 && range.location == 3) {
-        textField.text = [NSString stringWithFormat:@"%@-%@", textField.text, string];
+    if (range.length == 0 && range.location == 2) {
+        textField.text = [NSString stringWithFormat:@"%@%@-", textField.text, string];
         return NO;
     }
 
-    if (range.length == 1 && range.location == 4) {
+    if (range.length == 1 && range.location == 3) {
         range.location--;
         range.length   = 2;
         textField.text = [textField.text stringByReplacingCharactersInRange:range withString:@""];


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [X] My commits are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 6S, iOS 9.3
- [X] I have made the choice whether I want the [BitHub reward]

- - - - - - - - - -

### Description
The verification code for registering a new phone number comes as 6 digits number in two groups separated by a dash: 123-456. When typing in the received verification code, the user expects to type a dash after the first three digits, which is not possible. Prior to this commit, the dash would automatically appear after typing in the fourth digit.
With this commit, the dash is introduced after typing the third digit, resulting in a smoother user experience.