### PR TITLE
Issue1602 + small bug fix FREEBIE

### DIFF
--- a/Signal/src/view controllers/FingerprintViewController.m
+++ b/Signal/src/view controllers/FingerprintViewController.m
@@ -281,7 +281,7 @@ NS_ASSUME_NONNULL_BEGIN
         [UIAlertController alertControllerWithTitle:failureTitle
                                             message:error.localizedDescription
                                      preferredStyle:UIAlertControllerStyleAlert];
-    
+
     NSString *dismissText = NSLocalizedString(@"DISMISS_BUTTON_TEXT", nil);
     UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleCancel handler: ^(UIAlertAction *action){
         
@@ -311,7 +311,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     DDLogWarn(@"%@ Identity verification failed with error: %@", self.tag, error);
 }
-
 
 - (void)dismissViewControllerAnimated:(BOOL)flag completion:(nullable void (^)(void))completion
 {

--- a/Signal/src/view controllers/FingerprintViewController.m
+++ b/Signal/src/view controllers/FingerprintViewController.m
@@ -266,7 +266,7 @@ NS_ASSUME_NONNULL_BEGIN
             [self dismissViewControllerAnimated:true completion:nil];
     }];
     [successAlertController addAction:dismissAction];
-    
+
     [self presentViewController:successAlertController animated:YES completion:nil];
 }
 

--- a/Signal/src/view controllers/FingerprintViewController.m
+++ b/Signal/src/view controllers/FingerprintViewController.m
@@ -262,8 +262,8 @@ NS_ASSUME_NONNULL_BEGIN
                                             message:successDescription
                                      preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *dismissAction =
-    [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){
-        [self dismissViewControllerAnimated:true completion:nil];
+        [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){
+            [self dismissViewControllerAnimated:true completion:nil];
     }];
     [successAlertController addAction:dismissAction];
     
@@ -276,11 +276,11 @@ NS_ASSUME_NONNULL_BEGIN
     if (error.code != OWSErrorCodeUserError) {
         failureTitle = NSLocalizedString(@"FAILED_VERIFICATION_TITLE", @"alert title");
     } // else no title. We don't want to show a big scary "VERIFICATION FAILED" when it's just user error.
-    
+
     UIAlertController *failureAlertController =
-    [UIAlertController alertControllerWithTitle:failureTitle
-                                        message:error.localizedDescription
-                                 preferredStyle:UIAlertControllerStyleAlert];
+        [UIAlertController alertControllerWithTitle:failureTitle
+                                            message:error.localizedDescription
+                                     preferredStyle:UIAlertControllerStyleAlert];
     
     NSString *dismissText = NSLocalizedString(@"DISMISS_BUTTON_TEXT", nil);
     UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleCancel handler: ^(UIAlertAction *action){
@@ -299,7 +299,7 @@ NS_ASSUME_NONNULL_BEGIN
                          completion:nil];
     }];
     [failureAlertController addAction:dismissAction];
-    
+
     // TODO
     //        NSString retryText = NSLocalizedString(@"RETRY_BUTTON_TEXT", nil);
     //        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:retryText style:UIAlertActionStyleDefault
@@ -308,7 +308,7 @@ NS_ASSUME_NONNULL_BEGIN
     //        }];
     //        [failureAlertController addAction:retryAction];
     [self presentViewController:failureAlertController animated:YES completion:nil];
-    
+
     DDLogWarn(@"%@ Identity verification failed with error: %@", self.tag, error);
 }
 

--- a/Signal/src/view controllers/FingerprintViewController.m
+++ b/Signal/src/view controllers/FingerprintViewController.m
@@ -208,12 +208,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)showScanner
 {
-    // Camera stops capturing when "sharing" while in capture mode.
-    // Also, it's less obvious whats being "shared" at this point,
-    // so just disable sharing when in capture mode.
-    self.shareButton.enabled = NO;
-
     [self ows_askForCameraPermissions:^{
+        
+        // Camera stops capturing when "sharing" while in capture mode.
+        // Also, it's less obvious whats being "shared" at this point,
+        // so just disable sharing when in capture mode.
+        self.shareButton.enabled = NO;
+
         DDLogInfo(@"%@ Showing Scanner", self.tag);
         self.qrScanningView.hidden = NO;
         self.scanningInstructions.hidden = NO;

--- a/Signal/src/view controllers/FingerprintViewController.m
+++ b/Signal/src/view controllers/FingerprintViewController.m
@@ -255,16 +255,18 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *successTitle = NSLocalizedString(@"SUCCESSFUL_VERIFICATION_TITLE", nil);
     NSString *dismissText = NSLocalizedString(@"DISMISS_BUTTON_TEXT", nil);
     NSString *descriptionFormat = NSLocalizedString(
-        @"SUCCESSFUL_VERIFICATION_DESCRIPTION", @"Alert body after verifying privacy with {{other user's name}}");
+                                                    @"SUCCESSFUL_VERIFICATION_DESCRIPTION", @"Alert body after verifying privacy with {{other user's name}}");
     NSString *successDescription = [NSString stringWithFormat:descriptionFormat, self.contactName];
     UIAlertController *successAlertController =
-        [UIAlertController alertControllerWithTitle:successTitle
-                                            message:successDescription
-                                     preferredStyle:UIAlertControllerStyleAlert];
+    [UIAlertController alertControllerWithTitle:successTitle
+                                        message:successDescription
+                                 preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *dismissAction =
-        [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleDefault handler:nil];
+    [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){
+        [self dismissViewControllerAnimated:true completion:nil];
+    }];
     [successAlertController addAction:dismissAction];
-
+    
     [self presentViewController:successAlertController animated:YES completion:nil];
 }
 
@@ -274,16 +276,31 @@ NS_ASSUME_NONNULL_BEGIN
     if (error.code != OWSErrorCodeUserError) {
         failureTitle = NSLocalizedString(@"FAILED_VERIFICATION_TITLE", @"alert title");
     } // else no title. We don't want to show a big scary "VERIFICATION FAILED" when it's just user error.
-
+    
     UIAlertController *failureAlertController =
-        [UIAlertController alertControllerWithTitle:failureTitle
-                                            message:error.localizedDescription
-                                     preferredStyle:UIAlertControllerStyleAlert];
-
+    [UIAlertController alertControllerWithTitle:failureTitle
+                                        message:error.localizedDescription
+                                 preferredStyle:UIAlertControllerStyleAlert];
+    
     NSString *dismissText = NSLocalizedString(@"DISMISS_BUTTON_TEXT", nil);
-    UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleCancel handler:nil];
+    
+    UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleCancel handler: ^(UIAlertAction *action){
+        
+        // Restore previous layout
+        self.shareButton.enabled = YES;
+        self.qrScanningView.hidden = YES;
+        self.scanningInstructions.hidden = YES;
+        [UIView animateWithDuration:0.4
+                              delay:0.0
+                            options:UIViewAnimationOptionCurveEaseInOut
+                         animations:^{
+                             self.instructionsContainer.alpha = 1.0f;
+                             self.qrContainer.frame = self.scanningContainer.frame;
+                         }
+                         completion:nil];
+    }];
     [failureAlertController addAction:dismissAction];
-
+    
     // TODO
     //        NSString retryText = NSLocalizedString(@"RETRY_BUTTON_TEXT", nil);
     //        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:retryText style:UIAlertActionStyleDefault
@@ -292,7 +309,7 @@ NS_ASSUME_NONNULL_BEGIN
     //        }];
     //        [failureAlertController addAction:retryAction];
     [self presentViewController:failureAlertController animated:YES completion:nil];
-
+    
     DDLogWarn(@"%@ Identity verification failed with error: %@", self.tag, error);
 }
 

--- a/Signal/src/view controllers/FingerprintViewController.m
+++ b/Signal/src/view controllers/FingerprintViewController.m
@@ -255,12 +255,12 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *successTitle = NSLocalizedString(@"SUCCESSFUL_VERIFICATION_TITLE", nil);
     NSString *dismissText = NSLocalizedString(@"DISMISS_BUTTON_TEXT", nil);
     NSString *descriptionFormat = NSLocalizedString(
-                                                    @"SUCCESSFUL_VERIFICATION_DESCRIPTION", @"Alert body after verifying privacy with {{other user's name}}");
+        @"SUCCESSFUL_VERIFICATION_DESCRIPTION", @"Alert body after verifying privacy with {{other user's name}}");
     NSString *successDescription = [NSString stringWithFormat:descriptionFormat, self.contactName];
     UIAlertController *successAlertController =
-    [UIAlertController alertControllerWithTitle:successTitle
-                                        message:successDescription
-                                 preferredStyle:UIAlertControllerStyleAlert];
+        [UIAlertController alertControllerWithTitle:successTitle
+                                            message:successDescription
+                                     preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *dismissAction =
     [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){
         [self dismissViewControllerAnimated:true completion:nil];
@@ -283,7 +283,6 @@ NS_ASSUME_NONNULL_BEGIN
                                  preferredStyle:UIAlertControllerStyleAlert];
     
     NSString *dismissText = NSLocalizedString(@"DISMISS_BUTTON_TEXT", nil);
-    
     UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:dismissText style:UIAlertActionStyleCancel handler: ^(UIAlertAction *action){
         
         // Restore previous layout
@@ -312,6 +311,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     DDLogWarn(@"%@ Identity verification failed with error: %@", self.tag, error);
 }
+
 
 - (void)dismissViewControllerAnimated:(BOOL)flag completion:(nullable void (^)(void))completion
 {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6, iOS 10.2.1
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
This pull request should provide a solution to issue #1602 
The new behaviour is kept very simple and works as follows:
- When the keys are successfully scanned, the fingerprintViewController is dismissed
- When the key verification fails, the original layout is restored, so that the keys can be rescanned

This includes a small bugfix: When camera access is denied, then the share button will be disabled. This should be fixed by disabling the share button only after permissions are checked.

This is my first contribution. It is kept very simple, so there should be no problems merging this.