### PR TITLE
fix notification actions

### DIFF
--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -364,26 +364,6 @@ fileprivate let timeoutSeconds = 60
     }
 
     /**
-     * Initiate a call to recipient by recipientId
-     */
-    public func handleCallBack(recipientId: String) {
-        // TODO #function is called from objc, how to access swift defiend dispatch queue (OS_dispatch_queue)
-        //assertOnSignalingQueue()
-
-        guard self.call == nil else {
-            Logger.error("\(TAG) unexpectedly found an existing call when trying to call back: \(recipientId)")
-            return
-        }
-
-        // Because we may not be on signalingQueue (because this method is called from Objc which doesn't have
-        // access to signalingQueue (that I can find). FIXME?
-        type(of: self).signalingQueue.async {
-            let call = self.callUIAdapter.startOutgoingCall(handle: recipientId)
-            self.callUIAdapter.showCall(call)
-        }
-    }
-
-    /**
      * Remote client (could be caller or callee) sent us a connectivity update
      */
     public func handleRemoteAddedIceCandidate(thread: TSContactThread, callId: UInt64, sdp: String, lineIndex: Int32, mid: String) {

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -22,7 +22,9 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         self.notificationsAdapter = notificationsAdapter
     }
 
-    func startOutgoingCall(_ call: SignalCall) {
+    func startOutgoingCall(handle: String) -> SignalCall {
+        let call = SignalCall.outgoingCall(localId: UUID(), remotePhoneNumber: handle)
+
         CallService.signalingQueue.async {
             _ = self.callService.handleOutgoingCall(call).then {
                 Logger.debug("\(self.TAG) handleOutgoingCall succeeded")
@@ -30,6 +32,8 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
                 Logger.error("\(self.TAG) handleOutgoingCall failed with error: \(error)")
             }
         }
+
+        return call
     }
 
     func reportIncomingCall(_ call: SignalCall, callerName: String) {
@@ -51,10 +55,32 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         notificationsAdapter.presentMissedCall(call, callerName: callerName)
     }
 
+    func answerCall(localId: UUID) {
+        CallService.signalingQueue.async {
+            guard let call = self.callService.call else {
+                assertionFailure("\(self.TAG) in \(#function) No current call.")
+                return
+            }
+
+            self.answerCall(call)
+        }
+    }
+
     func answerCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
             PeerConnectionClient.startAudioSession()
             self.callService.handleAnswerCall(call)
+        }
+    }
+
+    func declineCall(localId: UUID) {
+        CallService.signalingQueue.async {
+            guard let call = self.callService.call else {
+                assertionFailure("\(self.TAG) in \(#function) No current call.")
+                return
+            }
+
+            self.declineCall(call)
         }
     }
 

--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -19,7 +19,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     let TAG = "[CallKitCallUIAdaptee]"
 
     private let callManager: CallKitCallManager
-    private let callService: CallService
+    internal let callService: CallService
     internal let notificationsAdapter: CallNotificationsAdapter
     private let provider: CXProvider
 
@@ -61,11 +61,15 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
     // MARK: CallUIAdaptee
 
-    func startOutgoingCall(_ call: SignalCall) {
+    func startOutgoingCall(handle: String) -> SignalCall {
+        let call = SignalCall.outgoingCall(localId: UUID(), remotePhoneNumber: handle)
+
         // Add the new outgoing call to the app's list of calls.
         // So we can find it in the provider delegate callbacks.
         callManager.addCall(call)
         callManager.startCall(call)
+
+        return call
     }
 
     func reportIncomingCall(_ call: SignalCall, callerName: String) {
@@ -93,8 +97,16 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
         }
     }
 
+    func answerCall(localId: UUID) {
+        assertionFailure("CallKit should answer calls via system call screen, not via notifications.")
+    }
+
     func answerCall(_ call: SignalCall) {
         callManager.answer(call: call)
+    }
+
+    func declineCall(localId: UUID) {
+        assertionFailure("CallKit should decline calls via system call screen, not via notifications.")
     }
 
     func declineCall(_ call: SignalCall) {

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -36,7 +36,7 @@
 @property (nonatomic, readonly) OWSContactsManager *contactsManager;
 @property (nonatomic, readonly) OWSMessageSender *messageSender;
 @property (nonatomic, readonly) OWSMessageFetcherJob *messageFetcherJob;
-@property (nonatomic, readonly, strong) CallService *callService;
+@property (nonatomic, readonly) CallUIAdapter *callUIAdapter;
 
 @end
 
@@ -76,7 +76,7 @@
     }
 
     _contactsManager = contactsManager;
-    _callService = callService;
+    _callUIAdapter = callService.callUIAdapter;
 
     // DEPRECATED Redphone uses notification tracker.
     _notificationTracker = notificationTracker;
@@ -298,7 +298,8 @@
             return;
         }
 
-        [self.callService handleAnswerCallWithLocalId:localId];
+
+        [self.callUIAdapter answerCallWithLocalId:localId];
     } else if ([identifier isEqualToString:PushManagerActionsDeclineCall]) {
         DDLogInfo(@"%@ received decline call action", self.tag);
 
@@ -314,7 +315,7 @@
             return;
         }
 
-        [self.callService handleDeclineCallWithLocalId:localId];
+        [self.callUIAdapter declineCallWithLocalId:localId];
     } else if ([identifier isEqualToString:PushManagerActionsCallBack]) {
         DDLogInfo(@"%@ received call back action", self.tag);
 
@@ -324,7 +325,7 @@
             return;
         }
 
-        [self.callService handleCallBackWithRecipientId:recipientId];
+        [self.callUIAdapter callBackWithRecipientId:recipientId];
     } else {
         DDLogDebug(@"%@ Unhandled action with identifier: %@", self.tag, identifier);
 


### PR DESCRIPTION
### Fix "Answer" from iOS9 notification doesn't init audio

The removed code was from an older eon. CallService shouldn't be touched
except via the CallUIAdapter since only there is the omnipresent
distinction between CallKit vs. NonCallKit made.

i.e. when the RTCAudioSession get's started depends on the
CallUIAdaptee.

// FREEBIE