### PR TITLE
Be even more cautious when tearing down a PeerConnectionClient.

### DIFF
--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -1064,22 +1064,10 @@ protocol CallServiceObserver: class {
         remoteVideoTrack = nil
         isRemoteVideoEnabled = false
 
-        // We make a local copy of peerConnectionClient and then clear
-        // the peerConnectionClient property immediately. This class' 
-        // PeerConnectionClientDelegate methods exit early if their 
-        // peerConnectionClient argument doesn't match the peerConnectionClient
-        // property.
-        //
-        // In practice this won't matter, since PeerConnectionClient invokes
-        // its delegate methods asynchronously, but we don't want to bake that
-        // assumption into this logic.
-        var peerConnectionClientCopy = peerConnectionClient
+        PeerConnectionClient.stopAudioSession()
+        peerConnectionClient?.terminate()
         Logger.debug("\(TAG) setting peerConnectionClient in \(#function)")
         peerConnectionClient = nil
-
-        PeerConnectionClient.stopAudioSession()
-        peerConnectionClientCopy?.terminate()
-        peerConnectionClientCopy = nil
 
         call?.removeAllObservers()
         call = nil

--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -423,10 +423,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         AssertIsOnMainThread()
         Logger.debug("\(TAG) in \(#function)")
 
-        delegate.peerConnectionClient(self, didUpdateLocal: nil)
-        delegate.peerConnectionClient(self, didUpdateRemote: nil)
-
-        PeerConnectionClient.signalingQueue.async {
+        PeerConnectionClient.signalingQueue.sync {
             assert(self.peerConnection != nil)
             self.terminateInternal()
         }


### PR DESCRIPTION
Eliminates a last class of edge cases around receiving "did add stream" events after a PCC has been torn down.

PTAL @michaelkirk 