### PR TITLE
Mkirk/coordinate busy

### DIFF
--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -405,7 +405,7 @@ protocol CallServiceObserver: class {
         Logger.verbose("\(TAG) receivedCallOffer for thread:\(thread)")
         let newCall = SignalCall.incomingCall(localId: UUID(), remotePhoneNumber: thread.contactIdentifier(), signalingId: callId)
 
-        guard call == nil else {
+        guard call == nil || Environment.getCurrent().phoneManager.hasOngoingCall() else {
             // TODO on iOS10+ we can use CallKit to swap calls rather than just returning busy immediately.
             Logger.verbose("\(TAG) receivedCallOffer for thread: \(thread) but we're already in call: \(call)")
 

--- a/Signal/src/phone/PhoneManager.m
+++ b/Signal/src/phone/PhoneManager.m
@@ -6,6 +6,7 @@
 #import "CallAudioManager.h"
 #import "PhoneManager.h"
 #import "RecentCallManager.h"
+#import "Signal-Swift.h"
 
 @implementation PhoneManager
 
@@ -92,12 +93,13 @@
     int64_t prevSession   = lastIncomingSessionId;
     lastIncomingSessionId = session.sessionId;
 
-    if ([currentCallControllerObservable.currentValue callState].futureTermination.isIncomplete) {
+    if ([currentCallControllerObservable.currentValue callState].futureTermination.isIncomplete || [self hasOngoingWebRTCCall]) {
         if (session.sessionId == prevSession) {
             Environment.errorNoter(@"Ignoring duplicate incoming call signal.", session, false);
             return;
         }
 
+        DDLogInfo(@"%@ Missed call due to Busy.", self.tag);
         [Environment.getCurrent.recentCallManager addMissedCallDueToBusy:session];
 
         [[CallConnectUtil asyncSignalTooBusyToAnswerCallWithSessionDescriptor:session] catchDo:^(id error) {
@@ -146,6 +148,11 @@
     return [self.curCallController callState].futureTermination.isIncomplete;
 }
 
+- (BOOL)hasOngoingWebRTCCall
+{
+    return !![Environment getCurrent].callService.call;
+}
+
 - (CallController *)curCallController {
     return currentCallControllerObservable.currentValue;
 }
@@ -170,6 +177,18 @@
     [[self curCallController] terminateWithReason:CallTerminationType_UncategorizedFailure
                                   withFailureInfo:@"PhoneManager terminated"
                                    andRelatedInfo:nil];
+}
+
+#pragma mark - Logging
+
++ (NSString *)tag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag
+{
+    return self.class.tag;
 }
 
 @end

--- a/Signal/src/phone/PhoneManager.m
+++ b/Signal/src/phone/PhoneManager.m
@@ -139,7 +139,11 @@
 
 - (BOOL)hasOngoingCall
 {
-    return self.curCallController != nil;
+    if (!self.curCallController) {
+        return NO;
+    }
+
+    return [self.curCallController callState].futureTermination.isIncomplete;
 }
 
 - (CallController *)curCallController {


### PR DESCRIPTION
scenarios:

Alice is on redphone call with Bob.
Charlie calls Alice via webRTC
Charlie sees busy <-- new behavior

Alice is on webRTC call with Bob.
Charlie calls Alice via Redphone
Charlie sees busy  <-- new behavior

Also https://github.com/WhisperSystems/Signal-iOS/commit/df2d3e5a36afc4d5cc7a94b3f69b02740d14cf96 fixes a related bug where subsequent redphone calls were inappropriately not allowed due to improperly checking for an "ongoing" redphone call.

PTAL @charlesmchen 