### PR TITLE
Prevent iRate prompt when handling local notifications

### DIFF
--- a/Libraries/iRate/iRate.h
+++ b/Libraries/iRate/iRate.h
@@ -165,6 +165,7 @@ typedef NS_ENUM(NSUInteger, iRateErrorCode) {
 - (void)promptIfAllCriteriaMet;
 - (void)openRatingsPageInAppStore;
 - (void)logEvent:(BOOL)deferPrompt;
+- (void)preventPromptAtNextTest;
 
 @end
 

--- a/Libraries/iRate/iRate.m
+++ b/Libraries/iRate/iRate.m
@@ -128,6 +128,7 @@ static NSString *const iRateMacAppStoreURLFormat  = @"macappstore://itunes.apple
 @property (nonatomic, strong) id visibleAlert;
 @property (nonatomic, assign) BOOL checkingForPrompt;
 @property (nonatomic, assign) BOOL checkingForAppStoreID;
+@property (nonatomic, assign) BOOL shouldPreventPromptAtNextTest;
 
 @end
 
@@ -224,6 +225,7 @@ static NSString *const iRateMacAppStoreURLFormat  = @"macappstore://itunes.apple
         self.remindPeriod                      = 1.0f;
         self.verboseLogging                    = NO;
         self.previewMode                       = NO;
+        self.shouldPreventPromptAtNextTest     = NO;
 
 #if DEBUG
 
@@ -404,6 +406,10 @@ static NSString *const iRateMacAppStoreURLFormat  = @"macappstore://itunes.apple
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+- (void)preventPromptAtNextTest {
+    self.shouldPreventPromptAtNextTest = YES;
+}
+
 - (void)incrementUseCount {
     self.usesCount++;
 }
@@ -413,6 +419,14 @@ static NSString *const iRateMacAppStoreURLFormat  = @"macappstore://itunes.apple
 }
 
 - (BOOL)shouldPromptForRating {
+    // Avoid potentially inconvenient prompt
+    if (self.shouldPreventPromptAtNextTest)
+    {
+        NSLog(@"iRate did not prompt for rating because it is potentially inconvenient");
+        self.shouldPreventPromptAtNextTest = NO;
+        return NO;
+    }
+
     // preview mode?
     if (self.previewMode) {
         NSLog(@"iRate preview mode is enabled - make sure you disable this for release");

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -332,6 +332,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 }
 
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification {
+    [AppStoreRating preventPromptAtNextTest];
     [[PushManager sharedManager] application:application didReceiveLocalNotification:notification];
 }
 

--- a/Signal/src/util/AppStoreRating.h
+++ b/Signal/src/util/AppStoreRating.h
@@ -11,5 +11,6 @@
 @interface AppStoreRating : NSObject
 
 + (void)setupRatingLibrary;
++ (void)preventPromptAtNextTest;
 
 @end

--- a/Signal/src/util/AppStoreRating.m
+++ b/Signal/src/util/AppStoreRating.m
@@ -25,4 +25,8 @@
     rate.rateButtonLabel                = NSLocalizedString(@"RATING_RATE", nil);
 }
 
++ (void)preventPromptAtNextTest {
+    iRate *rate = [iRate sharedInstance];
+    [rate preventPromptAtNextTest];
+}
 @end


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
 * iPhone5,2, iOS Version: 9.3.5
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Local notification prevents iRate prompt. I added a flag to prevent the next prompt to be presented.
Should fix #1530

Testing was a bit tricky as notifications are hard to generate. When the app was going to the background I created a new message and a local notification to ensure that:
- no prompt was presented when clicking on the notification
- a prompt was presented when clicking directly on the icon

I originally implemented another strategy that prevented useCount increment but the limiting condition may not be the useCount so I changed to the pushed alternatives.

I thought about an alternative adding a delay as a condition, for instance: Can't prompt in less than 30 seconds. That would delay the prompt to the next ```ApplicationEnterForeground```occurrence.

Let me know if you think alternatives (one of those or another one) would be preferred.