### PR TITLE
Make sure WebRTC preferences are synced *every* call

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ target 'Signal' do
     pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git'
     pod 'AxolotlKit',                 git: 'https://github.com/WhisperSystems/SignalProtocolKit.git'
     #pod 'AxolotlKit',                 path: '../SignalProtocolKit'
-    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'mkirk/webrtc'
+    pod 'SignalServiceKit',           git: 'https://github.com/WhisperSystems/SignalServiceKit.git', branch: 'mkirk/stale-recipient-settings'
     #pod 'SignalServiceKit',           path: '../SignalServiceKit'
     pod 'OpenSSL'
     pod 'PastelogKit',                '~> 1.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -123,7 +123,7 @@ DEPENDENCIES:
   - PastelogKit (~> 1.3)
   - PureLayout
   - SCWaveformView (~> 1.0)
-  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `mkirk/webrtc`)
+  - SignalServiceKit (from `https://github.com/WhisperSystems/SignalServiceKit.git`, branch `mkirk/stale-recipient-settings`)
   - SocketRocket (from `https://github.com/facebook/SocketRocket.git`)
   - ZXingObjC
 
@@ -131,7 +131,7 @@ EXTERNAL SOURCES:
   AxolotlKit:
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :branch: mkirk/webrtc
+    :branch: mkirk/stale-recipient-settings
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :git: https://github.com/facebook/SocketRocket.git
@@ -141,7 +141,7 @@ CHECKOUT OPTIONS:
     :commit: 919d541d6b8a8802a94f943026b8f68394e2c0b8
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: 9fdbbb7f8b16ebfad074543281737626a0778be5
+    :commit: 68912f308a4b56f20d25b8f3e20bedbe07f6922d
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 41b57bb2fc292a814f758441a05243eb38457027
@@ -173,6 +173,6 @@ SPEC CHECKSUMS:
   YapDatabase: b1e43555a34a5298e23a045be96817a5ef0da58f
   ZXingObjC: bf15b3814f7a105b6d99f47da2333c93a063650a
 
-PODFILE CHECKSUM: 9f2e2cf6d4db276e3d0280343260503d09c72979
+PODFILE CHECKSUM: e1fb21bd41196e97444f0d4a39f0029d40c7e629
 
 COCOAPODS: 1.0.1

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -424,7 +424,7 @@ protocol CallServiceObserver: class {
         Logger.debug("\(TAG) called \(#function)")
 
         guard self.thread != nil else {
-            handleFailedCall(error: .assertionError(description: "ignoring remote ice update for thread: \(thread.uniqueId) since there is no current thread. TODO: Signaling messages out of order?"))
+            handleFailedCall(error: .assertionError(description: "ignoring remote ice update for thread: \(thread.uniqueId) since there is no current thread. Call already ended?"))
             return
         }
 
@@ -960,7 +960,9 @@ protocol CallServiceObserver: class {
             call.state = .localFailure
             callUIAdapter.failCall(call, error: error)
         } else {
-            assertionFailure("\(TAG) in \(#function) but there was no call to fail.")
+            // This can happen when we receive an out of band signaling message (e.g. IceUpdate)
+            // after the call has ended
+            Logger.debug("\(TAG) in \(#function) but there was no call to fail.")
         }
 
         terminateCall()

--- a/Signal/src/view controllers/AdvancedSettingsTableViewController.m
+++ b/Signal/src/view controllers/AdvancedSettingsTableViewController.m
@@ -155,6 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     __weak AdvancedSettingsTableViewController *weakSelf = self;
     BOOL isWebRTCEnabled = sender.isOn;
+    DDLogInfo(@"%@ User set WebRTC calling to: %@", self.tag, (isWebRTCEnabled ? @"ON" : @"OFF"));
     TSUpdateAttributesRequest *request = [[TSUpdateAttributesRequest alloc] initWithUpdatedAttributes:isWebRTCEnabled];
     [[TSNetworkManager sharedManager] makeRequest:request
                                           success:^(NSURLSessionDataTask *task, id responseObject) {

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -543,9 +543,6 @@
 /* No comment provided by engineer. */
 "OUTGOING_CALL" = "Outgoing call";
 
-/* No comment provided by engineer. */
-"PHONE_NEEDS_UNLOCK" = "Your iPhone needs to be unlocked to receive new messages.";
-
 /* Alert body when verifying with {{contact name}} */
 "PRIVACY_VERIFICATION_FAILED_I_HAVE_WRONG_KEY_FOR_THEM" = "This doesn't look like your safety number with %@. Are you verifying the correct contact?";
 
@@ -842,6 +839,9 @@
 
 /* No comment provided by engineer. */
 "TXT_DELETE_TITLE" = "Delete";
+
+/* Alert Title */
+"UNABLE_TO_PLACE_CALL" = "Unable to place call.";
 
 /* Pressing this button moves an archived thread from the archive back to the inbox */
 "UNARCHIVE_ACTION" = "Unarchive";


### PR DESCRIPTION
This slows the UI, but only for people who have locally opted into
WebRTC calls, and the alternative is that users are likely to have stale
settings the first time a pair of people opt-in.

// FREEBIE