### PR TITLE
Compare both first and last names when sorting

### DIFF
--- a/Signal/src/contact/OWSContactsManager.m
+++ b/Signal/src/contact/OWSContactsManager.m
@@ -385,46 +385,10 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
             signalContacts[contact.textSecureIdentifiers.firstObject] = contact;
         }
     }
-    return [signalContacts.allValues sortedArrayUsingComparator:[[self class] contactComparator]];
-}
 
-+ (NSComparator)contactComparator {
-    return ^NSComparisonResult(id obj1, id obj2) {
-      Contact *contact1 = (Contact *)obj1;
-      Contact *contact2 = (Contact *)obj2;
-
-      BOOL firstNameOrdering = ABPersonGetSortOrdering() == kABPersonCompositeNameFormatFirstNameFirst ? YES : NO;
-
-      if (firstNameOrdering) {
-          if (contact1.firstName) {
-              if (contact2.firstName) {
-                  return [contact1.firstName caseInsensitiveCompare:contact2.firstName];
-              } else {
-                  return [contact1.firstName caseInsensitiveCompare:contact2.lastName];
-              }
-          } else {
-              if (contact2.firstName) {
-                  return [contact1.lastName caseInsensitiveCompare:contact2.firstName];
-              } else {
-                  return [contact1.lastName caseInsensitiveCompare:contact2.lastName];
-              }
-          }
-      } else {
-          if (contact1.lastName) {
-              if (contact2.lastName) {
-                  return [contact1.lastName caseInsensitiveCompare:contact2.lastName];
-              } else {
-                  return [contact1.lastName caseInsensitiveCompare:contact2.firstName];
-              }
-          } else {
-              if (contact2.lastName) {
-                  return [contact1.firstName caseInsensitiveCompare:contact2.lastName];
-              } else {
-                  return [contact1.firstName caseInsensitiveCompare:contact2.firstName];
-              }
-          }
-      };
-    };
+    BOOL firstNameOrdering = ABPersonGetSortOrdering() == kABPersonCompositeNameFormatFirstNameFirst ? YES : NO;
+    NSComparator contactsComparator = [Contact comparatorSortingNamesByFirstThenLast:firstNameOrdering];
+    return [signalContacts.allValues sortedArrayUsingComparator:contactsComparator];
 }
 
 - (NSArray<Contact *> *)signalContacts {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6s, iOS 10.1.1
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #1487 

If two names have the same last name, ensure we fall back on the
first name when sorting them.

This should not be merged until [SignalServiceKit PR #67](https://github.com/WhisperSystems/SignalServiceKit/pull/67) is merged and the Podfile has been updated to point the master SSK branch.

// FREEBIE