### PR TITLE
Fix crash in group member listing

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.6.7.1</string>
+	<string>2.6.7.2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/contact/OWSContactsManager.m
+++ b/Signal/src/contact/OWSContactsManager.m
@@ -386,9 +386,13 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
         }
     }
 
+    return [signalContacts.allValues sortedArrayUsingComparator:[[self class] contactComparator]];
+}
+
++ (NSComparator)contactComparator
+{
     BOOL firstNameOrdering = ABPersonGetSortOrdering() == kABPersonCompositeNameFormatFirstNameFirst ? YES : NO;
-    NSComparator contactsComparator = [Contact comparatorSortingNamesByFirstThenLast:firstNameOrdering];
-    return [signalContacts.allValues sortedArrayUsingComparator:contactsComparator];
+    return [Contact comparatorSortingNamesByFirstThenLast:firstNameOrdering];
 }
 
 - (NSArray<Contact *> *)signalContacts {


### PR DESCRIPTION
Restore contactsComparator which is still being used in the group member
listing

partial revert of 81e1ec4b9ed58e282e1d02a8c3a5b82e65f0cb4b

// FREEBIE