### PR TITLE
Address some lingering emoji cropping

### DIFF
--- a/Signal/src/Models/OWSMessagesBubblesSizeCalculator.m
+++ b/Signal/src/Models/OWSMessagesBubblesSizeCalculator.m
@@ -54,18 +54,16 @@ NS_ASSUME_NONNULL_BEGIN
         return [self messageBubbleSizeForCallData:messageData atIndexPath:indexPath withLayout:layout];
     }
 
-    CGSize size;
     // BEGIN HACK iOS10EmojiBug see: https://github.com/WhisperSystems/Signal-iOS/issues/1368
     if ([self shouldApplyiOS10EmojiFixToString:messageData.text font:layout.messageBubbleFont]) {
-        size = [self withiOS10EmojiFixSuperMessageBubbleSizeForMessageData:messageData
+        return [self withiOS10EmojiFixSuperMessageBubbleSizeForMessageData:messageData
                                                                atIndexPath:indexPath
                                                                 withLayout:layout];
     } else {
-        size = [super messageBubbleSizeForMessageData:messageData atIndexPath:indexPath withLayout:layout];
-    }
-    // END HACK iOS10EmojiBug see: https://github.com/WhisperSystems/Signal-iOS/issues/1368
+        // END HACK iOS10EmojiBug see: https://github.com/WhisperSystems/Signal-iOS/issues/1368
 
-    return CGSizeMake(size.width, size.height);
+        return [super messageBubbleSizeForMessageData:messageData atIndexPath:indexPath withLayout:layout];
+    }
 }
 
 /**
@@ -122,7 +120,8 @@ NS_ASSUME_NONNULL_BEGIN
     int lines = (int)floor(superSize.height / emojiFont.lineHeight);
 
     // Add an extra pixel per line to fit the emoji.
-    return CGSizeMake(superSize.width, superSize.height + lines);
+    // This is a crappy solution. Long messages with only one line of emoji will have an extra pixel per line.
+    return CGSizeMake(superSize.width, superSize.height + 1.5 * lines);
 }
 
 

--- a/Signal/test/Models/MesssagesBubblesSizeCalculatorTest.swift
+++ b/Signal/test/Models/MesssagesBubblesSizeCalculatorTest.swift
@@ -90,14 +90,21 @@ class MesssagesBubblesSizeCalculatorTest: XCTestCase {
         let messageData = FakeMessageData(text:"Wunderschönen Guten Morgaaaahhhn 😝 - hast du gut geschlafen ☺️😘")
         let actual = calculator.messageBubbleSize(for: messageData, at: indexPath, with: layout)
 
-        XCTAssertEqual(84, actual.height);
+        XCTAssertEqual(85.5, actual.height);
+    }
+
+    func testHeightForiOS10EmojiBug2() {
+        let messageData = FakeMessageData(text:"Test test test test test test test test test test test test 😊❤️❤️")
+        let actual = calculator.messageBubbleSize(for: messageData, at: indexPath, with: layout)
+
+        XCTAssertEqual(62, actual.height);
     }
 
     func testHeightForChineseWithEmojiBug() {
         let messageData = FakeMessageData(text:"一二三四五六七八九十甲乙丙😝戊己庚辛壬圭咖啡牛奶餅乾水果蛋糕")
         let actual = calculator.messageBubbleSize(for: messageData, at: indexPath, with: layout)
         // erroneously seeing 69 with the emoji fix in place.
-        XCTAssertEqual(84, actual.height);
+        XCTAssertEqual(85.5, actual.height);
     }
 
     func testHeightForChineseWithoutEmojiBug() {


### PR DESCRIPTION
This is an expedient, but not good, "fix". Some messages are going to
have extra space at the bottom of the bubble. But, for the time being,
that's preferable to getting messages clipped.

// FREEBIE