### PR TITLE
Rework startup logging.

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -23,6 +23,7 @@
 #import <SignalServiceKit/OWSIncomingMessageReadObserver.h>
 #import <SignalServiceKit/OWSMessageSender.h>
 #import <SignalServiceKit/TSAccountManager.h>
+#import <SignalServiceKit/AppVersion.h>
 
 NSString *const AppDelegateStoryboardMain = @"Main";
 NSString *const AppDelegateStoryboardRegistration = @"Registration";
@@ -52,6 +53,23 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     CategorizingLogger *logger = [CategorizingLogger categorizingLogger];
     [logger addLoggingCallback:^(NSString *category, id details, NSUInteger index){
     }];
+    
+    BOOL loggingIsEnabled;
+    
+#ifdef DEBUG
+    // Specified at Product -> Scheme -> Edit Scheme -> Test -> Arguments -> Environment to avoid things like
+    // the phone directory being looked up during tests.
+    loggingIsEnabled = TRUE;
+    [DebugLogger.sharedLogger enableTTYLogging];
+#elif RELEASE
+    loggingIsEnabled = Environment.preferences.loggingIsEnabled;
+#endif
+    
+    if (loggingIsEnabled) {
+        [DebugLogger.sharedLogger enableFileLogging];
+    }
+
+    [AppVersion instance];
 
     // Setting up environment
     [Environment setCurrent:[Release releaseEnvironmentWithLogging:logger]];
@@ -68,21 +86,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     }
     [Environment.getCurrent initCallListener];
 
-    BOOL loggingIsEnabled;
-
-#ifdef DEBUG
-    // Specified at Product -> Scheme -> Edit Scheme -> Test -> Arguments -> Environment to avoid things like
-    // the phone directory being looked up during tests.
-    loggingIsEnabled = TRUE;
-    [DebugLogger.sharedLogger enableTTYLogging];
-#elif RELEASE
-    loggingIsEnabled = Environment.preferences.loggingIsEnabled;
-#endif
     [self verifyBackgroundBeforeKeysAvailableLaunch];
-
-    if (loggingIsEnabled) {
-        [DebugLogger.sharedLogger enableFileLogging];
-    }
 
     [self setupTSKitEnv];
 


### PR DESCRIPTION
* Instantiate AppVersion asap.
* Ensure logging is configured before other startup logic.

Previously, we were configuring logging after Environment. But some of the logic used by Environment's initialization process does logging (and should). So it seems like we should configure logging before Environment. 

Is this safe? The proper ordering of these startup operations isn't clear. Is there anything in the logging configuration that depends on Environment? Do I need to investigate further?

PTAL @michaelkirk