### PR TITLE
Avoid crashes when closing peer connection client.

### DIFF
--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -250,6 +250,7 @@ protocol CallServiceObserver: class {
             // to do this explicitly.
             peerConnectionClient.createSignalingDataChannel()
 
+            assert(self.peerConnectionClient == nil, "Unexpected PeerConnectionClient instance")
             self.peerConnectionClient = peerConnectionClient
 
             return self.peerConnectionClient!.createOffer()
@@ -395,6 +396,7 @@ protocol CallServiceObserver: class {
         }.then() { (iceServers: [RTCIceServer]) -> Promise<HardenedRTCSessionDescription> in
             // FIXME for first time call recipients I think we'll see mic/camera permission requests here,
             // even though, from the users perspective, no incoming call is yet visible.
+            assert(self.peerConnectionClient == nil, "Unexpected PeerConnectionClient instance")
             self.peerConnectionClient = PeerConnectionClient(iceServers: iceServers, delegate: self)
 
             let offerSessionDescription = RTCSessionDescription(type: .offer, sdp: callerSessionDescription)
@@ -994,7 +996,6 @@ protocol CallServiceObserver: class {
         Logger.debug("\(TAG) in \(#function)")
 
         PeerConnectionClient.stopAudioSession()
-        peerConnectionClient?.setDelegate(delegate:nil)
         peerConnectionClient?.terminate()
 
         peerConnectionClient = nil

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -110,7 +110,14 @@ protocol CallServiceObserver: class {
 
     // MARK: Ivars
 
-    var peerConnectionClient: PeerConnectionClient?
+    var peerConnectionClient: PeerConnectionClient? {
+        didSet {
+            AssertIsOnMainThread()
+
+            Logger.debug("\(self.TAG) .peerConnectionClient setter: \(oldValue != nil) -> \(peerConnectionClient != nil)")
+        }
+    }
+
     // TODO code cleanup: move thread into SignalCall? Or refactor messageSender to take SignalRecipient identifier.
     var thread: TSContactThread?
     var call: SignalCall? {

--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -339,7 +339,6 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
         return setRemoteSessionDescription(remoteDescription)
             .then(on: PeerConnectionClient.signalingQueue) {
-                assert(self.peerConnection != nil)
                 return self.negotiateAnswerSessionDescription(constraints: constraints)
         }
     }
@@ -368,6 +367,12 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
         return Promise { fulfill, reject in
             assertOnSignalingQueue()
+
+            guard self.peerConnection != nil else {
+                Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
+                reject(NSError(domain:"Obsolete client", code:0, userInfo:nil))
+                return
+            }
 
             Logger.debug("\(self.TAG) negotiating answer session.")
 

--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -453,16 +453,16 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         localVideoTrack?.isEnabled = false
         remoteVideoTrack?.isEnabled = false
 
-        peerConnection.delegate = nil
-        peerConnection.close()
-        peerConnection = nil
-
         dataChannel = nil
         audioSender = nil
         audioTrack = nil
         videoSender = nil
         localVideoTrack = nil
         remoteVideoTrack = nil
+
+        peerConnection.delegate = nil
+        peerConnection.close()
+        peerConnection = nil
 
         delegate = nil
     }

--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -277,6 +277,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             PeerConnectionClient.signalingQueue.async {
                 guard self.peerConnection != nil else {
                     Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
+                    reject(NSError(domain:"Obsolete client", code:0, userInfo:nil))
                     return
                 }
 
@@ -284,6 +285,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
                     PeerConnectionClient.signalingQueue.async {
                         guard self.peerConnection != nil else {
                             Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
+                            reject(NSError(domain:"Obsolete client", code:0, userInfo:nil))
                             return
                         }
                         guard error == nil else {
@@ -316,14 +318,18 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
     public func setLocalSessionDescription(_ sessionDescription: HardenedRTCSessionDescription) -> Promise<Void> {
         AssertIsOnMainThread()
 
-        return PromiseKit.wrap { resolve in
+        return Promise { fulfill, reject in
             PeerConnectionClient.signalingQueue.async {
                 guard self.peerConnection != nil else {
                     Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
+                    reject(NSError(domain:"Obsolete client", code:0, userInfo:nil))
                     return
                 }
                 Logger.verbose("\(self.TAG) setting local session description: \(sessionDescription)")
-                self.peerConnection.setLocalDescription(sessionDescription.rtcSessionDescription, completionHandler:resolve)
+                self.peerConnection.setLocalDescription(sessionDescription.rtcSessionDescription,
+                                                        completionHandler: { _ in
+                                                            fulfill()
+                })
             }
         }
     }
@@ -341,14 +347,18 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
     public func setRemoteSessionDescription(_ sessionDescription: RTCSessionDescription) -> Promise<Void> {
         AssertIsOnMainThread()
 
-        return PromiseKit.wrap { resolve in
+        return Promise { fulfill, reject in
             PeerConnectionClient.signalingQueue.async {
                 guard self.peerConnection != nil else {
                     Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
+                    reject(NSError(domain:"Obsolete client", code:0, userInfo:nil))
                     return
                 }
                 Logger.verbose("\(self.TAG) setting remote description: \(sessionDescription)")
-                self.peerConnection.setRemoteDescription(sessionDescription, completionHandler: resolve)
+                self.peerConnection.setRemoteDescription(sessionDescription,
+                                                         completionHandler: { _ in
+                                                            fulfill()
+                })
             }
         }
     }
@@ -365,6 +375,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
                 PeerConnectionClient.signalingQueue.async {
                     guard self.peerConnection != nil else {
                         Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
+                        reject(NSError(domain:"Obsolete client", code:0, userInfo:nil))
                         return
                     }
                     guard error == nil else {


### PR DESCRIPTION
This work prevents crashes due to a number of edge cases, mostly concurrency-related.

* Adds asserts that `CallService. peerConnectionClient` is nil when we create a new `PeerConnectionClient`.  This isn't always true.  These asserts should help us identify a repro.
* `PeerConnectionClient` does a lot of dispatching to the signaling queue and the main thread. I've  used weak references and added checks in these places around termination.
* The exact order of operations during termination matters, as noted by the existing comment in `terminateInternal()`.  I've slightly reworked this logic.

It's quite easy to repro crashes before this branch that are not reproducible after this branch.  Just start & stop many calls to another device without even accepting the call on the second device.  It matters how quickly you hang up the call while its ringing - you can hang up immediately, right before the "ringing" state, right after the "ringing" state, or later.

PTAL @michaelkirk 