### PR TITLE
More space for non-callkit incoming call buttons

### DIFF
--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -255,7 +255,7 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
         spacerView.autoSetDimension(.height, toSize:buttonSize())
 
         incomingCallView = createContainerForCallControls(controlGroups : [
-            [acceptIncomingButton, spacerView, declineIncomingButton ]
+            [acceptIncomingButton, declineIncomingButton ]
             ])
     }
 
@@ -322,7 +322,12 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
                     spacer.autoPinEdge(.right, to:.left, of:subview)
                     spacer.setContentHuggingHorizontalLow()
                     spacer.autoVCenterInSuperview()
-                    if lastSpacer != nil {
+
+                    if subviews.count == 2 {
+                        // special case to hardcode the spacer's size when there is only 1 spacer.
+                        spacer.autoSetDimension(.width, toSize: ScaleFromIPhone5To7Plus(46, 60))
+                    } else if lastSpacer != nil {
+                        // else there is more than one spacer, and this isn't the first one.
                         spacer.autoMatch(.width, to:.width, of:lastSpacer!)
                     }
                     lastSpacer = spacer

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -250,8 +250,12 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
         declineIncomingButton = createButton(imageName:"hangup-active-wide",
                                              action:#selector(didPressDeclineCall))
 
+        let spacerView = UIView(frame: CGRect(x: 0, y: 0, width: buttonSize(), height: 0))
+        spacerView.autoSetDimension(.width, toSize:buttonSize())
+        spacerView.autoSetDimension(.height, toSize:buttonSize())
+
         incomingCallView = createContainerForCallControls(controlGroups : [
-            [acceptIncomingButton, declineIncomingButton ]
+            [acceptIncomingButton, spacerView, declineIncomingButton ]
             ])
     }
 

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -250,10 +250,6 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
         declineIncomingButton = createButton(imageName:"hangup-active-wide",
                                              action:#selector(didPressDeclineCall))
 
-        let spacerView = UIView(frame: CGRect(x: 0, y: 0, width: buttonSize(), height: 0))
-        spacerView.autoSetDimension(.width, toSize:buttonSize())
-        spacerView.autoSetDimension(.height, toSize:buttonSize())
-
         incomingCallView = createContainerForCallControls(controlGroups : [
             [acceptIncomingButton, declineIncomingButton ]
             ])

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -304,7 +304,6 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
             // If there's more than one subview in the row,
             // space them evenly within the row.
             var lastSubview: UIView?
-            var lastSpacer: UIView?
             for subview in subviews {
                 row.addSubview(subview)
                 subview.setContentHuggingHorizontalHigh()
@@ -322,11 +321,9 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
                     if subviews.count == 2 {
                         // special case to hardcode the spacer's size when there is only 1 spacer.
                         spacer.autoSetDimension(.width, toSize: ScaleFromIPhone5To7Plus(46, 60))
-                    } else if lastSpacer != nil {
-                        // else there is more than one spacer, and this isn't the first one.
-                        spacer.autoMatch(.width, to:.width, of:lastSpacer!)
+                    } else {
+                        spacer.autoSetDimension(.width, toSize: ScaleFromIPhone5To7Plus(3, 5))
                     }
-                    lastSpacer = spacer
                 }
 
                 lastSubview = subview


### PR DESCRIPTION
The "decline" and "accept" were too close together. Added a spacer, the
same size as an extra button between the two.

before:

![image](https://cloud.githubusercontent.com/assets/217057/22445616/515189ca-e716-11e6-8027-a9f3ab81df5c.png)

after:

![image](https://cloud.githubusercontent.com/assets/217057/22445676/898ba76c-e716-11e6-930a-b0d97481d5c5.png)

// FREEBIE
