### PR TITLE
Fix crash on boot =/

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -130,7 +130,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   SignalServiceKit:
-    :commit: 2dba7d141a4840eb96c1482e0dd2db11a854e6a3
+    :commit: 1098bc203e4ca2d7ae444b5a6e913b123455c5da
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 8096fef47d582bff8ae3758c9ae7af1d55ea53d6

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.1</string>
+	<string>2.5.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.5.1.0</string>
+	<string>2.5.2.2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -60,8 +60,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     }
     [Environment.getCurrent initCallListener];
 
-    [self setupTSKitEnv];
-
     BOOL loggingIsEnabled;
 
 #ifdef DEBUG
@@ -77,6 +75,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     if (loggingIsEnabled) {
         [DebugLogger.sharedLogger enableFileLogging];
     }
+
+    [self setupTSKitEnv];
 
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:kStoryboardName bundle:[NSBundle mainBundle]];
     UIViewController *viewController =

--- a/Signal/src/environment/VersionMigrations.m
+++ b/Signal/src/environment/VersionMigrations.m
@@ -75,6 +75,14 @@
         });
     }
 
+    if ([self isVersion:previousVersion atLeast:@"2.0.0" andLessThan:@"2.5.2"] && [TSAccountManager isRegistered]) {
+        [[TSStorageManager sharedManager].dbConnection
+            readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
+                NSUInteger legacyRecipientCount = [transaction numberOfKeysInCollection:@"TSRecipient"];
+                DDLogWarn(@"Removing %lu objects from TSRecipient collection", (unsigned long)legacyRecipientCount);
+                [transaction removeAllObjectsInCollection:@"TSRecipient"];
+            }];
+    }
     [Environment.preferences setAndGetCurrentVersion];
 }
 


### PR DESCRIPTION
I botched a migration 6 months ago and left some lingering TSRecipients serialized in
our data store, laying in wait to explode the next time we enumerate every
object in the database (e.g. when we add an index). Sigh.

fixes #1348

// FREEBIE