### PR TITLE
Ensure audio service observation of call is always correctly wired up.

### DIFF
--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -83,6 +83,11 @@ fileprivate let timeoutSeconds = 60
 // All Observer methods will be invoked from the main thread.
 protocol CallServiceObserver: class {
     /**
+     * Fired whenever the call changes.
+     */
+    func didUpdateCall(call: SignalCall?)
+
+    /**
      * Fired whenever the local or remote video track become active or inactive.
      */
     func didUpdateVideoTracks(localVideoTrack: RTCVideoTrack?,
@@ -132,6 +137,10 @@ protocol CallServiceObserver: class {
             call?.addObserverAndSyncState(observer: self)
 
             updateIsVideoEnabled()
+
+            for observer in observers {
+                observer.value?.didUpdateCall(call:call)
+            }
         }
     }
 

--- a/Signal/src/view controllers/CallViewController.swift
+++ b/Signal/src/view controllers/CallViewController.swift
@@ -774,6 +774,10 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
 
     // MARK: - CallServiceObserver
 
+    internal func didUpdateCall(call: SignalCall?) {
+        // Do nothing.
+    }
+
     internal func didUpdateVideoTracks(localVideoTrack: RTCVideoTrack?,
                                        remoteVideoTrack: RTCVideoTrack?) {
         AssertIsOnMainThread()


### PR DESCRIPTION
Previously, `CallUIAdapter` ensured that `CallAudioService` was always wired up to observe any call by doing so in the "only two" pathways for new calls: `reportIncomingCall()` and `startOutgoingCall()`.  The problem is that `OutboundCallInitiator` now uses a new pathway: `startAndShowOutgoingCall()`.  Rather than adding the right wiring there, I decided to DRY this up and by making `CallUIAdapter` observe `CallService` and setting up the observation anytime `CallService`'s call property is set.  That should handle all of these cases and future-proof us as well.

PTAL @michaelkirk 
