### PR TITLE
partial fix for crash in database modified

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -1900,9 +1900,7 @@ typedef enum : NSUInteger {
               [self.collectionView reloadData];
           }
           if (scrollToBottom) {
-              dispatch_async(dispatch_get_main_queue(), ^{
-                  [self scrollToBottomAnimated:YES];
-              });
+              [self scrollToBottomAnimated:YES];
           }
         }];
 }


### PR DESCRIPTION
An existing related crash is much more common after 33f6a9552058747d016a788f7de29144e598788e.

Partial revert of 33f6a9552058747d016a788f7de29144e598788e

This was the only change proximate to the crash.

Crash looks like this:

    Last Exception Backtrace:
    0   CoreFoundation                  0x189c601c0 __exceptionPreprocess + 124 (NSException.m:165)
    1   libobjc.A.dylib                 0x18869855c objc_exception_throw + 56 (objc-exception.mm:521)
    2   CoreFoundation                  0x189c60094 +[NSException raise:format:arguments:] + 104 (NSException.m:131)
    3   Foundation                      0x18a6ea82c -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 112 (NSException.m:157)
    4   UIKit                           0x1903a534c -[UICollectionView _endItemAnimationsWithInvalidationContext:tentativelyForReordering:animator:] + 13428 (UICollectionView.m:5585)
    5   UIKit                           0x1903a8e98 -[UICollectionView _endUpdatesWithInvalidationContext:tentativelyForReordering:animator:] + 92 (UICollectionView.m:6401)
    6   UIKit                           0x1903a9178 -[UICollectionView _performBatchUpdates:completion:invalidationContext:tentativelyForReordering:animator:] + 384 (UICollectionView.m:6459)
    7   UIKit                           0x1903a8fd8 -[UICollectionView _performBatchUpdates:completion:invalidationContext:tentativelyForReordering:] + 96 (UICollectionView.m:6423)
    8   UIKit                           0x1903a8f5c -[UICollectionView _performBatchUpdates:completion:invalidationContext:] + 84 (UICollectionView.m:6418)
    9   UIKit                           0x18fc834ec -[UICollectionView performBatchUpdates:completion:] + 64 (UICollectionView.m:6407)
    10  Signal                          0x1000d7e90 -[MessagesViewController yapDatabaseModified:] + 756 (MessagesViewController.m:1863)

// FREEBIE