### PR TITLE
Add accessibility labels for the new group and settings navbar buttons. FREEBIE.

### DIFF
--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -119,6 +119,9 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
     [self.navigationController.navigationBar setTranslucent:NO];
     [self useOWSBackButton];
     
+    self.navigationItem.rightBarButtonItem.accessibilityLabel = NSLocalizedString(
+        @"CREATE_NEW_GROUP", @"Accessibility label for the create group new group button");
+
     self.tableView.estimatedRowHeight = (CGFloat)60.0;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
 

--- a/Signal/src/view controllers/SignalsViewController.m
+++ b/Signal/src/view controllers/SignalsViewController.m
@@ -117,9 +117,11 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
     [self.segmentedControl addTarget:self
                               action:@selector(swappedSegmentedControl)
                     forControlEvents:UIControlEventValueChanged];
-    self.navigationItem.titleView = self.segmentedControl;
+    UINavigationItem *navigationItem = self.navigationItem;
+    navigationItem.titleView = self.segmentedControl;
     [self.segmentedControl setSelectedSegmentIndex:0];
-
+    navigationItem.leftBarButtonItem.accessibilityLabel = NSLocalizedString(
+        @"SETTINGS_BUTTON_ACCESSIBILITY", @"Accessibility hint for the settings button");
 
     if ([self.traitCollection respondsToSelector:@selector(forceTouchCapability)] &&
         (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable)) {

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -124,6 +124,9 @@
 /* No comment provided by engineer. */
 "COUNTRYCODE_SELECT_TITLE" = "Select Country Code";
 
+/* Accessibility label for the create new group button. */
+"CREATE_NEW_GROUP" = "Create new group";
+
 /* {{number of days}} embedded in strings, e.g. 'Alice updated disappearing messages expiration to {{5 days}}'. See other *_TIME_AMOUNT strings */
 "DAYS_TIME_AMOUNT" = "%u days";
 
@@ -779,6 +782,9 @@
 
 /* Table cell label */
 "SETTINGS_BLOCK_ON_IDENTITY_CHANGE_TITLE" = "Require Approval on Change";
+
+/* Settings button accessibility hint */
+"SETTINGS_BUTTON_ACCESSIBILITY" = "Settings";
 
 /* No comment provided by engineer. */
 "SETTINGS_CLEAR_HISTORY" = "Clear History Logs";


### PR DESCRIPTION
Add accessibility labels for the Create New Group and Settings navigation bar buttons. FREEBIE.

### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
* iPhone 6S Simulator
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Adds an accessibility label to the new group navigation bar button, which was previously labelled as 'btnGroup White', and an explicit label for the Settings navigation button, which was previously inheriting the name of its image ('settings'), but is now localizable.

(It's worth noting that making the storyboards localizable would be the 'real' solution here, but is a much larger change. The strings here (and their eventual translations) should still be useful once that change occurs).