### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ cache: cocoapods # pod install somtimes takes >20 minutes, so lets cache this
 
 osx_image: xcode8
 
+env:
+  -EARLY_START_SIMULATOR=1 # early starting simulator reduces false negatives due to test timeouts
+
 before_install:
     - brew update # we may not be running the latest version so always update
     - brew outdated xctool || brew upgrade xctool # only upgrade if outdated (saves 2 minutes)

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ clean:
 optional_early_start_simulator:
 ifdef EARLY_START_SIMULATOR
 		echo "Waiting for simulator to start to help with testing timeouts" &&\
-		xcrun instruments -w '${DEVICE_UUID}' || \
-		sleep 15;
+		xcrun instruments -w '${DEVICE_UUID}' || true # xcrun can return irrelevant non-zeroes.
 else
 		echo "Not waiting for simulator."
 endif

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ retest: optional_early_start_simulator
 	cd $(WORKING_DIR) && \
 		$(XCODE_BUILD) \
 			-destination '${BUILD_DESTINATION}' \
-			build test | xcpretty
+			test | xcpretty
 
 clean:
 	cd $(WORKING_DIR) && \


### PR DESCRIPTION
Another attempt at fixing CI flakiness since xcode8 upgrade. Tests fail to start as often as they succeed.

Start simulator before running tests to avoid timeout when launching tests.

