### PR TITLE
Prevent going to the "Background Notifications" when tapping "Notification Sounds"

### DIFF
--- a/Signal/src/view controllers/NotificationSettingsViewController.m
+++ b/Signal/src/view controllers/NotificationSettingsViewController.m
@@ -12,6 +12,8 @@
 #import "NotificationSettingsOptionsViewController.h"
 #import "PropertyListPreferences.h"
 
+#define kNotificationOptionSection 0
+
 @interface NotificationSettingsViewController ()
 
 @property NSArray *notificationsSections;
@@ -62,7 +64,7 @@
     }
 
     PropertyListPreferences *prefs = Environment.preferences;
-    if (indexPath.section == 0) {
+    if (indexPath.section == kNotificationOptionSection) {
         NotificationType notifType = [prefs notificationPreviewType];
         NSString *detailString     = [prefs nameForNotificationPreviewType:notifType];
 
@@ -90,10 +92,26 @@
     [Environment.preferences setSoundInForeground:sender.on];
 }
 
+- (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
+    switch (indexPath.section) {
+        case kNotificationOptionSection: {
+            return indexPath;
+        }
+        default: {
+            return nil;
+        }
+    }
+}
+
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    NotificationSettingsOptionsViewController *vc =
-        [[NotificationSettingsOptionsViewController alloc] initWithStyle:UITableViewStyleGrouped];
-    [self.navigationController pushViewController:vc animated:YES];
+    switch (indexPath.section) {
+        case kNotificationOptionSection: {
+            NotificationSettingsOptionsViewController *vc =
+                [[NotificationSettingsOptionsViewController alloc] initWithStyle:UITableViewStyleGrouped];
+            [self.navigationController pushViewController:vc animated:YES];
+            break;
+        }
+    }
 }
 
 - (void)tableView:(UITableView *)tableView didDeselectRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone Version: iPhone5,2, iOS Version: 9.3.5 
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Prevent going to the "Background Notifications" when tapping "Notification Sounds"
Fixes #1508