### PR TITLE
Automatically adjust message bubble text size on dynamic text changes.

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -313,7 +313,7 @@ typedef enum : NSUInteger {
 {
     if (shouldObserve) {
         [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(dynamicTypeSettingsModified:)
+                                                 selector:@selector(didChangePreferredContentSize:)
                                                      name:UIContentSizeCategoryDidChangeNotification
                                                    object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -960,7 +960,7 @@ typedef enum : NSUInteger {
 
  @param notification NSNotification with the dynamic type change information.
  */
-- (void)dynamicTypeSettingsModified:(NSNotification *)notification {
+- (void)didChangePreferredContentSize:(NSNotification *)notification {
     [self.collectionView.collectionViewLayout setMessageBubbleFont:[UIFont ows_dynamicTypeBodyFont]];
     [self.collectionView reloadData];
     [self reloadInputToolbarSizeIfNeeded];

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -313,6 +313,10 @@ typedef enum : NSUInteger {
 {
     if (shouldObserve) {
         [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(dynamicTypeSettingsModified:)
+                                                     name:UIContentSizeCategoryDidChangeNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(yapDatabaseModified:)
                                                      name:YapDatabaseModifiedNotification
                                                    object:nil];
@@ -329,6 +333,9 @@ typedef enum : NSUInteger {
                                                      name:UIApplicationDidEnterBackgroundNotification
                                                    object:nil];
     } else {
+        [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                     name:UIContentSizeCategoryDidChangeNotification
+                                                   object:nil];
         [[NSNotificationCenter defaultCenter] removeObserver:self
                                                      name:YapDatabaseModifiedNotification
                                                    object:nil];
@@ -917,6 +924,47 @@ typedef enum : NSUInteger {
 }
 
 #pragma mark - Adjusting cell label heights
+
+
+/**
+ Due to the usage of JSQMessagesViewController, and it non-conformity to Dynamyc Type
+ we're left to our own devices to make this as usable as possible.
+ JSQMessagesVC also does not expose the constraint for the input toolbar height nor does it seem to
+ give us a method to tell it to re-adjust (I think it should observe the preferredDefaultHeight property).
+ 
+ With that in mind, we use magical runtime to get that property, and if it doesn't exist, we just don't apply the dynamic
+ type change. If it does exist, than we apply the font changes and adjust the views to contain them properly.
+ 
+ This is not the prettiest code, but it's working code. We should tag this code for deletion as soon as JSQMessagesVC adops Dynamic type.
+ */
+- (void)reloadInputToolbarSizeIfNeeded {
+    NSLayoutConstraint *heightConstraint = ((NSLayoutConstraint *)[self valueForKeyPath:@"toolbarHeightConstraint"]);
+    if (heightConstraint == nil) {
+        return;
+    }
+
+    [self.inputToolbar.contentView.textView setFont:[UIFont ows_dynamicTypeBodyFont]];
+
+    CGRect f = self.inputToolbar.contentView.textView.frame;
+    f.size.height = [self.inputToolbar.contentView.textView sizeThatFits:self.inputToolbar.contentView.textView.frame.size].height;
+    self.inputToolbar.contentView.textView.frame = f;
+
+    self.inputToolbar.preferredDefaultHeight = self.inputToolbar.contentView.textView.frame.size.height + 16;
+    heightConstraint.constant = self.inputToolbar.preferredDefaultHeight;
+    [self.inputToolbar setNeedsLayout];
+}
+
+
+/**
+ Called whenever the user manually changes the dynamic type options inside Settings.
+
+ @param notification NSNotification with the dynamic type change information.
+ */
+- (void)dynamicTypeSettingsModified:(NSNotification *)notification {
+    [self.collectionView.collectionViewLayout setMessageBubbleFont:[UIFont ows_dynamicTypeBodyFont]];
+    [self.collectionView reloadData];
+    [self reloadInputToolbarSizeIfNeeded];
+}
 
 - (CGFloat)collectionView:(JSQMessagesCollectionView *)collectionView
                               layout:(JSQMessagesCollectionViewFlowLayout *)collectionViewLayout


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 7, iOS 10.1
 * iOS Simulator 6, 7, 7 Plus, iOS 10.0
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description

- This addresses some of the concerns raised #1453. While the chat screen does respond to dynamic type, it only does so currently if the user leaves the chat screen and return. This makes it so that the screen size adjusts as soon as the user changes the text size settings.
