### PR TITLE
Outgoing message sound respects Settings toggle (#1373)

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -654,7 +654,9 @@ typedef enum : NSUInteger {
                       date:(NSDate *)date
 {
     if (text.length > 0) {
-        [JSQSystemSoundPlayer jsq_playMessageSentSound];
+        if ([Environment.preferences soundInForeground]) {
+            [JSQSystemSoundPlayer jsq_playMessageSentSound];
+        }
 
         TSOutgoingMessage *message;
         OWSDisappearingMessagesConfiguration *configuration =


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6s Plus, iOS 10.1
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description

This PR makes it so that the "outgoing message sent" sound effect will not play if the "Notification Sounds" toggle is set to OFF in the Settings -> Notification menu, as per #1373. 

Manually tested on my phone. It looked like there weren't already automated tests in place for this view controller, so figuring out how to write a test against my 3-line change when I don't already have familiarity with the codebase seemed a bit much.

### Verification steps

1. Make sure your device sound is on and volume is up.
2. Send a message. It should play an outgoing message sound.
3. Go to Settings -> Notifications, and disable "Notification Sounds"
4. Send another message. It shouldn't play a sound.

