### PR TITLE
fix slow loading conversation screen with disappearing messages

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Signal' do
     pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git'
-    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'mkirk/empty-bubble-disappearing-self#1393'
+    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git'
     #pod 'SignalServiceKit',           path: '../SignalServiceKit'
     pod 'OpenSSL',                    '~> 1.0.208'
     pod 'PastelogKit',                '~> 1.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -122,13 +122,12 @@ DEPENDENCIES:
   - OpenSSL (~> 1.0.208)
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
-  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `mkirk/empty-bubble-disappearing-self#1393`)
+  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`)
   - SocketRocket (from `https://github.com/facebook/SocketRocket.git`)
   - ZXingObjC
 
 EXTERNAL SOURCES:
   SignalServiceKit:
-    :branch: mkirk/empty-bubble-disappearing-self#1393
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :git: https://github.com/facebook/SocketRocket.git
@@ -167,6 +166,6 @@ SPEC CHECKSUMS:
   YapDatabase: b1e43555a34a5298e23a045be96817a5ef0da58f
   ZXingObjC: bf15b3814f7a105b6d99f47da2333c93a063650a
 
-PODFILE CHECKSUM: e8495fa75a157c62674121b7f0faf30ee7542ec6
+PODFILE CHECKSUM: f5e3e3b84c4c471518f4e3a32746e6a0e13808f6
 
 COCOAPODS: 1.0.1

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.1</string>
+	<string>2.6.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.6.1.3</string>
+	<string>2.6.2.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -664,6 +664,9 @@ typedef enum : NSUInteger {
     }
 }
 
+#pragma mark - UICollectionViewDelegate
+
+// Override JSQMVC
 - (BOOL)collectionView:(JSQMessagesCollectionView *)collectionView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     if (indexPath == nil) {
@@ -677,6 +680,16 @@ typedef enum : NSUInteger {
 
     // Super method returns false for media methods. We want menu for *all* items
     return YES;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView
+    didEndDisplayingCell:(nonnull UICollectionViewCell *)cell
+      forItemAtIndexPath:(nonnull NSIndexPath *)indexPath
+{
+    if ([cell conformsToProtocol:@protocol(OWSExpirableMessageView)]) {
+        id<OWSExpirableMessageView> expirableView = (id<OWSExpirableMessageView>)cell;
+        [expirableView stopExpirationTimer];
+    }
 }
 
 #pragma mark - JSQMessages CollectionView DataSource

--- a/Signal/src/views/OWSExpirableMessageView.h
+++ b/Signal/src/views/OWSExpirableMessageView.h
@@ -15,6 +15,8 @@ static const CGFloat OWSExpirableMessageViewTimerWidth = 10.0f;
 - (void)startExpirationTimerWithExpiresAtSeconds:(uint64_t)expiresAtSeconds
                           initialDurationSeconds:(uint32_t)initialDurationSeconds;
 
+- (void)stopExpirationTimer;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Signal/src/views/OWSExpirationTimerView.h
+++ b/Signal/src/views/OWSExpirationTimerView.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startTimerWithExpiresAtSeconds:(uint64_t)expiresAtSeconds
                 initialDurationSeconds:(uint32_t)initialDurationSeconds;
 
-- (void)stopBlinking;
+- (void)stopTimer;
 
 @end
 

--- a/Signal/src/views/OWSIncomingMessageCollectionViewCell.m
+++ b/Signal/src/views/OWSIncomingMessageCollectionViewCell.m
@@ -24,7 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)prepareForReuse
 {
     [super prepareForReuse];
-    [self.expirationTimerView stopBlinking];
     self.expirationTimerViewWidthConstraint.constant = 0.0f;
 }
 
@@ -36,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
     self.expirationTimerViewWidthConstraint.constant = OWSExpirableMessageViewTimerWidth;
     [self.expirationTimerView startTimerWithExpiresAtSeconds:expiresAtSeconds
                                       initialDurationSeconds:initialDurationSeconds];
+}
+
+- (void)stopExpirationTimer
+{
+    [self.expirationTimerView stopTimer];
 }
 
 @end

--- a/Signal/src/views/OWSOutgoingMessageCollectionViewCell.m
+++ b/Signal/src/views/OWSOutgoingMessageCollectionViewCell.m
@@ -24,7 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)prepareForReuse
 {
     [super prepareForReuse];
-    [self.expirationTimerView stopBlinking];
     self.expirationTimerViewWidthConstraint.constant = 0.0f;
 }
 
@@ -36,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
     self.expirationTimerViewWidthConstraint.constant = OWSExpirableMessageViewTimerWidth;
     [self.expirationTimerView startTimerWithExpiresAtSeconds:expiresAtSeconds
                                       initialDurationSeconds:initialDurationSeconds];
+}
+
+- (void)stopExpirationTimer
+{
+    [self.expirationTimerView stopTimer];
 }
 
 @end


### PR DESCRIPTION
If you continuously exit and re-enter a conversation with disappearing message timers, you'll notice things gradually get slo o o o  o wer. 

Due to a memory leak fixed in this PR.