### PR TITLE
Prevent CallKit timeout when placing outgoing call

### DIFF
--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -228,14 +228,9 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
             return
         }
 
-        self.callService.handleOutgoingCall(call).then { () -> Void in
-            action.fulfill()
-            self.provider.reportOutgoingCall(with: call.localId, startedConnectingAt: nil)
-            }.catch { error in
-                Logger.error("\(self.TAG) error \(error) in \(#function)")
-                self.callManager.removeCall(call)
-                action.fail()
-        }
+        _ = self.callService.handleOutgoingCall(call)
+        action.fulfill()
+        self.provider.reportOutgoingCall(with: call.localId, startedConnectingAt: nil)
     }
 
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {


### PR DESCRIPTION
More fallout from the outbound call timeout which was causing all
CallKit calls not promptly answered to show "Call Failed"

Inserting the timeout exacerbated an existing issue: We can't wait for
long before choosing to fulfill/fail an action without CallKit falling
over and assuming the call failed.

We don't actually need to consider the case where we "fail to initiate"
the outgoing call. Instead we say it started "successfully, and if there
is an error, the existing promise error handling will fail the call at
that time.

// FREEBIE
