### PR TITLE
Fix groups breaking without avatar

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -130,7 +130,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   SignalServiceKit:
-    :commit: a0df56a68e5db7729a209b069bcdfd56e6d7e92a
+    :commit: 1824af5335d8faa9f30eed40f0e1dc8198650ceb
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 8096fef47d582bff8ae3758c9ae7af1d55ea53d6

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.5.0.16</string>
+	<string>2.5.0.17</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -158,12 +158,13 @@ typedef enum : NSUInteger {
         return;
     }
 
-    if ([_thread isKindOfClass:[TSGroupThread class]] &&
-        ![((TSGroupThread *)_thread).groupModel.groupMemberIds containsObject:[TSAccountManager localNumber]]) {
-
-        [self inputToolbar].hidden = YES; // user has requested they leave the group. further sends disallowed
-        [self.inputToolbar endEditing:TRUE];
-        self.navigationItem.rightBarButtonItem = nil; // further group action disallowed
+    if ([_thread isKindOfClass:[TSGroupThread class]]) {
+        TSGroupThread *groupThread = (TSGroupThread *)self.thread;
+        if (![groupThread.groupModel.groupMemberIds containsObject:[TSAccountManager localNumber]]) {
+            [self inputToolbar].hidden = YES; // user has requested they leave the group. further sends disallowed
+            [self.inputToolbar endEditing:TRUE];
+            self.navigationItem.rightBarButtonItem = nil; // further group action disallowed
+        }
     } else {
         [self inputToolbar].hidden = NO;
         [self loadDraftInCompose];


### PR DESCRIPTION
- Group updates were appearing as "unsupported attachment"
- Couldn't message in a new group unless it had attachment.

// FREEBIE