### PR TITLE
Charlesmchen/webrtc/video2 

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -72,7 +72,7 @@
 	<key>NSAppleMusicUsageDescription</key>
 	<string>Signal needs to use Apple Music to play media attachments.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Signal will let you take a photo to send to your contacts. You can review it before sending.</string>
+	<string>Signal uses your camera to take photos and for video calls.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Signal uses your contacts to find users you know. We do not store your contacts on the server.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -5,11 +5,13 @@
 #import <Foundation/Foundation.h>
 
 #import "AppAudioManager.h"
+#import "Asserts.h"
 #import "Environment.h"
 #import "NotificationsManager.h"
 #import "OWSCallNotificationsAdaptee.h"
 #import "OWSContactAvatarBuilder.h"
 #import "OWSContactsManager.h"
+#import "OWSDispatch.h"
 #import "OWSLogger.h"
 #import "OWSWebRTCDataProtos.pb.h"
 #import "PhoneNumber.h"
@@ -54,3 +56,5 @@
 #import <SignalServiceKit/TSStorageManager+keyingMaterial.h>
 #import <SignalServiceKit/TSThread.h>
 #import <WebRTC/RTCAudioSession.h>
+#import <WebRTC/RTCCameraPreviewView.h>
+#import <WebRTC/RTCEAGLVideoView.h>

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -31,16 +31,17 @@ import Foundation
     // MARK: - CallObserver
 
     internal func stateDidChange(call: SignalCall, state: CallState) {
-        DispatchQueue.main.async {
-            self.handleState(state)
-        }
+        AssertIsOnMainThread()
+        self.handleState(state)
     }
 
     internal func muteDidChange(call: SignalCall, isMuted: Bool) {
+        AssertIsOnMainThread()
         Logger.verbose("\(TAG) in \(#function) is no-op")
     }
 
     internal func speakerphoneDidChange(call: SignalCall, isEnabled: Bool) {
+        AssertIsOnMainThread()
         if isEnabled {
             setAudioSession(category: AVAudioSessionCategoryPlayAndRecord, options: .defaultToSpeaker)
         } else {
@@ -49,6 +50,7 @@ import Foundation
     }
 
     internal func hasVideoDidChange(call: SignalCall, hasVideo: Bool) {
+        AssertIsOnMainThread()
         // no-op
     }
 
@@ -131,7 +133,7 @@ import Foundation
             return
         }
 
-        vibrateTimer = WeakTimer.scheduledTimer(timeInterval: vibrateRepeatDuration, target: self, userInfo: nil, repeats: true) {[weak self] timer in
+        vibrateTimer = WeakTimer.scheduledTimer(timeInterval: vibrateRepeatDuration, target: self, userInfo: nil, repeats: true) {[weak self] _ in
             self?.ringVibration()
         }
         vibrateTimer?.fire()

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -116,7 +116,9 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
 
     func localHangupCall(_ call: SignalCall) {
         CallService.signalingQueue.async {
-            guard call.localId == self.callService.call?.localId else {
+            // If both parties hang up at the same moment,
+            // call might already be nil.
+            guard self.callService.call == nil || call.localId == self.callService.call?.localId else {
                 assertionFailure("\(self.TAG) in \(#function) localId does not match current call")
                 return
             }

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -193,13 +193,7 @@ protocol CallObserver: class {
     // MARK: Equatable
 
     static func == (lhs: SignalCall, rhs: SignalCall) -> Bool {
-        objc_sync_enter(self)
-
-        let result = lhs.localId == rhs.localId
-
-        objc_sync_exit(self)
-
-        return result
+        return lhs.localId == rhs.localId
     }
 
     static func newCallSignalingId() -> UInt64 {

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -17,6 +17,7 @@ enum CallState: String {
     case remoteBusy // terminal
 }
 
+// All Observer methods will be invoked from the main thread.
 protocol CallObserver: class {
     func stateDidChange(call: SignalCall, state: CallState)
     func hasVideoDidChange(call: SignalCall, hasVideo: Bool)
@@ -26,6 +27,8 @@ protocol CallObserver: class {
 
 /**
  * Data model for a WebRTC backed voice/video call.
+ *
+ * This class' state should only be accessed on the signaling queue.
  */
 @objc class SignalCall: NSObject {
 
@@ -39,51 +42,97 @@ protocol CallObserver: class {
 
     // Distinguishes between calls locally, e.g. in CallKit
     let localId: UUID
-    
+
     var hasVideo = false {
         didSet {
-            Logger.debug("\(TAG) hasVideo changed: \(oldValue) -> \(hasVideo)")
-            for observer in observers {
-                observer.value?.hasVideoDidChange(call: self, hasVideo: hasVideo)
+            // This should only occur on the signaling queue.
+            objc_sync_enter(self)
+
+            let observers = self.observers
+            let call = self
+            let hasVideo = self.hasVideo
+
+            objc_sync_exit(self)
+
+            DispatchQueue.main.async {
+                for observer in observers {
+                    observer.value?.hasVideoDidChange(call: call, hasVideo: hasVideo)
+                }
             }
         }
     }
 
     var state: CallState {
         didSet {
-            Logger.debug("\(TAG) state changed: \(oldValue) -> \(state)")
+            // This should only occur on the signaling queue.
+            objc_sync_enter(self)
+            Logger.debug("\(TAG) state changed: \(oldValue) -> \(self.state)")
 
             // Update connectedDate
-            if state == .connected {
+            if self.state == .connected {
                 if connectedDate == nil {
                     connectedDate = NSDate()
                 }
             } else {
                 connectedDate = nil
             }
-            for observer in observers {
-                observer.value?.stateDidChange(call: self, state: state)
+
+            let observers = self.observers
+            let call = self
+            let state = self.state
+
+            objc_sync_exit(self)
+
+            DispatchQueue.main.async {
+                for observer in observers {
+                    observer.value?.stateDidChange(call: call, state: state)
+                }
             }
         }
     }
 
     var isMuted = false {
         didSet {
-            Logger.debug("\(TAG) muted changed: \(oldValue) -> \(isMuted)")
-            for observer in observers {
-                observer.value?.muteDidChange(call: self, isMuted: isMuted)
+            // This should only occur on the signaling queue.
+            objc_sync_enter(self)
+
+            Logger.debug("\(TAG) muted changed: \(oldValue) -> \(self.isMuted)")
+
+            let observers = self.observers
+            let call = self
+            let isMuted = self.isMuted
+
+            objc_sync_exit(self)
+
+            DispatchQueue.main.async {
+                for observer in observers {
+                    observer.value?.muteDidChange(call: call, isMuted: isMuted)
+                }
             }
         }
     }
 
     var isSpeakerphoneEnabled = false {
         didSet {
-            Logger.debug("\(TAG) isSpeakerphoneEnabled changed: \(oldValue) -> \(isSpeakerphoneEnabled)")
-            for observer in observers {
-                observer.value?.speakerphoneDidChange(call: self, isEnabled: isSpeakerphoneEnabled)
+            // This should only occur on the signaling queue.
+            objc_sync_enter(self)
+
+            Logger.debug("\(TAG) isSpeakerphoneEnabled changed: \(oldValue) -> \(self.isSpeakerphoneEnabled)")
+
+            let observers = self.observers
+            let call = self
+            let isSpeakerphoneEnabled = self.isSpeakerphoneEnabled
+
+            objc_sync_exit(self)
+
+            DispatchQueue.main.async {
+                for observer in observers {
+                    observer.value?.speakerphoneDidChange(call: call, isEnabled: isSpeakerphoneEnabled)
+                }
             }
         }
     }
+
     var connectedDate: NSDate?
 
     var error: CallError?
@@ -108,26 +157,49 @@ protocol CallObserver: class {
     // -
 
     func addObserverAndSyncState(observer: CallObserver) {
+        objc_sync_enter(self)
+
         observers.append(Weak(value: observer))
 
-        // Synchronize observer with current call state
-        observer.stateDidChange(call: self, state: self.state)
-    }
+        let call = self
+        let state = self.state
 
-    func removeObserver(_ observer: CallObserver) {
-        while let index = observers.index(where: { $0.value === observer }) {
-            observers.remove(at: index)
+        objc_sync_exit(self)
+
+        DispatchQueue.main.async {
+            // Synchronize observer with current call state
+            observer.stateDidChange(call: call, state: state)
         }
     }
 
+    func removeObserver(_ observer: CallObserver) {
+        objc_sync_enter(self)
+
+        while let index = observers.index(where: { $0.value === observer }) {
+            observers.remove(at: index)
+        }
+
+        objc_sync_exit(self)
+    }
+
     func removeAllObservers() {
+        objc_sync_enter(self)
+
         observers = []
+
+        objc_sync_exit(self)
     }
 
     // MARK: Equatable
 
     static func == (lhs: SignalCall, rhs: SignalCall) -> Bool {
-        return lhs.localId == rhs.localId
+        objc_sync_enter(self)
+
+        let result = lhs.localId == rhs.localId
+
+        objc_sync_exit(self)
+
+        return result
     }
 
     static func newCallSignalingId() -> UInt64 {

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -7,10 +7,9 @@ import WebRTC
 import PromiseKit
 
 // TODO: Add category so that button handlers can be defined where button is created.
-// TODO: Add logic to button handlers.
 // TODO: Ensure buttons enabled & disabled as necessary.
 @objc(OWSCallViewController)
-class CallViewController: UIViewController, CallObserver {
+class CallViewController: UIViewController, CallObserver, CallServiceObserver, RTCEAGLVideoViewDelegate {
 
     enum CallDirection {
         case unspecified, outgoing, incoming
@@ -25,7 +24,6 @@ class CallViewController: UIViewController, CallObserver {
 
     // MARK: Properties
 
-    var peerConnectionClient: PeerConnectionClient?
     var callDirection: CallDirection = .unspecified
     var thread: TSContactThread!
     var call: SignalCall!
@@ -59,6 +57,15 @@ class CallViewController: UIViewController, CallObserver {
 
     var acceptIncomingButton: UIButton!
     var declineIncomingButton: UIButton!
+
+    // MARK: Video Views
+
+    var remoteVideoView: RTCEAGLVideoView!
+    var localVideoView: RTCCameraPreviewView!
+    weak var localVideoTrack: RTCVideoTrack?
+    weak var remoteVideoTrack: RTCVideoTrack?
+    var remoteVideoSize: CGSize! = CGSize.zero
+    var videoViewConstraints: [NSLayoutConstraint] = []
 
     // MARK: Control Groups
 
@@ -132,7 +139,11 @@ class CallViewController: UIViewController, CallObserver {
 
         // Subscribe for future call updates
         call.addObserverAndSyncState(observer: self)
+
+        Environment.getCurrent().callService.addObserverAndSyncState(observer:self)
     }
+
+    // MARK: - Create Views
 
     func createViews() {
         // Dark blurred background.
@@ -140,9 +151,22 @@ class CallViewController: UIViewController, CallObserver {
         blurView = UIVisualEffectView(effect: blurEffect)
         self.view.addSubview(blurView)
 
+        // Create the video views first, as they are under the other views.
+        createVideoViews()
+
         createContactViews()
         createOngoingCallControls()
         createIncomingCallControls()
+    }
+
+    func createVideoViews() {
+        remoteVideoView = RTCEAGLVideoView()
+        remoteVideoView.delegate = self
+        localVideoView = RTCCameraPreviewView()
+        remoteVideoView.isHidden = true
+        localVideoView.isHidden = true
+        self.view.addSubview(remoteVideoView)
+        self.view.addSubview(localVideoView)
     }
 
     func createContactViews() {
@@ -291,6 +315,8 @@ class CallViewController: UIViewController, CallObserver {
         return row
     }
 
+    // MARK: - Layout
+
     override func updateViewConstraints() {
         if !hasConstraints {
             // We only want to create our constraints once.
@@ -310,9 +336,19 @@ class CallViewController: UIViewController, CallObserver {
             // The buttons have built-in 10% margins, so to appear centered
             // the avatar's bottom spacing should be a bit less.
             let avatarBottomSpacing = ScaleFromIPhone5To7Plus(18, 41)
+            // Layout of the local video view is a bit unusual because 
+            // although the view is square, it will be used
+            let videoPreviewHMargin = CGFloat(0)
 
             // Dark blurred background.
             blurView.autoPinEdgesToSuperviewEdges()
+
+            // TODO: Prevent overlap of localVideoView and contact views.
+            localVideoView.autoPinEdge(toSuperviewEdge:.right, withInset:videoPreviewHMargin)
+            localVideoView.autoPinEdge(toSuperviewEdge:.top, withInset:topMargin)
+            let localVideoSize = ScaleFromIPhone5To7Plus(80, 100)
+            localVideoView.autoSetDimension(.width, toSize:localVideoSize)
+            localVideoView.autoSetDimension(.height, toSize:localVideoSize)
 
             contactNameLabel.autoPinEdge(toSuperviewEdge:.top, withInset:topMargin)
             contactNameLabel.autoPinWidthToSuperview(withMargin:contactHMargin)
@@ -342,8 +378,59 @@ class CallViewController: UIViewController, CallObserver {
             incomingCallView.setContentHuggingVerticalHigh()
         }
 
+        updateVideoViewLayout()
+
         super.updateViewConstraints()
     }
+
+    internal func updateVideoViewLayout() {
+        NSLayoutConstraint.deactivate(self.videoViewConstraints)
+
+        var constraints: [NSLayoutConstraint] = []
+
+        // We fill the screen with the remote video. The remote video's
+        // aspect ratio may not (and in fact will very rarely) match the 
+        // aspect ratio of the current device, so parts of the remote
+        // video will be hidden offscreen.  
+        //
+        // It's better to trim the remote video than to adopt a letterboxed
+        // layout.
+        if remoteVideoSize.width > 0 && remoteVideoSize.height > 0 &&
+            self.view.bounds.size.width > 0 && self.view.bounds.size.height > 0 {
+
+            var remoteVideoWidth = self.view.bounds.size.width
+            var remoteVideoHeight = self.view.bounds.size.height
+            if remoteVideoSize.width / self.view.bounds.size.width > remoteVideoSize.height / self.view.bounds.size.height {
+                remoteVideoWidth = round(self.view.bounds.size.height * remoteVideoSize.width / remoteVideoSize.height)
+            } else {
+                remoteVideoHeight = round(self.view.bounds.size.width * remoteVideoSize.height / remoteVideoSize.width)
+            }
+            constraints.append(remoteVideoView.autoSetDimension(.width, toSize:remoteVideoWidth))
+            constraints.append(remoteVideoView.autoSetDimension(.height, toSize:remoteVideoHeight))
+            constraints += remoteVideoView.autoCenterInSuperview()
+
+            remoteVideoView.frame = CGRect(origin:CGPoint.zero,
+                                           size:CGSize(width:remoteVideoWidth,
+                                                       height:remoteVideoHeight))
+
+            remoteVideoView.isHidden = false
+        } else {
+            constraints += remoteVideoView.autoPinEdgesToSuperviewEdges()
+            remoteVideoView.isHidden = true
+        }
+
+        self.videoViewConstraints = constraints
+    }
+
+    func traverseViewHierarchy(view: UIView!, visitor: (UIView) -> Void) {
+        visitor(view)
+
+        for subview in view.subviews {
+            traverseViewHierarchy(view:subview, visitor:visitor)
+        }
+    }
+
+    // MARK: - Methods
 
     // objc accessible way to set our swift enum.
     func setOutgoingCallDirection() {
@@ -359,6 +446,8 @@ class CallViewController: UIViewController, CallObserver {
         // TODO Show something in UI.
         Logger.error("\(TAG) call failed with error: \(error)")
     }
+
+    // MARK: - View State
 
     func localizedTextForCallState(_ callState: CallState) -> String {
         assert(Thread.isMainThread)
@@ -541,27 +630,87 @@ class CallViewController: UIViewController, CallObserver {
     // MARK: - CallObserver
 
     internal func stateDidChange(call: SignalCall, state: CallState) {
-        DispatchQueue.main.async {
-            Logger.info("\(self.TAG) new call status: \(state)")
-            self.updateCallUI(callState: state)
-        }
+        AssertIsOnMainThread()
+        Logger.info("\(self.TAG) new call status: \(state)")
+        self.updateCallUI(callState: state)
     }
 
     internal func hasVideoDidChange(call: SignalCall, hasVideo: Bool) {
-        DispatchQueue.main.async {
-            self.updateCallUI(callState: call.state)
-        }
+        AssertIsOnMainThread()
+        self.updateCallUI(callState: call.state)
     }
 
     internal func muteDidChange(call: SignalCall, isMuted: Bool) {
-        DispatchQueue.main.async {
-            self.updateCallUI(callState: call.state)
-        }
+        AssertIsOnMainThread()
+        self.updateCallUI(callState: call.state)
     }
 
     internal func speakerphoneDidChange(call: SignalCall, isEnabled: Bool) {
-        DispatchQueue.main.async {
-            self.updateCallUI(callState: call.state)
+        AssertIsOnMainThread()
+        self.updateCallUI(callState: call.state)
+    }
+
+    // MARK: - Video
+
+    internal func updateLocalVideoTrack(localVideoTrack: RTCVideoTrack?) {
+        AssertIsOnMainThread()
+        if self.localVideoTrack == localVideoTrack {
+            return
         }
+
+        self.localVideoTrack = localVideoTrack
+
+        var source: RTCAVFoundationVideoSource?
+        if localVideoTrack?.source is RTCAVFoundationVideoSource {
+            source = localVideoTrack?.source as! RTCAVFoundationVideoSource
+        }
+        localVideoView.captureSession = source?.captureSession
+        let isHidden = source == nil
+        Logger.info("\(TAG) \(#function) isHidden: \(isHidden)")
+        localVideoView.isHidden = source == nil
+
+        updateVideoViewLayout()
+    }
+
+    internal func updateRemoteVideoTrack(remoteVideoTrack: RTCVideoTrack?) {
+        AssertIsOnMainThread()
+        if self.remoteVideoTrack == remoteVideoTrack {
+            return
+        }
+
+        self.remoteVideoTrack?.remove(remoteVideoView)
+        self.remoteVideoTrack = nil
+        remoteVideoView.renderFrame(nil)
+        self.remoteVideoTrack = remoteVideoTrack
+        self.remoteVideoTrack?.add(remoteVideoView)
+
+        // TODO: We need to figure out how to observe start/stop of remote video.
+
+        updateVideoViewLayout()
+    }
+
+    // MARK: - CallServiceObserver
+
+    internal func didUpdateVideoTracks(localVideoTrack: RTCVideoTrack?,
+                                       remoteVideoTrack: RTCVideoTrack?) {
+        AssertIsOnMainThread()
+
+        updateLocalVideoTrack(localVideoTrack:localVideoTrack)
+        updateRemoteVideoTrack(remoteVideoTrack:remoteVideoTrack)
+    }
+
+    // MARK: - RTCEAGLVideoViewDelegate
+
+    internal func videoView(_ videoView: RTCEAGLVideoView, didChangeVideoSize size: CGSize) {
+        AssertIsOnMainThread()
+
+        if videoView != remoteVideoView {
+            return
+        }
+
+        Logger.info("\(TAG) \(#function): \(size)")
+
+        remoteVideoSize = size
+        updateVideoViewLayout()
     }
 }

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -654,7 +654,7 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
 
     internal func updateLocalVideoTrack(localVideoTrack: RTCVideoTrack?) {
         AssertIsOnMainThread()
-        if self.localVideoTrack == localVideoTrack {
+        guard self.localVideoTrack == localVideoTrack else {
             return
         }
 
@@ -667,14 +667,14 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
         localVideoView.captureSession = source?.captureSession
         let isHidden = source == nil
         Logger.info("\(TAG) \(#function) isHidden: \(isHidden)")
-        localVideoView.isHidden = source == nil
+        localVideoView.isHidden = isHidden
 
         updateVideoViewLayout()
     }
 
     internal func updateRemoteVideoTrack(remoteVideoTrack: RTCVideoTrack?) {
         AssertIsOnMainThread()
-        if self.remoteVideoTrack == remoteVideoTrack {
+        guard self.remoteVideoTrack == remoteVideoTrack else {
             return
         }
 


### PR DESCRIPTION
Roughs out the video-related views.

* Adds views for local and remote video to call view.
* Adds plumbing for the local and remote video tracks from the `PeerConnectionClient` to `CallService`.
* Adds plumbing for the local and remote video tracks from the `CallService` to `CallViewController`.
* Ensures observers of `SignalCall` and `CallService` are always invoked on main thread.
* Improve thread safety of `SignalCall` and `CallService`.

PTAL @michaelkirk 