### PR TITLE
Improve accessibility a bit

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -236,6 +236,8 @@ typedef enum : NSUInteger {
     self.messageAdapterCache = [[NSCache alloc] init];
 
     _attachButton = [[UIButton alloc] init];
+    _attachButton.accessibilityLabel = NSLocalizedString(@"ATTACHMENT_LABEL", @"Accessibility label for attaching photos");
+    _attachButton.accessibilityHint = NSLocalizedString(@"ATTACHMENT_HINT", @"Accessibility hint describing what you can do with the attachment button");
     [_attachButton setFrame:CGRectMake(0,
                                        0,
                                        JSQ_TOOLBAR_ICON_WIDTH + JSQ_IMAGE_INSET * 2,
@@ -498,6 +500,7 @@ typedef enum : NSUInteger {
                                                                        style:UIBarButtonItemStylePlain
                                                                       target:self
                                                                       action:@selector(callAction)];
+        callButton.accessibilityLabel = NSLocalizedString(@"CALL_LABEL", "Accessibilty label for placing call button");
         callButton.imageInsets = UIEdgeInsetsMake(0, -10, 0, 10);
         [barButtons addObject:callButton];
     } else if ([self.thread isGroupThread]) {
@@ -508,14 +511,19 @@ typedef enum : NSUInteger {
                                             action:@selector(didTapManageGroupButton:)];
         // Hack to shrink button image
         manageGroupButton.imageInsets = UIEdgeInsetsMake(10, 20, 10, 0);
+        manageGroupButton.accessibilityLabel = NSLocalizedString(@"GROUP_SETTINGS_LABEL", @"Accessibilty label for group settings");
         [barButtons addObject:manageGroupButton];
     }
 
     if (disappearingMessagesConfiguration.isEnabled) {
-        [barButtons addObject:[[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"ic_timer"]
+        UIBarButtonItem *timerButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"ic_timer"]
                                                                style:UIBarButtonItemStylePlain
                                                               target:self
-                                                              action:@selector(didTapTimerInNavbar)]];
+                                                              action:@selector(didTapTimerInNavbar)];
+        timerButton.accessibilityLabel = NSLocalizedString(@"DISAPPEARING_MESSAGES_LABEL", @"Accessibility label for disappearing messages");
+        NSString *formatString = NSLocalizedString(@"DISAPPEARING_MESSAGES_HINT", @"Accessibility hint that contains current timeout information");
+        timerButton.accessibilityHint = [NSString stringWithFormat:formatString, [disappearingMessagesConfiguration durationString]];
+        [barButtons addObject:timerButton];
     }
 
     self.navigationItem.rightBarButtonItems = [barButtons copy];

--- a/Signal/src/view controllers/NewGroupViewController.m
+++ b/Signal/src/view controllers/NewGroupViewController.m
@@ -110,6 +110,7 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
                                             action:@selector(createGroup)];
         self.navigationItem.rightBarButtonItem.imageInsets = UIEdgeInsetsMake(0, -10, 0, 10);
         self.navigationItem.title                          = NSLocalizedString(@"NEW_GROUP_DEFAULT_TITLE", @"");
+        self.navigationItem.rightBarButtonItem.accessibilityLabel = NSLocalizedString(@"FINISH_GROUP_CREATION_LABEL", @"Accessibilty label for finishing new group");
     } else {
         self.navigationItem.rightBarButtonItem =
             [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"UPDATE_BUTTON_TITLE", @"")

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -52,11 +52,20 @@
 /* No comment provided by engineer. */
 "ATTACHMENT_DOWNLOADING" = "Attachment is downloading";
 
+/* Accessibility hint describing what you can do with the attachment button */
+"ATTACHMENT_HINT" = "Choose or take a picture and then send it";
+
+/* Accessibility label for attaching photos */
+"ATTACHMENT_LABEL" = "Attachment";
+
 /* No comment provided by engineer. */
 "ATTACHMENT_QUEUED" = "New attachment queued for retrieval.";
 
 /* No comment provided by engineer. */
 "AUDIO_PERMISSION_MESSAGE" = "Signal requires access to your microphone to work properly. You can restore the permission in the Settings app >> Privacy >> Microphone >> Signal";
+
+/* Accessibilty label for placing call button */
+"CALL_LABEL" = "Call";
 
 /* No comment provided by engineer. */
 "CALLBACK_BUTTON_TITLE" = "Call back";
@@ -120,6 +129,12 @@
 
 /* subheading in conversation settings */
 "DISAPPEARING_MESSAGES_DESCRIPTION" = "When enabled, messages sent and received in this conversation will disappear after they have been seen.";
+
+/* Accessibility hint that contains current timeout information */
+"DISAPPEARING_MESSAGES_HINT" = "Currently messages disappear after %@";
+
+/* Accessibility label for disappearing messages */
+"DISAPPEARING_MESSAGES_LABEL" = "Disappearing messages settings";
 
 /* Generic short text for button to dismiss a dialog */
 "DISMISS_BUTTON_TEXT" = "Dismiss";
@@ -265,6 +280,9 @@
 /* No comment provided by engineer. */
 "FINGERPRINT_SHRED_KEYMATERIAL_BUTTON" = "Reset this session.";
 
+/* Accessibilty label for finishing new group */
+"FINISH_GROUP_CREATION_LABEL" = "Finish creating group";
+
 /* No comment provided by engineer. */
 "GROUP_AVATAR_CHANGED" = "Avatar changed. ";
 
@@ -294,6 +312,9 @@
 
 /* No comment provided by engineer. */
 "GROUP_REMOVING_FAILED" = "Failed to leave group";
+
+/* Accessibilty label for group settings */
+"GROUP_SETTINGS_LABEL" = "Group settings";
 
 /* No comment provided by engineer. */
 "GROUP_TITLE_CHANGED" = "Title is now '%@'. ";


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE, 10.1.1
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -
This is a start at #864 and #1210. Any feedback on how well this conveys meaning to the user/fits with Apple's HIG would be appreciated. Major missing pieces that still need to happen:

- [] We have to localize the Storyboards and I'm not sure how to do that - a number of the confusing buttons are built in IB and while I can set runtime defined `accessibilityLabel`s and such it doesn't localize into files without additional Xcode black magic
- [] I want to do magic tap at least on phone calls, just need to work out the state logic properly
- [] We can make things like reading out the message a lot nicer where it says things like "sent on" instead of just spitting out the date (WhatsApp does it well)
- [] I couldn't figure out a way to tap on the name to get to the conversation settings with VO enabled, maybe #1498 will help with that, you can do it in WhatsApp just fine

#1498 conflicts with this so hopefully that can be merged first and then this can be rebased/updated. This is my first time using VO, quite an experience.