### PR TITLE
Don't show permissions pop-up until user has seen contact disclaimer

### DIFF
--- a/Signal/src/view controllers/SignalsViewController.m
+++ b/Signal/src/view controllers/SignalsViewController.m
@@ -191,13 +191,6 @@
 
 - (void)didAppearForNewlyRegisteredUser
 {
-    [self promptNewUserForContactsWithCompletion:^{
-        [self ensureNotificationsUpToDate];
-    }];
-}
-
-- (void)promptNewUserForContactsWithCompletion:(void (^)())completionHandler
-{
     ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
     switch (status) {
         case kABAuthorizationStatusNotDetermined:
@@ -212,16 +205,18 @@
                               actionWithTitle:NSLocalizedString(@"REGISTER_CONTACTS_CONTINUE", nil)
                                         style:UIAlertActionStyleCancel
                                       handler:^(UIAlertAction *action) {
+                                          [self ensureNotificationsUpToDate];
                                           [[Environment getCurrent].contactsManager doAfterEnvironmentInitSetup];
                                       }]];
 
-            [self presentViewController:controller animated:YES completion:completionHandler];
+            [self presentViewController:controller animated:YES completion:nil];
             break;
         }
         default: {
             DDLogError(@"%@ Unexpected for new user to have kABAuthorizationStatus:%ld", self.tag, status);
+            [self ensureNotificationsUpToDate];
             [[Environment getCurrent].contactsManager doAfterEnvironmentInitSetup];
-            completionHandler();
+
             break;
         }
     }


### PR DESCRIPTION
New installs are getting smashed with three popups at once. It's really gross.

This is still gross, but a little less terrible. What we really need is a better on boarding process explaining the need for these permissions.

// FREEBIE