### PR TITLE
contact can be nil for outgoing redphone call

### DIFF
--- a/Signal/src/call/OutboundCallInitiator.swift
+++ b/Signal/src/call/OutboundCallInitiator.swift
@@ -91,9 +91,9 @@ import Foundation
         Logger.info("\(TAG) Placing redphone call to: \(recipientId)")
 
         let number = PhoneNumber.tryParsePhoneNumber(fromUserSpecifiedText: recipientId)
-        let contact = self.contactsManager.latestContact(for: number)
         assert(number != nil)
-        assert(contact != nil)
+
+        let contact: Contact? = self.contactsManager.latestContact(for: number)
 
         redphoneManager.initiateOutgoingCall(to: contact, atRemoteNumber: number)
 


### PR DESCRIPTION
Now that it's easier to start a thread with a non-contact recipient this
is more relevant.

// FREEBIE

PTAL @charlesmchen 
