### PR TITLE
Bail on startup if DB password is inaccessible

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'Signal' do
     pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git'
     pod 'AxolotlKit', git: 'https://github.com/WhisperSystems/SignalProtocolKit.git'
-    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'master'
+    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'mkirk/dont-reset-storage-before-first-unlock'
     #pod 'SignalServiceKit',           path: '../SignalServiceKit'
     pod 'OpenSSL'
     pod 'PastelogKit',                '~> 1.3'

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'Signal' do
     pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git'
     pod 'AxolotlKit', git: 'https://github.com/WhisperSystems/SignalProtocolKit.git'
-    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'mkirk/dont-reset-storage-before-first-unlock'
+    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'master'
     #pod 'SignalServiceKit',           path: '../SignalServiceKit'
     pod 'OpenSSL'
     pod 'PastelogKit',                '~> 1.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - OpenSSL
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
-  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `master`)
+  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `mkirk/dont-reset-storage-before-first-unlock`)
   - SocketRocket (from `https://github.com/facebook/SocketRocket.git`)
   - ZXingObjC
 
@@ -129,7 +129,7 @@ EXTERNAL SOURCES:
   AxolotlKit:
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :branch: master
+    :branch: mkirk/dont-reset-storage-before-first-unlock
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :git: https://github.com/facebook/SocketRocket.git
@@ -139,7 +139,7 @@ CHECKOUT OPTIONS:
     :commit: 714f5ebe199ecc999b33c6f97a4bb57e2db90e75
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: 8f81015730111d235ce90edc2f920170134a9e62
+    :commit: 4846aabd13d30bb39bcc3bea395abe40beaced57
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 41b57bb2fc292a814f758441a05243eb38457027
@@ -170,6 +170,6 @@ SPEC CHECKSUMS:
   YapDatabase: b1e43555a34a5298e23a045be96817a5ef0da58f
   ZXingObjC: bf15b3814f7a105b6d99f47da2333c93a063650a
 
-PODFILE CHECKSUM: cb24c78080551874a45d1a20de4a1bef7427b41f
+PODFILE CHECKSUM: 92037a2e2a31e58603ec77779d6e87f5f54b0d2a
 
 COCOAPODS: 1.0.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - OpenSSL
   - PastelogKit (~> 1.3)
   - SCWaveformView (~> 1.0)
-  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `mkirk/dont-reset-storage-before-first-unlock`)
+  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `master`)
   - SocketRocket (from `https://github.com/facebook/SocketRocket.git`)
   - ZXingObjC
 
@@ -129,7 +129,7 @@ EXTERNAL SOURCES:
   AxolotlKit:
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :branch: mkirk/dont-reset-storage-before-first-unlock
+    :branch: master
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :git: https://github.com/facebook/SocketRocket.git
@@ -139,7 +139,7 @@ CHECKOUT OPTIONS:
     :commit: 714f5ebe199ecc999b33c6f97a4bb57e2db90e75
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: 4846aabd13d30bb39bcc3bea395abe40beaced57
+    :commit: a112930277890f78676ae32632e9e1ed44034c45
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 41b57bb2fc292a814f758441a05243eb38457027
@@ -170,6 +170,6 @@ SPEC CHECKSUMS:
   YapDatabase: b1e43555a34a5298e23a045be96817a5ef0da58f
   ZXingObjC: bf15b3814f7a105b6d99f47da2333c93a063650a
 
-PODFILE CHECKSUM: 92037a2e2a31e58603ec77779d6e87f5f54b0d2a
+PODFILE CHECKSUM: cb24c78080551874a45d1a20de4a1bef7427b41f
 
 COCOAPODS: 1.0.1

--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		452ECA4D1E087E7200E2F016 /* MessageFetcherJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452ECA4C1E087E7200E2F016 /* MessageFetcherJob.swift */; };
 		452ECA4E1E087E7200E2F016 /* MessageFetcherJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452ECA4C1E087E7200E2F016 /* MessageFetcherJob.swift */; };
 		4531C9C41DD8E6D800F08304 /* JSQMessagesCollectionViewCell+OWS.m in Sources */ = {isa = PBXBuildFile; fileRef = 4531C9C31DD8E6D800F08304 /* JSQMessagesCollectionViewCell+OWS.m */; };
+		45387B041E36D650005D00B3 /* OWS102MoveLoggingPreferenceToUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 45387B031E36D650005D00B3 /* OWS102MoveLoggingPreferenceToUserDefaults.m */; };
 		453D28B71D32BA5F00D523F0 /* OWSDisplayedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 453D28B61D32BA5F00D523F0 /* OWSDisplayedMessage.m */; };
 		453D28BA1D332DB100D523F0 /* OWSMessagesBubblesSizeCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = 453D28B91D332DB100D523F0 /* OWSMessagesBubblesSizeCalculator.m */; };
 		453D28BB1D332DB100D523F0 /* OWSMessagesBubblesSizeCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = 453D28B91D332DB100D523F0 /* OWSMessagesBubblesSizeCalculator.m */; };
@@ -572,6 +573,8 @@
 		452ECA4C1E087E7200E2F016 /* MessageFetcherJob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessageFetcherJob.swift; path = Jobs/MessageFetcherJob.swift; sourceTree = "<group>"; };
 		4531C9C21DD8E6D800F08304 /* JSQMessagesCollectionViewCell+OWS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JSQMessagesCollectionViewCell+OWS.h"; sourceTree = "<group>"; };
 		4531C9C31DD8E6D800F08304 /* JSQMessagesCollectionViewCell+OWS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "JSQMessagesCollectionViewCell+OWS.m"; sourceTree = "<group>"; };
+		45387B021E36D650005D00B3 /* OWS102MoveLoggingPreferenceToUserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OWS102MoveLoggingPreferenceToUserDefaults.h; path = Migrations/OWS102MoveLoggingPreferenceToUserDefaults.h; sourceTree = "<group>"; };
+		45387B031E36D650005D00B3 /* OWS102MoveLoggingPreferenceToUserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWS102MoveLoggingPreferenceToUserDefaults.m; path = Migrations/OWS102MoveLoggingPreferenceToUserDefaults.m; sourceTree = "<group>"; };
 		453CC0361D08E1A60040EBA3 /* sn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sn; path = translations/sn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		453D28B51D32BA5F00D523F0 /* OWSDisplayedMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OWSDisplayedMessage.h; sourceTree = "<group>"; };
 		453D28B61D32BA5F00D523F0 /* OWSDisplayedMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWSDisplayedMessage.m; sourceTree = "<group>"; };
@@ -1222,14 +1225,16 @@
 		45666F731D9BFDB9008FE134 /* Migrations */ = {
 			isa = PBXGroup;
 			children = (
-				45666F741D9BFE00008FE134 /* OWS100RemoveTSRecipientsMigration.h */,
-				45666F751D9BFE00008FE134 /* OWS100RemoveTSRecipientsMigration.m */,
 				45666F791D9C0533008FE134 /* OWSDatabaseMigration.h */,
 				45666F7A1D9C0533008FE134 /* OWSDatabaseMigration.m */,
 				45666F7C1D9C0814008FE134 /* OWSDatabaseMigrationRunner.h */,
 				45666F7D1D9C0814008FE134 /* OWSDatabaseMigrationRunner.m */,
+				45666F741D9BFE00008FE134 /* OWS100RemoveTSRecipientsMigration.h */,
+				45666F751D9BFE00008FE134 /* OWS100RemoveTSRecipientsMigration.m */,
 				4516E3FD1DD2193B00DC4206 /* OWS101ExistingUsersBlockOnIdentityChange.h */,
 				4516E3FE1DD2193B00DC4206 /* OWS101ExistingUsersBlockOnIdentityChange.m */,
+				45387B021E36D650005D00B3 /* OWS102MoveLoggingPreferenceToUserDefaults.h */,
+				45387B031E36D650005D00B3 /* OWS102MoveLoggingPreferenceToUserDefaults.m */,
 			);
 			name = Migrations;
 			sourceTree = "<group>";
@@ -2869,6 +2874,7 @@
 				4531C9C41DD8E6D800F08304 /* JSQMessagesCollectionViewCell+OWS.m in Sources */,
 				4516E3FF1DD2193B00DC4206 /* OWS101ExistingUsersBlockOnIdentityChange.m in Sources */,
 				76EB05A818170B33006006FC /* RtpSocket.m in Sources */,
+				45387B041E36D650005D00B3 /* OWS102MoveLoggingPreferenceToUserDefaults.m in Sources */,
 				E197B61818BBEC1A00F073E5 /* RemoteIOAudio.m in Sources */,
 				B67ADDC41989FF8700E1A773 /* RPServerRequestsManager.m in Sources */,
 				EF764C351DB67CC5000D9A87 /* UIViewController+CameraPermissions.m in Sources */,

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.6.13.0</string>
+	<string>2.6.13.1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -386,7 +386,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
         return;
     }
 
-    if ([TSStorageManager isDatabasePasswordAccessible]) {
+    if (![TSStorageManager isDatabasePasswordAccessible]) {
         UILocalNotification *notification = [[UILocalNotification alloc] init];
         notification.alertBody            = NSLocalizedString(@"PHONE_NEEDS_UNLOCK", nil);
         [[UIApplication sharedApplication] presentLocalNotificationNow:notification];

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -58,13 +58,26 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // Initializing logger
-    CategorizingLogger *logger = [CategorizingLogger categorizingLogger];
-    [logger addLoggingCallback:^(NSString *category, id details, NSUInteger index){
-    }];
+    BOOL loggingIsEnabled;
+#ifdef DEBUG
+    // Specified at Product -> Scheme -> Edit Scheme -> Test -> Arguments -> Environment to avoid things like
+    // the phone directory being looked up during tests.
+    loggingIsEnabled = TRUE;
+    [DebugLogger.sharedLogger enableTTYLogging];
+#elif RELEASE
+    loggingIsEnabled = Environment.preferences.loggingIsEnabled;
+#endif
+    if (loggingIsEnabled) {
+        [DebugLogger.sharedLogger enableFileLogging];
+    }
 
     // XXX - careful when moving this. It must happen before we initialize TSStorageManager.
     [self verifyDBKeysAvailableBeforeBackgroundLaunch];
+
+    // Initializing env logger
+    CategorizingLogger *logger = [CategorizingLogger categorizingLogger];
+    [logger addLoggingCallback:^(NSString *category, id details, NSUInteger index){
+    }];
 
     // Setting up environment
     [Environment setCurrent:[Release releaseEnvironmentWithLogging:logger]];
@@ -80,21 +93,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
         [Environment.getCurrent.contactsManager doAfterEnvironmentInitSetup];
     }
     [Environment.getCurrent initCallListener];
-
-    BOOL loggingIsEnabled;
-
-#ifdef DEBUG
-    // Specified at Product -> Scheme -> Edit Scheme -> Test -> Arguments -> Environment to avoid things like
-    // the phone directory being looked up during tests.
-    loggingIsEnabled = TRUE;
-    [DebugLogger.sharedLogger enableTTYLogging];
-#elif RELEASE
-    loggingIsEnabled = Environment.preferences.loggingIsEnabled;
-#endif
-
-    if (loggingIsEnabled) {
-        [DebugLogger.sharedLogger enableFileLogging];
-    }
 
     [self setupTSKitEnv];
 

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -387,9 +387,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     }
 
     if (![TSStorageManager isDatabasePasswordAccessible]) {
-        UILocalNotification *notification = [[UILocalNotification alloc] init];
-        notification.alertBody            = NSLocalizedString(@"PHONE_NEEDS_UNLOCK", nil);
-        [[UIApplication sharedApplication] presentLocalNotificationNow:notification];
         DDLogInfo(@"%@ exiting because we are in the background and the database password is not accessible.", self.tag);
         exit(0);
     }

--- a/Signal/src/environment/Migrations/OWS102MoveLoggingPreferenceToUserDefaults.h
+++ b/Signal/src/environment/Migrations/OWS102MoveLoggingPreferenceToUserDefaults.h
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "OWSDatabaseMigration.h"
+
+@interface OWS102MoveLoggingPreferenceToUserDefaults : OWSDatabaseMigration
+
+@end

--- a/Signal/src/environment/Migrations/OWS102MoveLoggingPreferenceToUserDefaults.m
+++ b/Signal/src/environment/Migrations/OWS102MoveLoggingPreferenceToUserDefaults.m
@@ -1,0 +1,57 @@
+//
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "OWS102MoveLoggingPreferenceToUserDefaults.h"
+#import "DebugLogger.h"
+#import "Environment.h"
+#import "PropertyListPreferences.h"
+
+// Increment a similar constant for every future DBMigration
+static NSString *const OWS102MoveLoggingPreferenceToUserDefaultsMigrationId = @"102";
+
+@implementation OWS102MoveLoggingPreferenceToUserDefaults
+
++ (NSString *)migrationId
+{
+    return OWS102MoveLoggingPreferenceToUserDefaultsMigrationId;
+}
+
+- (void)runUpWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
+    DDLogWarn(@"[OWS102MoveLoggingPreferenceToUserDefaultsMigrationId] copying existing logging preference to "
+              @"NSUserDefaults");
+
+    NSNumber *existingValue = [self.storageManager objectForKey:PropertyListPreferencesKeyEnableDebugLog
+                                                   inCollection:PropertyListPreferencesSignalDatabaseCollection];
+
+    if (existingValue) {
+        DDLogInfo(@"%@ assigning existing value: %@", self.tag, existingValue);
+        [[Environment preferences] setLoggingEnabled:[existingValue boolValue]];
+
+        if (![existingValue boolValue]) {
+            DDLogInfo(@"%@ Disabling file logger after one-time log settings migration.", self.tag);
+            // Since we're migrating, we didn't have the appropriate value on startup, and incorrectly started logging.
+            [DebugLogger.sharedLogger disableFileLogging];
+        } else {
+            DDLogInfo(@"%@ Continuing to log after one-time log settings migration.", self.tag);
+        }
+    } else {
+        DDLogInfo(@"%@ not assigning any value, since no previous value was stored.", self.tag);
+    }
+}
+
+
+#pragma mark - Logging
+
++ (NSString *)tag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag
+{
+    return self.class.tag;
+}
+
+@end

--- a/Signal/src/environment/Migrations/OWSDatabaseMigrationRunner.m
+++ b/Signal/src/environment/Migrations/OWSDatabaseMigrationRunner.m
@@ -4,6 +4,7 @@
 #import "OWSDatabaseMigrationRunner.h"
 #import "OWS100RemoveTSRecipientsMigration.h"
 #import "OWS101ExistingUsersBlockOnIdentityChange.h"
+#import "OWS102MoveLoggingPreferenceToUserDefaults.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,7 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return @[
         [[OWS100RemoveTSRecipientsMigration alloc] initWithStorageManager:self.storageManager],
-        [[OWS101ExistingUsersBlockOnIdentityChange alloc] initWithStorageManager:self.storageManager]
+        [[OWS101ExistingUsersBlockOnIdentityChange alloc] initWithStorageManager:self.storageManager],
+        [[OWS102MoveLoggingPreferenceToUserDefaults alloc] initWithStorageManager:self.storageManager]
     ];
 }
 

--- a/Signal/src/environment/PropertyListPreferences.h
+++ b/Signal/src/environment/PropertyListPreferences.h
@@ -13,6 +13,10 @@ typedef NS_ENUM(NSUInteger, TSImageQuality) {
     TSImageQualityLow = 4
 };
 
+// Used when migrating logging to NSUserDefaults.
+extern NSString *const PropertyListPreferencesSignalDatabaseCollection;
+extern NSString *const PropertyListPreferencesKeyEnableDebugLog;
+
 @interface PropertyListPreferences : NSObject
 
 #pragma mark - Helpers

--- a/Signal/src/environment/PropertyListPreferences.m
+++ b/Signal/src/environment/PropertyListPreferences.m
@@ -68,16 +68,6 @@ NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecorded
     [self setValueForKey:PropertyListPreferencesKeyCallStreamDESBufferLevel toValue:@(value)];
 }
 
-- (BOOL)loggingIsEnabled
-{
-    NSNumber *preference = [self tryGetValueForKey:PropertyListPreferencesKeyEnableDebugLog];
-    if (preference) {
-        return [preference boolValue];
-    } else {
-        return YES;
-    }
-}
-
 - (BOOL)screenSecurityIsEnabled
 {
     NSNumber *preference = [self tryGetValueForKey:PropertyListPreferencesKeyScreenSecurity];
@@ -130,9 +120,21 @@ NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecorded
     [self setValueForKey:PropertyListPreferencesKeyHasRegisteredVoipPush toValue:@(enabled)];
 }
 
+- (BOOL)loggingIsEnabled
+{
+    NSNumber *preference = [NSUserDefaults.standardUserDefaults objectForKey:PropertyListPreferencesKeyEnableDebugLog];
+
+    if (preference) {
+        return [preference boolValue];
+    } else {
+        return YES;
+    }
+}
+
 - (void)setLoggingEnabled:(BOOL)flag
 {
-    [self setValueForKey:PropertyListPreferencesKeyEnableDebugLog toValue:@(flag)];
+    [NSUserDefaults.standardUserDefaults setObject:@(flag) forKey:PropertyListPreferencesKeyEnableDebugLog];
+    [NSUserDefaults.standardUserDefaults synchronize];
 }
 
 - (nullable NSString *)lastRanVersion


### PR DESCRIPTION
Most likely this would be  because the user hasn't unlocked their device
since last restart.

This behavior existed once before, but the startup ordering is pretty
delicate. So, we're now redundantly checking in SSK in case this
delicate startup logic gets mis-ordered again.

Also fixed the AppDelegate method to check for the proper
applicationState, since it will never be "active" in didFinishLaunching.

fixes https://github.com/WhisperSystems/Signal-iOS/issues/1627

corresponding SSK: https://github.com/WhisperSystems/SignalServiceKit/pull/99

PTAL @charlesmchen 

// FREEBIE
