### PR TITLE
Don’t assert when two devices call each other simultaneously.

### DIFF
--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -47,7 +47,7 @@ extension CallUIAdaptee {
         AssertIsOnMainThread()
 
         guard self.callService.call == nil else {
-            assertionFailure("unexpectedly found an existing call when trying to call back: \(recipientId)")
+            Logger.debug("unexpectedly found an existing call when trying to start outgoing call: \(recipientId)")
             return
         }
 

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -47,7 +47,7 @@ extension CallUIAdaptee {
         AssertIsOnMainThread()
 
         guard self.callService.call == nil else {
-            Logger.debug("unexpectedly found an existing call when trying to start outgoing call: \(recipientId)")
+            Logger.info("unexpectedly found an existing call when trying to start outgoing call: \(recipientId)")
             return
         }
 


### PR DESCRIPTION
This shouldn't assert; it's not a bug, just an edge case that we want to handle properly.

PTAL @michaelkirk 