### PR TITLE
Fix show error message when download fails

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
@@ -155,12 +155,10 @@
 
                     if (pointer.isDownloading) {
                         adapter.messageBody = NSLocalizedString(@"ATTACHMENT_DOWNLOADING", nil);
+                    } else if (pointer.hasFailed) {
+                        adapter.messageBody = NSLocalizedString(@"ATTACHMENT_DOWNLOAD_FAILED", nil);
                     } else {
-                        if (pointer.hasFailed) {
-                            adapter.messageBody = NSLocalizedString(@"ATTACHMENT_QUEUED", nil);
-                        } else {
-                            adapter.messageBody = NSLocalizedString(@"ATTACHMENT_DOWNLOAD_FAILED", nil);
-                        }
+                        adapter.messageBody = NSLocalizedString(@"ATTACHMENT_QUEUED", nil);
                     }
                 } else {
                     DDLogError(@"We retrieved an attachment that doesn't have a known type : %@",


### PR DESCRIPTION

Previously we had our "queued" and "failed" logic backwards.

// FREEBIE