### PR TITLE
[SSK] remove Cuba from domain fronting

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -139,7 +139,7 @@ CHECKOUT OPTIONS:
     :commit: 714f5ebe199ecc999b33c6f97a4bb57e2db90e75
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: 45391cadd32df2fd8e3ee6b63d294d11bff45077
+    :commit: 8f81015730111d235ce90edc2f920170134a9e62
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 41b57bb2fc292a814f758441a05243eb38457027

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.12</string>
+	<string>2.6.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.6.12.0</string>
+	<string>2.6.13.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>


### PR DESCRIPTION
Current implementation is blocked in Cuba, plus there are reports of
Signal working w/o domain fronting anyway.

PTAL @charlesmchen 

// FREEBIE
