### PR TITLE
code verification: show complete phone number

### DIFF
--- a/Signal/src/view controllers/CodeVerificationViewController.m
+++ b/Signal/src/view controllers/CodeVerificationViewController.m
@@ -45,7 +45,8 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self enableServerActions:YES];
-    [_phoneNumberEntered setText:_formattedPhoneNumber];
+    [_phoneNumberEntered setText:
+        [PhoneNumber bestEffortFormatPartialUserSpecifiedTextToLookLikeAPhoneNumber:[TSAccountManager localNumber]]];
     [self adjustScreenSizes];
 }
 


### PR DESCRIPTION
### Contributor checklist
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [X] My commits are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 6S, iOS 9.3
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards)

- - - - - - - - - -

### Description
During account creation in the verification code step the user should be presented with his complete international phone number (including country code), entered in the previous step.