### PR TITLE
Better concurrent call handling

### DIFF
--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -133,6 +133,8 @@ protocol CallObserver: class {
         }
     }
 
+    var isOnHold = false
+
     var connectedDate: NSDate?
 
     var error: CallError?

--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -285,20 +285,19 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
             action.fail()
             return
         }
-        Logger.warn("TODO, unimplemented set held call: \(call)")
 
-        // TODO FIXME
-        //        // Update the SpeakerboxCall's underlying hold state.
-        //        call.isOnHold = action.isOnHold
-        //
-        //        // Stop or start audio in response to holding or unholding the call.
-        //        if call.isOnHold {
-        //            // stopAudio() <-- SpeakerBox
-        //            PeerConnectionClient.stopAudioSession()
-        //        } else {
-        //            // startAudio() <-- SpeakerBox
-        //            PeerConnectionClient.startAudioSession()
-        //        }
+        // Update the SignalCall's underlying hold state.
+        call.isOnHold = action.isOnHold
+
+        // Stop or start audio in response to holding or unholding the call.
+        if call.isOnHold {
+            // stopAudio() <-- SpeakerBox
+            PeerConnectionClient.stopAudioSession()
+        } else {
+            // startAudio() <-- SpeakerBox
+            // This is redundant with what happens in `provider(_:didActivate:)`
+            //PeerConnectionClient.startAudioSession()
+        }
 
         // Signal to the system that the action has been successfully performed.
         action.fulfill()


### PR DESCRIPTION
This addresses a couple issues related to receiving calls when already on a call. 


So. previously, when you initiated a Signal Call to Possum, connected and started talking. Then received a non-Signal call from Squirrel, you'd see this:

![squirrel](https://cloud.githubusercontent.com/assets/217057/22442227/93fe98e8-e708-11e6-80b7-2d75b7c5130e.jpg)

Which is weird, because you shouldn't be able to  "Accept" the new call without specifying what to do with the old call (e.g. "Hold" or "End" the existing call).

Turns out, we never marked the outgoing SignalCall as connected, so that's fixed in e425d35
With that, the interrupting call screen looks like this:

![hold accept](https://cloud.githubusercontent.com/assets/217057/22442482/9673118e-e709-11e6-8ca2-971d5db98858.jpg)

Note the "hold & accept" option. We didn't intend on supporting hold initially, but I took a stab at it, just to see how difficult it would be in: https://github.com/WhisperSystems/Signal-iOS/commit/969b73cad8ed3fb542848e398a4620a9f1d40f9e

It worked, in that you could interrupt the Signal call with Possum by holding it, talk to Squirrel, then upon ending the call with Squirrel you'd be back talking to Possum, no problem.

BUT, before ending the interrupting call from Squirrel, if you *chose* to swap between held calls from the callkit screen, Signal call audio with Possum would not properly resume (unless you returned to the Signal app on your own volition, but that's not a thing we could reasonably expect users to discover.)

So I backed away form supporting Call muting for now, and went the route of fully disabling it for *outgoing* calls the same way we already were for *incoming* calls. Now the same call screen looks like this:

![end accept](https://cloud.githubusercontent.com/assets/217057/22442711/40be39fc-e70a-11e6-8e57-e1cce8ae554d.jpg)

finé

PTAL @charlesmchen 