### PR TITLE
TouchID support (FREEBIE)

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		76EB064818170B33006006FC /* Zid.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB04FD18170B33006006FC /* Zid.m */; };
 		76EB065618170B34006006FC /* InCallViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB050C18170B33006006FC /* InCallViewController.m */; };
 		76EB068618170B34006006FC /* ContactTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB052F18170B33006006FC /* ContactTableViewCell.m */; };
+		86CE280F1E2D5E8400813C64 /* TouchIDManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 86CE280E1E2D5E8400813C64 /* TouchIDManager.m */; };
 		954AEE6A1DF33E01002E5410 /* ContactsPickerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954AEE681DF33D32002E5410 /* ContactsPickerTest.swift */; };
 		A10FDF79184FB4BB007FF963 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76C87F18181EFCE600C4ACAB /* MediaPlayer.framework */; };
 		A11CD70D17FA230600A2D1B1 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A11CD70C17FA230600A2D1B1 /* QuartzCore.framework */; };
@@ -849,6 +850,8 @@
 		76EB052E18170B33006006FC /* ContactTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContactTableViewCell.h; sourceTree = "<group>"; };
 		76EB052F18170B33006006FC /* ContactTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContactTableViewCell.m; sourceTree = "<group>"; };
 		80CD5E19DD23200E7926EEA7 /* libPods-Signal.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Signal.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		86CE280D1E2D5E8400813C64 /* TouchIDManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TouchIDManager.h; sourceTree = "<group>"; };
+		86CE280E1E2D5E8400813C64 /* TouchIDManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TouchIDManager.m; sourceTree = "<group>"; };
 		954AEE681DF33D32002E5410 /* ContactsPickerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactsPickerTest.swift; sourceTree = "<group>"; };
 		A11CD70C17FA230600A2D1B1 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		A163E8AA16F3F6A90094D68B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -1783,6 +1786,8 @@
 				76EB04F818170B33006006FC /* ThreadManager.m */,
 				76EB04F918170B33006006FC /* TimeUtil.h */,
 				76EB04FA18170B33006006FC /* TimeUtil.m */,
+				86CE280D1E2D5E8400813C64 /* TouchIDManager.h */,
+				86CE280E1E2D5E8400813C64 /* TouchIDManager.m */,
 				B97940251832BD2400BD66CB /* UIUtil.h */,
 				B97940261832BD2400BD66CB /* UIUtil.m */,
 				76EB04FB18170B33006006FC /* Util.h */,
@@ -2870,6 +2875,7 @@
 				4516E3FF1DD2193B00DC4206 /* OWS101ExistingUsersBlockOnIdentityChange.m in Sources */,
 				76EB05A818170B33006006FC /* RtpSocket.m in Sources */,
 				E197B61818BBEC1A00F073E5 /* RemoteIOAudio.m in Sources */,
+				86CE280F1E2D5E8400813C64 /* TouchIDManager.m in Sources */,
 				B67ADDC41989FF8700E1A773 /* RPServerRequestsManager.m in Sources */,
 				EF764C351DB67CC5000D9A87 /* UIViewController+CameraPermissions.m in Sources */,
 				76EB059418170B33006006FC /* HttpManager.m in Sources */,

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -13,6 +13,7 @@
 #import "Release.h"
 #import "Signal-Swift.h"
 #import "TSMessagesManager.h"
+#import "TouchIDManager.h"
 #import "TSPreKeyManager.h"
 #import "TSSocketManager.h"
 #import "TextSecureKitEnv.h"
@@ -230,21 +231,33 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     if (getenv("runningTests_dontStartApp")) {
         return;
     }
-
-    [[TSAccountManager sharedInstance] ifRegistered:YES
-                                           runAsync:^{
-                                               // We're double checking that the app is active, to be sure since we
-                                               // can't verify in production env due to code
-                                               // signing.
-                                               [TSSocketManager becomeActiveFromForeground];
-                                               [[Environment getCurrent].contactsManager verifyABPermission];
-                                               
-                                               // This will fetch new messages, if we're using domain
-                                               // fronting.
-                                               [[PushManager sharedManager] applicationDidBecomeActive];
-                                           }];
     
-    [self removeScreenProtection];
+    if (Environment.preferences.touchIDIsEnabled && !TouchIDManager.shared.isTouchIDUnlocked) {
+		// If the user has canceled the TouchID prompt, we want to display the 
+		// screen protection until they exit/re-enter the app, or else
+		// their home button will be hijacked and they'll be unable to switch apps.
+		if (!TouchIDManager.shared.userDidCancel) {
+			[self presentTouchID];
+		} else {
+			[self protectScreen];
+		}
+    } else {
+        // This path will be hit after TouchID authentication, as the TouchID prompt
+        // triggers a `resignActive`/`becomeActive`.
+        [[TSAccountManager sharedInstance] ifRegistered:YES
+                                               runAsync:^{
+                                                   // We're double checking that the app is active, to be sure since we
+                                                   // can't verify in production env due to code
+                                                   // signing.
+                                                   [TSSocketManager becomeActiveFromForeground];
+                                                   [[Environment getCurrent].contactsManager verifyABPermission];
+                                                   
+                                                   // This will fetch new messages, if we're using domain
+                                                   // fronting.
+                                                   [[PushManager sharedManager] applicationDidBecomeActive];
+                                               }];
+        [self removeScreenProtection];
+    }
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {
@@ -293,6 +306,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     }
 }
 
+#pragma mark - Screen Protection
+
 /**
  * Screen protection obscures the app screen shown in the app switcher.
  */
@@ -314,6 +329,32 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     if (Environment.preferences.screenSecurityIsEnabled) {
         self.screenProtectionWindow.hidden = NO;
     }
+}
+
+- (void)presentTouchID {
+    [self protectScreen];
+    [TouchIDManager.shared authenticateViaTouchIDCompletion:^(TouchIDAuthResult result) {
+        switch (result) {
+            case TouchIDAuthResultSuccess:
+                [self removeScreenProtection];
+                break;
+                
+            case TouchIDAuthResultUnavailable:
+                // We shouldn't be able to reach this state, as a user won't be able to 
+                // enable TouchID in the first place if it was never available.
+                break;
+                
+            case TouchIDAuthResultFailed:
+                // TouchID failed; don't unlock.
+                break;
+                
+            case TouchIDAuthResultUserCanceled:
+                // User canceled; we don't want to unlock the phone, but we want to avoid an endless cycle of 
+                // TouchID prompts, which hijacks the homebutton and prevents the user from switching apps,
+                // so just show the security screen until the user backgrounds and foregrounds the app.
+                break;
+        }
+    }];
 }
 
 - (void)removeScreenProtection {

--- a/Signal/src/environment/PropertyListPreferences.h
+++ b/Signal/src/environment/PropertyListPreferences.h
@@ -38,6 +38,9 @@ typedef NS_ENUM(NSUInteger, TSImageQuality) {
 - (BOOL)screenSecurityIsEnabled;
 - (void)setScreenSecurity:(BOOL)flag;
 
+- (BOOL)touchIDIsEnabled;
+- (void)setTouchIDEnabled:(BOOL)enabled;
+
 - (NotificationType)notificationPreviewType;
 - (void)setNotificationPreviewType:(NotificationType)type;
 - (NSString *)nameForNotificationPreviewType:(NotificationType)notificationType;

--- a/Signal/src/environment/PropertyListPreferences.m
+++ b/Signal/src/environment/PropertyListPreferences.m
@@ -10,6 +10,7 @@ NSString *const PropertyListPreferencesSignalDatabaseCollection = @"SignalPrefer
 
 NSString *const PropertyListPreferencesKeyCallStreamDESBufferLevel = @"CallStreamDesiredBufferLevel";
 NSString *const PropertyListPreferencesKeyScreenSecurity = @"Screen Security Key";
+NSString *const PropertyListPreferencesKeyTouchID = @"TouchID Key";
 NSString *const PropertyListPreferencesKeyEnableDebugLog = @"Debugging Log Enabled Key";
 NSString *const PropertyListPreferencesKeyNotificationPreviewType = @"Notification Preview Type Key";
 NSString *const PropertyListPreferencesKeyHasSentAMessage = @"User has sent a message";
@@ -84,6 +85,15 @@ NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecorded
     return preference ? [preference boolValue] : YES;
 }
 
+- (BOOL)touchIDIsEnabled 
+{
+    NSNumber *preference = [self tryGetValueForKey:PropertyListPreferencesKeyTouchID];
+    if ([preference isKindOfClass: NSNumber.class]) {
+        return preference.boolValue;
+    }
+    return NO;
+}
+
 - (BOOL)getHasSentAMessage
 {
     NSNumber *preference = [self tryGetValueForKey:PropertyListPreferencesKeyHasSentAMessage];
@@ -123,6 +133,11 @@ NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecorded
 - (void)setScreenSecurity:(BOOL)flag
 {
     [self setValueForKey:PropertyListPreferencesKeyScreenSecurity toValue:@(flag)];
+}
+
+- (void)setTouchIDEnabled:(BOOL)enabled 
+{
+    [self setValueForKey:PropertyListPreferencesKeyTouchID toValue:@(enabled)];
 }
 
 - (void)setHasRegisteredVOIPPush:(BOOL)enabled

--- a/Signal/src/util/TouchIDManager.h
+++ b/Signal/src/util/TouchIDManager.h
@@ -1,0 +1,34 @@
+//
+//  TouchIDManager.h
+//  Signal
+//
+//  Created by Frederic Barthelemy on 3/4/15.
+//  Copyright (c) 2015 Open Whisper Systems. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, TouchIDAuthResult) {
+    TouchIDAuthResultUserCanceled = -2,
+    TouchIDAuthResultUnavailable = -1,
+    TouchIDAuthResultFailed = 0,
+    TouchIDAuthResultSuccess = 1
+};
+
+/**
+ * Utility methods for detecting TouchID & using it
+ */
+@interface TouchIDManager : NSObject
+/// Singleton access.
++ (instancetype)shared;
+/// Returns true if the app has been backgrounded for under `TouchIDLockTimeoutDefault` seconds.
+@property (nonatomic, assign) BOOL isTouchIDUnlocked;
+/// Returns `YES` if user recently manually canceled the prompt. Useful for preventing an infinite UI loop of TouchID prompts.
+/// Set back to `NO` after backgrounding the app
+@property (nonatomic, assign) BOOL userDidCancel;
+/// Returns true if the TouchID hardware is present on the device.
+- (BOOL)isTouchIDAvailable;
+/// Asks user to authenticate with TouchID.
+- (void)authenticateViaTouchIDCompletion:(void(^)(TouchIDAuthResult result))completion;
+
+@end

--- a/Signal/src/util/TouchIDManager.m
+++ b/Signal/src/util/TouchIDManager.m
@@ -1,0 +1,84 @@
+//
+//  TouchIDManager.m
+//  Signal
+//
+//  Created by Frederic Barthelemy on 3/4/15.
+//  Copyright (c) 2015 Open Whisper Systems. All rights reserved.
+//
+
+#import <LocalAuthentication/LocalAuthentication.h>
+#import "TouchIDManager.h"
+
+/// The number of seconds the app must be backgrounded before we lock the screen.
+NSTimeInterval const TouchIDLockTimeoutDefault = 60;
+
+@interface TouchIDManager()
+/// The time (since epoch) the phone was backgrounded during an unlocked state. Will be 0 if never unlocked.
+@property (nonatomic, assign) NSTimeInterval timeBackgroundedAfterUnlock;
+@end
+
+@implementation TouchIDManager
+
++ (instancetype)shared {
+    static TouchIDManager *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[TouchIDManager alloc] init];
+        [[NSNotificationCenter defaultCenter] addObserver:sharedInstance selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    });
+    return sharedInstance;
+}
+
+- (void)applicationDidEnterBackground:(NSNotification *)note {
+    // We want to reset `timeBackgroundedAfterUnlock` when the user backgrounds the app.
+    // Note that this notification does not get called during the TouchID presentation, unlike
+    // the AppDelegate's `applicationWillResignActive`.
+    if (!self.userDidCancel) {
+        // Only want to reset timeout if the app is backgrounded and the user _hasn't_ recently canceled the TouchID prompt.
+        self.timeBackgroundedAfterUnlock = [NSDate date].timeIntervalSince1970;
+    }
+    self.userDidCancel = NO;
+}
+
+- (BOOL)isTouchIDAvailable {
+    LAContext *myContext = [[LAContext alloc] init];
+    NSError *authError = nil;
+    return [myContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError] && !authError;
+}
+
+- (void)authenticateViaTouchIDCompletion:(void (^)(TouchIDAuthResult))completion {
+    LAContext *myContext = [[LAContext alloc] init];
+    // Disable the "Enter Password" button because we don't currently have a password fallback
+    // See http://stackoverflow.com/a/29498981
+    myContext.localizedFallbackTitle = @""; 
+    if (!self.isTouchIDAvailable) {
+        completion(TouchIDAuthResultUnavailable);
+    } else {
+        [myContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+                  localizedReason:NSLocalizedString(@"TOUCHID_SECURITY_PROMPT",@"")
+                            reply:^(BOOL success, NSError *error) {
+                                dispatch_async(dispatch_get_main_queue(), ^{
+                                    if (error || !success){
+                                        DDLogError(@"Error Accessing TouchID: %@",error);
+                                        if (error.code == -2) {
+                                            // User canceled
+                                            self.userDidCancel = YES;
+                                            completion(TouchIDAuthResultUserCanceled);
+                                        } else {
+                                            completion(TouchIDAuthResultFailed);
+                                        }
+                                    } else {
+                                        self.timeBackgroundedAfterUnlock = [NSDate date].timeIntervalSince1970;
+                                        completion(TouchIDAuthResultSuccess);
+                                    }
+                                });
+                            }];
+    }
+}
+
+- (BOOL)isTouchIDUnlocked {
+    NSTimeInterval currentTime = [NSDate date].timeIntervalSince1970;
+    return currentTime - self.timeBackgroundedAfterUnlock <= TouchIDLockTimeoutDefault;
+}
+
+@end

--- a/Signal/src/view controllers/PrivacySettingsTableViewController.m
+++ b/Signal/src/view controllers/PrivacySettingsTableViewController.m
@@ -10,19 +10,28 @@
 
 #import "Environment.h"
 #import "PropertyListPreferences.h"
+#import "TouchIDManager.h"
 #import "UIUtil.h"
 #import <25519/Curve25519.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
-    PrivacySettingsTableViewControllerSectionIndexScreenSecurity,
+    PrivacySettingsTableViewControllerSectionIndexSecurity,
     PrivacySettingsTableViewControllerSectionIndexHistoryLog,
     PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange
 };
 
+/// A row in `PrivacySettingsTableViewControllerSectionIndexSecurity`.
+typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSecurityRowIndex) {
+    PrivacySettingsTableViewControllerSecurityRowIndexTouchID,
+    PrivacySettingsTableViewControllerSecurityRowIndexScreen
+};
+
 @interface PrivacySettingsTableViewController ()
 
+@property (nonatomic, strong) UITableViewCell *enableTouchIDSecurityCell;
+@property (nonatomic, strong) UISwitch *enableTouchIDSecuritySwitch;
 @property (nonatomic, strong) UITableViewCell *enableScreenSecurityCell;
 @property (nonatomic, strong) UISwitch *enableScreenSecuritySwitch;
 @property (nonatomic, strong) UITableViewCell *blockOnIdentityChangeCell;
@@ -48,7 +57,17 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     [super loadView];
 
     self.title = NSLocalizedString(@"SETTINGS_PRIVACY_TITLE", @"");
-
+    
+    // TouchID Cell
+    self.enableTouchIDSecurityCell = [[UITableViewCell alloc] init];
+    self.enableTouchIDSecurityCell.textLabel.text = NSLocalizedString(@"SETTINGS_TOUCHID_SECURITY", @"");
+    
+    self.enableTouchIDSecuritySwitch = [[UISwitch alloc] initWithFrame:CGRectZero];
+    self.enableTouchIDSecuritySwitch.enabled = NO; // Disable until we verify
+    [self.enableTouchIDSecuritySwitch addTarget:self
+                                         action:@selector(didToggleTouchIDSwitch:)
+                               forControlEvents:UIControlEventTouchUpInside];
+    
     // Enable Screen Security Cell
     self.enableScreenSecurityCell                = [[UITableViewCell alloc] init];
     self.enableScreenSecurityCell.textLabel.text = NSLocalizedString(@"SETTINGS_SCREEN_SECURITY", @"");
@@ -75,6 +94,32 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     [self.blockOnIdentityChangeSwitch addTarget:self
                                          action:@selector(didToggleBlockOnIdentityChangeSwitch:)
                                forControlEvents:UIControlEventTouchUpInside];
+        
+    self.enableTouchIDSecurityCell.accessoryView = self.enableTouchIDSecuritySwitch;
+    self.enableTouchIDSecurityCell.userInteractionEnabled = YES;
+    
+    //Clear History Log Cell
+    self.clearHistoryLogCell = [[UITableViewCell alloc]init];
+    self.clearHistoryLogCell.textLabel.text = NSLocalizedString(@"SETTINGS_CLEAR_HISTORY", @"");
+    self.clearHistoryLogCell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    
+    [self detectTouchID];
+    [self validateSecuritySwitches];
+}
+
+/// Enables or disables the TouchID switch based on hardware availability.
+- (void)detectTouchID {
+    if (TouchIDManager.shared.isTouchIDAvailable) {
+        self.enableTouchIDSecuritySwitch.enabled = YES;
+    } else {
+        // Cannot use touchID at this time / on this device
+        self.enableTouchIDSecuritySwitch.enabled = NO;
+    }
+    
+#if DEBUG
+    // Always Show TouchID controls for debugging!
+    self.enableTouchIDSecuritySwitch.enabled = YES;
+#endif
 }
 
 #pragma mark - Table view data source
@@ -84,22 +129,20 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    switch (section) {
-        case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
-            return 1;
+    switch ((PrivacySettingsTableViewControllerSectionIndex)section) {
+        case PrivacySettingsTableViewControllerSectionIndexSecurity:
+            return 2; // TouchID and Screen Security
         case PrivacySettingsTableViewControllerSectionIndexHistoryLog:
             return 1;
         case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
             return 1;
-        default:
-            return 0;
     }
 }
 
 - (nullable NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    switch (section) {
-        case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
+    switch ((PrivacySettingsTableViewControllerSectionIndex)section) {
+        case PrivacySettingsTableViewControllerSectionIndexSecurity:
             return NSLocalizedString(@"SETTINGS_SCREEN_SECURITY_DETAIL", nil);
         case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
             return NSLocalizedString(
@@ -111,8 +154,13 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     switch (indexPath.section) {
-        case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
-            return self.enableScreenSecurityCell;
+        case PrivacySettingsTableViewControllerSectionIndexSecurity:
+            switch ((PrivacySettingsTableViewControllerSecurityRowIndex)indexPath.row) {
+                case PrivacySettingsTableViewControllerSecurityRowIndexTouchID:
+                    return self.enableTouchIDSecurityCell;
+                case PrivacySettingsTableViewControllerSecurityRowIndexScreen:
+                    return self.enableScreenSecurityCell;
+            }
         case PrivacySettingsTableViewControllerSectionIndexHistoryLog:
             return self.clearHistoryLogCell;
         case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
@@ -127,7 +175,7 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
 - (nullable NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     switch (section) {
-        case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
+        case PrivacySettingsTableViewControllerSectionIndexSecurity:
             return NSLocalizedString(@"SETTINGS_SECURITY_TITLE", @"Section header");
         case PrivacySettingsTableViewControllerSectionIndexHistoryLog:
             return NSLocalizedString(@"SETTINGS_HISTORYLOG_TITLE", @"Section header");
@@ -138,10 +186,21 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     }
 }
 
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+-(BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+    switch ((PrivacySettingsTableViewControllerSectionIndex)indexPath.section) {
+        case PrivacySettingsTableViewControllerSectionIndexHistoryLog:
+            return YES;
+        case PrivacySettingsTableViewControllerSectionIndexSecurity:
+        case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
+            return NO;
+    }
+}
+
+-(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
-    switch (indexPath.section) {
+    switch ((PrivacySettingsTableViewControllerSectionIndex)indexPath.section) {
         case PrivacySettingsTableViewControllerSectionIndexHistoryLog: {
             UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
                                                                                      message:NSLocalizedString(@"SETTINGS_DELETE_HISTORYLOG_CONFIRMATION", @"Alert message before user confirms clearing history")
@@ -162,7 +221,9 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
             [self presentViewController:alertController animated:true completion:nil];
             break;
         }
-        default:
+        case PrivacySettingsTableViewControllerSectionIndexSecurity:
+        case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
+            // These cells aren't tappable
             break;
     }
 }
@@ -174,6 +235,42 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     BOOL enabled = self.enableScreenSecuritySwitch.isOn;
     DDLogInfo(@"%@ toggled screen security: %@", self.tag, enabled ? @"ON" : @"OFF");
     [Environment.preferences setScreenSecurity:enabled];
+    [self validateSecuritySwitches];
+}
+
+- (void)didToggleTouchIDSwitch:(UISwitch *)sender
+{
+    // Make the user verify with TouchID when enabling/disabling.
+    BOOL enabled = self.enableTouchIDSecuritySwitch.isOn;
+    DDLogInfo(@"%@ toggled touchID: %@", self.tag, enabled ? @"ON" : @"OFF");
+    __weak typeof(self) weakSelf = self;
+    [TouchIDManager.shared authenticateViaTouchIDCompletion:^(TouchIDAuthResult result) {
+        switch (result) {
+            case TouchIDAuthResultUnavailable:
+            case TouchIDAuthResultUserCanceled:
+            case TouchIDAuthResultFailed:
+                // restore switch state
+                weakSelf.enableTouchIDSecuritySwitch.on = !enabled;
+                break;
+            case TouchIDAuthResultSuccess:
+                [Environment.preferences setTouchIDEnabled:enabled];
+                if (enabled) {
+                    // If TouchID is on, Screen Security must also be on.
+                    [Environment.preferences setScreenSecurity:YES];
+                }
+                break;
+        }
+        [weakSelf validateSecuritySwitches];
+    }];
+}
+
+/// Ensures that security switches reflect the user's preferences.
+- (void)validateSecuritySwitches
+{
+    self.enableTouchIDSecuritySwitch.on = Environment.preferences.touchIDIsEnabled;
+    // TouchID requires ScreenSecurity to be enabled.
+    self.enableScreenSecuritySwitch.enabled = !Environment.preferences.touchIDIsEnabled;
+    self.enableScreenSecuritySwitch.on = Environment.preferences.screenSecurityIsEnabled;
 }
 
 - (void)didToggleBlockOnIdentityChangeSwitch:(UISwitch *)sender

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -769,6 +769,12 @@
 /* Section header */
 "SETTINGS_PRIVACY_VERIFICATION_TITLE" = "Safety Numbers Approval";
 
+/* The text on the Touch ID prompt */
+"TOUCHID_SECURITY_PROMPT" = "Unlock with Touch ID";
+
+/* The TouchID row text, in the settings screen. */
+"SETTINGS_TOUCHID_SECURITY" = "Touch ID";
+
 /* No comment provided by engineer. */
 "SETTINGS_SCREEN_SECURITY" = "Enable Screen Security";
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE, iOS 10.2.0 (sorry, this is the only device I have handy! It'd be nice to test it on an iOS 8 device, and a device without TouchID support.)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR adds Touch ID support to the app. It builds off @fbartho's work from https://github.com/WhisperSystems/Signal-iOS/pull/663, with updated style conventions and rebased off `master`. Here's a [video](https://www.dropbox.com/s/us2qoarije7cfvq/TouchID.mov?dl=0) of it in action.

Summary:
- Adds a TouchID security toggle to the Privacy settings (off by default).
- Enabling it will require a TouchID authentication on first launch, and after 60 seconds in the background. (Note that there isn't UI informing the user of the 60 second cut-off; we may wish to add a label somewhere, or change the timeout to something shorter, like 1 second.)
- Requires TouchID authentication when enabling/disabling the feature.
- Enabling TouchID will automatically enable Screen Security.
- Disables the TouchID switch if there is no hardware availability (untested).
- Adds a setter and getter in `PropertyListPreferences` (I'm assuming this class is appropriately secure for this setting, as it's also responsible for the Screen Security feature, but if it's not, we'll want to use the keychain for storage).
- Adds two localized strings (English only) for the prompt and the settings toggle.
- Canceling TouchID will immediately re-present the prompt, as we don't currently have a password option to fallback on.

Tested:
- User launches app for first time; is not prompted for TouchID.
- User enables/disables TouchID in settings; is prompted for TouchID both times.
- User cancels TouchID after enabling/disabling; TouchID setting is unchanged.
- User launches app with TouchID enabled; is prompted for TouchID.
- User authenticates with TouchID, backgrounds app, then foregrounds app within 60 seconds of backgrounding; is _not_ prompted for TouchID.
-  User authenticates with TouchID, backgrounds app, then foregrounds app _after_ 60 seconds of backgrounding; _is_ prompted for TouchID.
