### PR TITLE
Sync CallKit mute button state with in app mute button.

### DIFF
--- a/Signal/src/Storyboard/Main.storyboard
+++ b/Signal/src/Storyboard/Main.storyboard
@@ -347,6 +347,8 @@
                         <outlet property="contactAvatarView" destination="id3-xi-PFz" id="CUV-hJ-Qcp"/>
                         <outlet property="contactNameLabel" destination="UbL-8Z-oK1" id="h9V-l9-JVF"/>
                         <outlet property="incomingCallControls" destination="5E5-dq-23I" id="fWz-1n-pjI"/>
+                        <outlet property="muteButton" destination="NES-Ce-PcK" id="Eku-Tx-cMN"/>
+                        <outlet property="speakerPhoneButton" destination="Bb2-w8-mPU" id="GYN-Z6-i5I"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5mi-rT-gg5" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -578,8 +578,6 @@ fileprivate let timeoutSeconds = 60
         let callRecord = TSCall(timestamp: NSDate.ows_millisecondTimeStamp(), withCallNumber: call.remotePhoneNumber, callType: RPRecentCallTypeIncoming, in: thread)
         callRecord.save()
 
-        callUIAdapter.answerCall(call)
-
         let message = DataChannelMessage.forConnected(callId: call.signalingId)
         if peerConnectionClient.sendDataChannelMessage(data: message.asData()) {
             Logger.debug("\(TAG) sendDataChannelMessage returned true")

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -718,6 +718,13 @@ fileprivate let timeoutSeconds = 60
             handleFailedCall(error: .assertionError(description:"\(TAG) peerConnectionClient unexpectedly nil in \(#function)"))
             return
         }
+
+        guard let call = self.call else {
+            handleFailedCall(error: .assertionError(description:"\(TAG) call unexpectedly nil in \(#function)"))
+            return
+        }
+
+        call.isMuted = isMuted
         peerConnectionClient.setAudioEnabled(enabled: !isMuted)
     }
 

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -48,7 +48,9 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
     }
 
     internal func answerCall(_ call: SignalCall) {
-        // NO-OP
+        CallService.signalingQueue.async {
+            self.callService.handleAnswerCall(call)
+        }
     }
 
     internal func declineCall(_ call: SignalCall) {

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -18,7 +18,7 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         self.notificationsAdapter = notificationsAdapter
     }
 
-    public func startOutgoingCall(_ call: SignalCall) {
+    internal func startOutgoingCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             _ = self.callService.handleOutgoingCall(call).then {
                 Logger.debug("\(self.TAG) handleOutgoingCall succeeded")
@@ -28,7 +28,7 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         }
     }
 
-    public func reportIncomingCall(_ call: SignalCall, callerName: String) {
+    internal func reportIncomingCall(_ call: SignalCall, callerName: String) {
         Logger.debug("\(TAG) \(#function)")
 
         // present Call View controller
@@ -43,23 +43,30 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         }
     }
 
-    public func reportMissedCall(_ call: SignalCall, callerName: String) {
+    internal func reportMissedCall(_ call: SignalCall, callerName: String) {
         notificationsAdapter.presentMissedCall(call, callerName: callerName)
     }
 
-    public func answerCall(_ call: SignalCall) {
+    internal func answerCall(_ call: SignalCall) {
         // NO-OP
     }
 
-    public func declineCall(_ call: SignalCall) {
+    internal func declineCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             self.callService.handleDeclineCall(call)
         }
     }
 
-    public func endCall(_ call: SignalCall) {
+    internal func endCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             self.callService.handleLocalHungupCall(call)
         }
     }
+
+    internal func toggleMute(call: SignalCall, isMuted: Bool) {
+        CallService.signalingQueue.async {
+            self.callService.handleToggledMute(isMuted: isMuted)
+        }
+    }
+
 }

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -18,7 +18,7 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         self.notificationsAdapter = notificationsAdapter
     }
 
-    internal func startOutgoingCall(_ call: SignalCall) {
+    func startOutgoingCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             _ = self.callService.handleOutgoingCall(call).then {
                 Logger.debug("\(self.TAG) handleOutgoingCall succeeded")
@@ -28,7 +28,7 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         }
     }
 
-    internal func reportIncomingCall(_ call: SignalCall, callerName: String) {
+    func reportIncomingCall(_ call: SignalCall, callerName: String) {
         Logger.debug("\(TAG) \(#function)")
 
         // present Call View controller
@@ -43,29 +43,29 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         }
     }
 
-    internal func reportMissedCall(_ call: SignalCall, callerName: String) {
+    func reportMissedCall(_ call: SignalCall, callerName: String) {
         notificationsAdapter.presentMissedCall(call, callerName: callerName)
     }
 
-    internal func answerCall(_ call: SignalCall) {
+    func answerCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             self.callService.handleAnswerCall(call)
         }
     }
 
-    internal func declineCall(_ call: SignalCall) {
+    func declineCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             self.callService.handleDeclineCall(call)
         }
     }
 
-    internal func endCall(_ call: SignalCall) {
+    func endCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             self.callService.handleLocalHungupCall(call)
         }
     }
 
-    internal func toggleMute(call: SignalCall, isMuted: Bool) {
+    func toggleMute(call: SignalCall, isMuted: Bool) {
         CallService.signalingQueue.async {
             self.callService.handleToggledMute(isMuted: isMuted)
         }

--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -275,25 +275,6 @@ class PeerConnectionClient: NSObject {
         let buffer = RTCDataBuffer(data: data, isBinary: false)
         return dataChannel.sendData(buffer)
     }
-
-    // MARK: CallAudioManager
-
-    internal func configureAudioSession() {
-        Logger.warn("TODO: \(#function)")
-    }
-
-    internal func stopAudio() {
-        Logger.warn("TODO: \(#function)")
-    }
-
-    internal func startAudio() {
-        guard let audioSender = self.audioSender else {
-            Logger.error("\(TAG) ignoring \(#function) because audioSender was nil")
-            return
-        }
-
-        Logger.warn("TODO: \(#function)")
-    }
 }
 
 /**

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -16,7 +16,7 @@ enum CallState: String {
     case remoteBusy // terminal
 }
 
-protocol CallDelegate {
+protocol CallDelegate: class {
     func stateDidChange(call: SignalCall, state: CallState)
     func muteDidChange(call: SignalCall, isMuted: Bool)
 }
@@ -28,7 +28,7 @@ protocol CallDelegate {
 
     let TAG = "[SignalCall]"
 
-    var delegate: CallDelegate?
+    weak var delegate: CallDelegate?
     let remotePhoneNumber: String
 
     // Signal Service identifier for this Call. Used to coordinate the call across remote clients.

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -16,6 +16,11 @@ enum CallState: String {
     case remoteBusy // terminal
 }
 
+protocol CallDelegate {
+    func stateDidChange(call: SignalCall, state: CallState)
+    func muteDidChange(call: SignalCall, isMuted: Bool)
+}
+
 /**
  * Data model for a WebRTC backed voice/video call.
  */
@@ -23,20 +28,29 @@ enum CallState: String {
 
     let TAG = "[SignalCall]"
 
+    var delegate: CallDelegate?
+    let remotePhoneNumber: String
+
+    // Signal Service identifier for this Call. Used to coordinate the call across remote clients.
+    let signalingId: UInt64
+
+    // Distinguishes between calls locally, e.g. in CallKit
+    let localId: UUID
+    var hasVideo = false
     var state: CallState {
         didSet {
             Logger.debug("\(TAG) state changed: \(oldValue) -> \(state)")
-            stateDidChange?(state)
+            delegate?.stateDidChange(call: self, state: state)
+        }
+    }
+    var isMuted = false {
+        didSet {
+            Logger.debug("\(TAG) muted changed: \(oldValue) -> \(isMuted)")
+            delegate?.muteDidChange(call: self, isMuted: isMuted)
         }
     }
 
-    let signalingId: UInt64
-    let remotePhoneNumber: String
-    let localId: UUID
-    var hasVideo = false
     var error: CallError?
-
-    var stateDidChange: ((_ newState: CallState) -> Void)?
 
     init(localId: UUID, signalingId: UInt64, state: CallState, remotePhoneNumber: String) {
         self.localId = localId

--- a/Signal/src/call/Speakerbox/CallKitCallManager.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallManager.swift
@@ -5,8 +5,12 @@ import UIKit
 import CallKit
 
 /**
- * Based on SpeakerboxCallManager, from the Apple CallKit Example app. Though, it's responsibilities are mostly mirrored (and delegated from) CallKitCallUIAdaptee.
- * TODO: Would it simplify things to merge this into CallKitCallUIAdaptee?
+ * Requests actions from CallKit
+ *
+ * @Discussion:
+ *   Based on SpeakerboxCallManager, from the Apple CallKit Example app. Though, it's responsibilities are mostly 
+ *   mirrored (and delegated from) CallKitCallUIAdaptee.
+ *   TODO: Would it simplify things to merge this into CallKitCallUIAdaptee?
  */
 @available(iOS 10.0, *)
 final class CallKitCallManager: NSObject {
@@ -48,6 +52,14 @@ final class CallKitCallManager: NSObject {
         let muteCallAction = CXSetMutedCallAction(call: call.localId, muted: isMuted)
         let transaction = CXTransaction()
         transaction.addAction(muteCallAction)
+
+        requestTransaction(transaction)
+    }
+
+    func answer(call: SignalCall) {
+        let answerCallAction = CXAnswerCallAction(call: call.localId)
+        let transaction = CXTransaction()
+        transaction.addAction(answerCallAction)
 
         requestTransaction(transaction)
     }

--- a/Signal/src/call/Speakerbox/CallKitCallManager.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallManager.swift
@@ -5,12 +5,13 @@ import UIKit
 import CallKit
 
 /**
- * Based on SpeakerboxCallManager, from the Apple CallKit Example app. Though, it's responsibilities are mostly mirrored (and delegated from) CallUIAdapter?
+ * Based on SpeakerboxCallManager, from the Apple CallKit Example app. Though, it's responsibilities are mostly mirrored (and delegated from) CallKitCallUIAdaptee.
  * TODO: Would it simplify things to merge this into CallKitCallUIAdaptee?
  */
 @available(iOS 10.0, *)
 final class CallKitCallManager: NSObject {
 
+    let TAG = "[CallKitCallManager]"
     let callController = CXCallController()
 
     // MARK: Actions
@@ -43,12 +44,20 @@ final class CallKitCallManager: NSObject {
         requestTransaction(transaction)
     }
 
+    func toggleMute(call: SignalCall, isMuted: Bool) {
+        let muteCallAction = CXSetMutedCallAction(call: call.localId, muted: isMuted)
+        let transaction = CXTransaction()
+        transaction.addAction(muteCallAction)
+
+        requestTransaction(transaction)
+    }
+
     private func requestTransaction(_ transaction: CXTransaction) {
         callController.request(transaction) { error in
             if let error = error {
-                print("Error requesting transaction: \(error)")
+                Logger.error("\(self.TAG) Error requesting transaction: \(error)")
             } else {
-                print("Requested transaction successfully")
+                Logger.debug("\(self.TAG) Requested transaction successfully")
             }
         }
     }

--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -55,14 +55,14 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
     // MARK: CallUIAdaptee
 
-    internal func startOutgoingCall(_ call: SignalCall) {
+    func startOutgoingCall(_ call: SignalCall) {
         // Add the new outgoing call to the app's list of calls.
         // So we can find it in the provider delegate callbacks.
         callManager.addCall(call)
         callManager.startCall(call)
     }
 
-    internal func reportIncomingCall(_ call: SignalCall, callerName: String) {
+    func reportIncomingCall(_ call: SignalCall, callerName: String) {
         // Construct a CXCallUpdate describing the incoming call, including the caller.
         let update = CXCallUpdate()
         update.remoteHandle = CXHandle(type: .phoneNumber, value: call.remotePhoneNumber)
@@ -83,19 +83,19 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
         }
     }
 
-    internal func answerCall(_ call: SignalCall) {
+    func answerCall(_ call: SignalCall) {
         callManager.answer(call: call)
     }
 
-    internal func declineCall(_ call: SignalCall) {
+    func declineCall(_ call: SignalCall) {
         callManager.end(call: call)
     }
 
-    internal func endCall(_ call: SignalCall) {
+    func endCall(_ call: SignalCall) {
         callManager.end(call: call)
     }
 
-    internal func toggleMute(call: SignalCall, isMuted: Bool) {
+    func toggleMute(call: SignalCall, isMuted: Bool) {
         callManager.toggleMute(call: call, isMuted: isMuted)
     }
 

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -14,6 +14,7 @@ protocol CallUIAdaptee {
     func answerCall(_ call: SignalCall)
     func declineCall(_ call: SignalCall)
     func endCall(_ call: SignalCall)
+    func toggleMute(call: SignalCall, isMuted: Bool)
 }
 
 // Shared default implementations
@@ -85,5 +86,9 @@ class CallUIAdapter {
 
     internal func showCall(_ call: SignalCall) {
         adaptee.showCall(call)
+    }
+
+    internal func toggleMute(call: SignalCall, isMuted: Bool) {
+        adaptee.toggleMute(call: call, isMuted: isMuted)
     }
 }

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -44,7 +44,7 @@ class CallUIAdapter {
         if Platform.isSimulator {
             // CallKit doesn't seem entirely supported in simulator.
             // e.g. you can't receive calls in the call screen.
-            // So we use the non-call kit call UI.
+            // So we use the non-CallKit call UI.
             Logger.info("\(TAG) choosing non-callkit adaptee for simulator.")
             adaptee = NonCallKitCallUIAdaptee(callService: callService, notificationsAdapter: notificationsAdapter)
         } else if #available(iOS 10.0, *) {

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -5,6 +5,7 @@ import Foundation
 import WebRTC
 import PromiseKit
 
+// TODO move this somewhere else.
 @objc class CallAudioService: NSObject {
     private let TAG = "[CallAudioService]"
     private var vibrateTimer: Timer?

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -126,7 +126,7 @@ import PromiseKit
 }
 
 @objc(OWSCallViewController)
-class CallViewController: UIViewController {
+class CallViewController: UIViewController, CallDelegate {
 
     enum CallDirection {
         case unspecified, outgoing, incoming
@@ -201,8 +201,8 @@ class CallViewController: UIViewController {
             // No-op, since call service is already set up at this point, the result of which was presenting this viewController.
         }
 
-        call.stateDidChange = callStateDidChange
-        callStateDidChange(call.state)
+        call.delegate = self
+        stateDidChange(call: call, state: call.state)
     }
 
     // objc accessible way to set our swift enum.
@@ -266,13 +266,6 @@ class CallViewController: UIViewController {
 
     // MARK: - Actions
 
-    func callStateDidChange(_ newState: CallState) {
-        DispatchQueue.main.async {
-            self.updateCallUI(callState: newState)
-        }
-        self.audioService.handleState(newState)
-    }
-
     /**
      * Ends a connected call. Do not confuse with `didPressDeclineCall`.
      */
@@ -290,8 +283,10 @@ class CallViewController: UIViewController {
     @IBAction func didPressMute(sender muteButton: UIButton) {
         Logger.info("\(TAG) called \(#function)")
         muteButton.isSelected = !muteButton.isSelected
-        CallService.signalingQueue.async {
-            self.callService.handleToggledMute(isMuted: muteButton.isSelected)
+        if let call = self.call {
+            callUIAdapter.toggleMute(call: call, isMuted: muteButton.isSelected)
+        } else {
+            Logger.warn("\(TAG) hung up, but call was unexpectedly nil")
         }
     }
 
@@ -331,5 +326,21 @@ class CallViewController: UIViewController {
         }
 
         self.dismiss(animated: true)
+    }
+
+    // MARK: - Call Delegate
+
+    internal func stateDidChange(call: SignalCall, state: CallState) {
+        DispatchQueue.main.async {
+            self.updateCallUI(callState: state)
+        }
+        self.audioService.handleState(state)
+    }
+
+    internal func muteDidChange(call: SignalCall, isMuted: Bool) {
+        Logger.debug("\(TAG) in \(#function)")
+        DispatchQueue.main.async {
+            self.muteButton.isSelected = call.isMuted
+        }
     }
 }

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -135,7 +135,7 @@ class CallViewController: UIViewController, CallDelegate {
     let TAG = "[CallViewController]"
 
     // Dependencies
-    let callService: CallService
+    
     let callUIAdapter: CallUIAdapter
     let contactsManager: OWSContactsManager
     let audioService: CallAudioService
@@ -165,7 +165,7 @@ class CallViewController: UIViewController, CallDelegate {
 
     required init?(coder aDecoder: NSCoder) {
         contactsManager = Environment.getCurrent().contactsManager
-        callService = Environment.getCurrent().callService
+        let callService = Environment.getCurrent().callService!
         callUIAdapter = callService.callUIAdapter
         audioService = CallAudioService()
         super.init(coder: aDecoder)
@@ -173,7 +173,7 @@ class CallViewController: UIViewController, CallDelegate {
 
     required init() {
         contactsManager = Environment.getCurrent().contactsManager
-        callService = Environment.getCurrent().callService
+        let callService = Environment.getCurrent().callService!
         callUIAdapter = callService.callUIAdapter
         audioService = CallAudioService()
         super.init(nibName: nil, bundle: nil)
@@ -286,7 +286,7 @@ class CallViewController: UIViewController, CallDelegate {
         if let call = self.call {
             callUIAdapter.toggleMute(call: call, isMuted: muteButton.isSelected)
         } else {
-            Logger.warn("\(TAG) hung up, but call was unexpectedly nil")
+            Logger.warn("\(TAG) pressed mute, but call was unexpectedly nil")
         }
     }
 
@@ -308,9 +308,7 @@ class CallViewController: UIViewController, CallDelegate {
             return
         }
 
-        CallService.signalingQueue.async {
-            self.callService.handleAnswerCall(call)
-        }
+        callUIAdapter.answerCall(call)
     }
 
     /**
@@ -338,7 +336,6 @@ class CallViewController: UIViewController, CallDelegate {
     }
 
     internal func muteDidChange(call: SignalCall, isMuted: Bool) {
-        Logger.debug("\(TAG) in \(#function)")
         DispatchQueue.main.async {
             self.muteButton.isSelected = call.isMuted
         }


### PR DESCRIPTION
**note:** this isn't targeting master.

Fixes a problem where the system call screen (CallKit) mute button could get out of sync with the in-app call screen's mute button.

This includes a refactor which, I think, better separates concerns and consequently reduces dependencies in the CallViewController.

PTAL @charlesmchen 