### PR TITLE
prevent session corruption

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,8 +3,9 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Signal' do
     pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git'
-    pod 'AxolotlKit', git: 'https://github.com/WhisperSystems/SignalProtocolKit.git'
-    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'master'
+    pod 'AxolotlKit',                 git: 'https://github.com/WhisperSystems/SignalProtocolKit.git', branch: 'mkirk/session-corruption'
+    #pod 'AxolotlKit',                 path: '../SignalProtocolKit'
+    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'mkirk/session-corruption'
     #pod 'SignalServiceKit',           path: '../SignalServiceKit'
     pod 'OpenSSL'
     pod 'PastelogKit',                '~> 1.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -115,31 +115,32 @@ PODS:
   - ZXingObjC/All (3.1.0)
 
 DEPENDENCIES:
-  - AxolotlKit (from `https://github.com/WhisperSystems/SignalProtocolKit.git`)
+  - AxolotlKit (from `https://github.com/WhisperSystems/SignalProtocolKit.git`, branch `mkirk/session-corruption`)
   - FFCircularProgressView (~> 0.5)
   - JSQMessagesViewController
   - OpenSSL
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
-  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `master`)
+  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `mkirk/session-corruption`)
   - SocketRocket (from `https://github.com/facebook/SocketRocket.git`)
   - ZXingObjC
 
 EXTERNAL SOURCES:
   AxolotlKit:
+    :branch: mkirk/session-corruption
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :branch: master
+    :branch: mkirk/session-corruption
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :git: https://github.com/facebook/SocketRocket.git
 
 CHECKOUT OPTIONS:
   AxolotlKit:
-    :commit: 714f5ebe199ecc999b33c6f97a4bb57e2db90e75
+    :commit: 55630ef62403de7eee31ac42b8827e390b6194f3
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: 8f81015730111d235ce90edc2f920170134a9e62
+    :commit: c4f1df22c80e6063c2ceb2272f0b277b42592502
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 41b57bb2fc292a814f758441a05243eb38457027
@@ -170,6 +171,6 @@ SPEC CHECKSUMS:
   YapDatabase: b1e43555a34a5298e23a045be96817a5ef0da58f
   ZXingObjC: bf15b3814f7a105b6d99f47da2333c93a063650a
 
-PODFILE CHECKSUM: cb24c78080551874a45d1a20de4a1bef7427b41f
+PODFILE CHECKSUM: 5f6175b05282b4a2e1e78fbeb88a00ab78cafebd
 
 COCOAPODS: 1.0.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -139,7 +139,7 @@ CHECKOUT OPTIONS:
     :commit: 714f5ebe199ecc999b33c6f97a4bb57e2db90e75
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: 45391cadd32df2fd8e3ee6b63d294d11bff45077
+    :commit: 8f81015730111d235ce90edc2f920170134a9e62
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 41b57bb2fc292a814f758441a05243eb38457027

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.12</string>
+	<string>2.6.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.6.12.0</string>
+	<string>2.6.13.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -21,9 +21,11 @@
 #import "TSSocketManager.h"
 #import "TextSecureKitEnv.h"
 #import "VersionMigrations.h"
+#import <AxolotlKit/SessionCipher.h>
 #import <PastelogKit/Pastelog.h>
 #import <PromiseKit/AnyPromise.h>
 #import <SignalServiceKit/OWSDisappearingMessagesJob.h>
+#import <SignalServiceKit/OWSDispatch.h>
 #import <SignalServiceKit/OWSIncomingMessageReadObserver.h>
 #import <SignalServiceKit/OWSMessageSender.h>
 #import <SignalServiceKit/TSAccountManager.h>
@@ -165,6 +167,9 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 }
 
 - (void)setupTSKitEnv {
+    // Encryption/Descryption mutates session state and must be synchronized on a serial queue.
+    [SessionCipher setSessionCipherDispatchQueue:[OWSDispatch sessionCipher]];
+
     [TextSecureKitEnv sharedEnv].contactsManager = [Environment getCurrent].contactsManager;
     [[TSStorageManager sharedManager] setupDatabase];
     [TextSecureKitEnv sharedEnv].notificationsManager = [[NotificationsManager alloc] init];


### PR DESCRIPTION
(based on #1626 - ignore the commit re: Cuban censorship)

Coordinate SignalProtocol encryption/decryption on a single serial queue. Previously message sending encrypted on the sending thread, while message receiving decrypted on the main thread.

Though I was not able to reliably reproduce this, this is a likely source of session corruption. E.g. when receiving and sending messages simultaneously we compute and store the state, potentially clobbering the newly generated state from sending with the newly generated state from receiving.

**Corresponding PRs:**

SignalProtocol: https://github.com/WhisperSystems/SignalProtocolKit/pull/14
SignalService: https://github.com/WhisperSystems/SignalServiceKit/pull/98

PTAL @charlesmchen 
