### PR TITLE
Fixes #1390: Make settings menu more obvious

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -501,23 +501,17 @@ typedef enum : NSUInteger {
                                                                       action:@selector(callAction)];
         callButton.imageInsets = UIEdgeInsetsMake(0, -10, 0, 10);
         [barButtons addObject:callButton];
-    } else if ([self.thread isGroupThread]) {
-        UIBarButtonItem *manageGroupButton =
-            [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"contact-options-action"]
-                                             style:UIBarButtonItemStylePlain
-                                            target:self
-                                            action:@selector(didTapManageGroupButton:)];
-        // Hack to shrink button image
-        manageGroupButton.imageInsets = UIEdgeInsetsMake(10, 20, 10, 0);
-        [barButtons addObject:manageGroupButton];
     }
 
-    if (disappearingMessagesConfiguration.isEnabled) {
-        [barButtons addObject:[[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"ic_timer"]
-                                                               style:UIBarButtonItemStylePlain
-                                                              target:self
-                                                              action:@selector(didTapTimerInNavbar)]];
-    }
+    UIBarButtonItem *conversationSettingsButton =
+        [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"contact-options-action"]
+                                         style:UIBarButtonItemStylePlain
+                                        target:self
+                                        action:@selector(didTapConversationSettingsButton:)];
+    // Hack to shrink button image
+    conversationSettingsButton.imageInsets = UIEdgeInsetsMake(10, 20, 10, 0);
+    [barButtons addObject:conversationSettingsButton];
+
 
     self.navigationItem.rightBarButtonItems = [barButtons copy];
 }
@@ -1113,15 +1107,9 @@ typedef enum : NSUInteger {
     [self showConversationSettings];
 }
 
-- (void)didTapManageGroupButton:(id)sender
+- (void)didTapConversationSettingsButton:(id)sender
 {
     DDLogDebug(@"%@ Tapped options menu in navbar", self.tag);
-    [self showConversationSettings];
-}
-
-- (void)didTapTimerInNavbar
-{
-    DDLogDebug(@"%@ Tapped timer in navbar", self.tag);
     [self showConversationSettings];
 }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE, iOS 10.1
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

* Always show settings button
* Remove timer button

See the linked issue. The timer link goes to the settings anyway and we are already using the `...` for group messages so it make sense to just extend that to all convos. I'm still not sure if the phone should be the far right item or not for consistency with group contacts. I also think there is a bit too much space between the icons but that might just be me.

I'm open to other ideas if the timer icon link is something we 100% want. You need to get to settings to configure it anyway so the discoverability of that feature is pretty poor at the moment.

Also, how do we feel about making it a modal for consistency with the other settings.

iPhone SE screenshot:
![img_0753](https://cloud.githubusercontent.com/assets/2245080/20473450/cf65734a-af8e-11e6-8cd6-298e326d9076.jpg)
