### PR TITLE
TURN-only option, and for unknown caller

### DIFF
--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -120,7 +120,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
     private var remoteVideoTrack: RTCVideoTrack?
     private var cameraConstraints: RTCMediaConstraints
 
-    init(iceServers: [RTCIceServer], delegate: PeerConnectionClientDelegate, callDirection: CallDirection) {
+    init(iceServers: [RTCIceServer], delegate: PeerConnectionClientDelegate, callDirection: CallDirection, useTurnOnly: Bool) {
         AssertIsOnMainThread()
 
         self.iceServers = iceServers
@@ -130,6 +130,12 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         configuration.iceServers = iceServers
         configuration.bundlePolicy = .maxBundle
         configuration.rtcpMuxPolicy = .require
+        if useTurnOnly {
+            Logger.debug("\(TAG) using iceTransportPolicy: relay")
+            configuration.iceTransportPolicy = .relay
+        } else {
+            Logger.debug("\(TAG) using iceTransportPolicy: default")
+        }
 
         let connectionConstraintsDict = ["DtlsSrtpKeyAgreement": "true"]
         connectionConstraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: connectionConstraintsDict)

--- a/Signal/src/environment/PropertyListPreferences.h
+++ b/Signal/src/environment/PropertyListPreferences.h
@@ -71,6 +71,11 @@ extern NSString *const PropertyListPreferencesKeyEnableDebugLog;
 - (BOOL)isCallKitEnabled;
 - (void)setIsCallKitEnabled:(BOOL)flag;
 
+#pragma mark direct call connectivity (non-TURN)
+
+- (BOOL)isDirectCallConnectionAllowed;
+- (void)setIsDirectCallConnectionAllowed:(BOOL)flag;
+
 #pragma mark - Block on Identity Change
 
 - (BOOL)shouldBlockOnIdentityChange;

--- a/Signal/src/environment/PropertyListPreferences.m
+++ b/Signal/src/environment/PropertyListPreferences.m
@@ -23,6 +23,7 @@ NSString *const PropertyListPreferencesKeyHasRegisteredVoipPush = @"VOIPPushEnab
 NSString *const PropertyListPreferencesKeyLastRecordedPushToken = @"LastRecordedPushToken";
 NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecordedVoipToken";
 NSString *const PropertyListPreferencesKeyCallKitEnabled = @"CallKitEnabled";
+NSString *const PropertyListPreferencesKeyDirectCallConnectionAllowed = @"DirectCallConnectionAllowed";
 
 @implementation PropertyListPreferences
 
@@ -138,6 +139,9 @@ NSString *const PropertyListPreferencesKeyCallKitEnabled = @"CallKitEnabled";
 
 - (void)setLoggingEnabled:(BOOL)flag
 {
+    // Logging preferences are stored in UserDefaults instead of the database, so that we can (optionally) start
+    // logging before the database is initialized. This is important because sometimes there are problems *with* the
+    // database initialization, and without logging it would be hard to track down.
     [NSUserDefaults.standardUserDefaults setObject:@(flag) forKey:PropertyListPreferencesKeyEnableDebugLog];
     [NSUserDefaults.standardUserDefaults synchronize];
 }
@@ -180,6 +184,21 @@ NSString *const PropertyListPreferencesKeyCallKitEnabled = @"CallKitEnabled";
 - (void)setIsCallKitEnabled:(BOOL)flag
 {
     [self setValueForKey:PropertyListPreferencesKeyCallKitEnabled toValue:@(flag)];
+}
+
+#pragma mark direct call connectivity (non-TURN)
+
+// Allow callers to connect directly, when desirable, vs. enforcing TURN only proxy connectivity
+
+- (BOOL)isDirectCallConnectionAllowed
+{
+    NSNumber *preference = [self tryGetValueForKey:PropertyListPreferencesKeyDirectCallConnectionAllowed];
+    return preference ? [preference boolValue] : YES;
+}
+
+- (void)setIsDirectCallConnectionAllowed:(BOOL)flag
+{
+    [self setValueForKey:PropertyListPreferencesKeyDirectCallConnectionAllowed toValue:@(flag)];
 }
 
 #pragma mark Notification Preferences

--- a/Signal/src/view controllers/PrivacySettingsTableViewController.m
+++ b/Signal/src/view controllers/PrivacySettingsTableViewController.m
@@ -14,16 +14,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     PrivacySettingsTableViewControllerSectionIndexScreenSecurity,
+    PrivacySettingsTableViewControllerSectionIndexCalling,
     PrivacySettingsTableViewControllerSectionIndexHistoryLog,
-    PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange
+    PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange,
+    PrivacySettingsTableViewControllerSectionIndex_Count // meta section to track how many sections
 };
 
 @interface PrivacySettingsTableViewController ()
 
 @property (nonatomic, strong) UITableViewCell *enableScreenSecurityCell;
 @property (nonatomic, strong) UISwitch *enableScreenSecuritySwitch;
+
+@property (nonatomic) UITableViewCell *callsAllowDirectConnectionCell;
+@property (nonatomic) UISwitch *callsAllowDirectConnectionSwitch;
+
 @property (nonatomic, strong) UITableViewCell *blockOnIdentityChangeCell;
 @property (nonatomic, strong) UISwitch *blockOnIdentityChangeSwitch;
+
 @property (nonatomic, strong) UITableViewCell *clearHistoryLogCell;
 
 @end
@@ -59,6 +66,16 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
                                         action:@selector(didToggleScreenSecuritySwitch:)
                               forControlEvents:UIControlEventTouchUpInside];
 
+    // Allow calls to connect directly vs. using TURN exclusively
+    self.callsAllowDirectConnectionCell = [UITableViewCell new];
+    self.callsAllowDirectConnectionCell.textLabel.text = NSLocalizedString(@"SETTINGS_CALLING_ALLOW_DIRECT_CONNECTION_TITLE", @"Table cell label");
+    self.callsAllowDirectConnectionSwitch = [UISwitch new];
+    self.callsAllowDirectConnectionCell.accessoryView = self.callsAllowDirectConnectionSwitch;
+    [self.callsAllowDirectConnectionSwitch setOn:[Environment.preferences isDirectCallConnectionAllowed]];
+    [self.callsAllowDirectConnectionSwitch addTarget:self
+                                              action:@selector(didToggleCallsAllowDirectConnectionSwitch:)
+                                    forControlEvents:UIControlEventTouchUpInside];
+
     // Clear History Log Cell
     self.clearHistoryLogCell                = [[UITableViewCell alloc] init];
     self.clearHistoryLogCell.textLabel.text = NSLocalizedString(@"SETTINGS_CLEAR_HISTORY", @"");
@@ -79,12 +96,14 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 3;
+    return PrivacySettingsTableViewControllerSectionIndex_Count;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     switch (section) {
         case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
+            return 1;
+        case PrivacySettingsTableViewControllerSectionIndexCalling:
             return 1;
         case PrivacySettingsTableViewControllerSectionIndexHistoryLog:
             return 1;
@@ -100,6 +119,8 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     switch (section) {
         case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
             return NSLocalizedString(@"SETTINGS_SCREEN_SECURITY_DETAIL", nil);
+        case PrivacySettingsTableViewControllerSectionIndexCalling:
+            return NSLocalizedString(@"SETTINGS_CALLING_ALLOW_DIRECT_CONNECTION_DESCRIPTION", @"User settings section footer, a detailed explanation");
         case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
             return NSLocalizedString(
                 @"SETTINGS_BLOCK_ON_IDENITY_CHANGE_DETAIL", @"User settings section footer, a detailed explanation");
@@ -112,6 +133,8 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     switch (indexPath.section) {
         case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
             return self.enableScreenSecurityCell;
+        case PrivacySettingsTableViewControllerSectionIndexCalling:
+            return self.callsAllowDirectConnectionCell;
         case PrivacySettingsTableViewControllerSectionIndexHistoryLog:
             return self.clearHistoryLogCell;
         case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
@@ -128,6 +151,8 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     switch (section) {
         case PrivacySettingsTableViewControllerSectionIndexScreenSecurity:
             return NSLocalizedString(@"SETTINGS_SECURITY_TITLE", @"Section header");
+        case PrivacySettingsTableViewControllerSectionIndexCalling:
+            return NSLocalizedString(@"SETTINGS_SECTION_TITLE_CALLING", @"settings topic header for table section");
         case PrivacySettingsTableViewControllerSectionIndexHistoryLog:
             return NSLocalizedString(@"SETTINGS_HISTORYLOG_TITLE", @"Section header");
         case PrivacySettingsTableViewControllerSectionIndexBlockOnIdentityChange:
@@ -180,6 +205,13 @@ typedef NS_ENUM(NSInteger, PrivacySettingsTableViewControllerSectionIndex) {
     BOOL enabled = self.blockOnIdentityChangeSwitch.isOn;
     DDLogInfo(@"%@ toggled blockOnIdentityChange: %@", self.tag, enabled ? @"ON" : @"OFF");
     [Environment.preferences setShouldBlockOnIdentityChange:enabled];
+}
+
+- (void)didToggleCallsAllowDirectConnectionSwitch:(UISwitch *)sender
+{
+    BOOL enabled = sender.isOn;
+    DDLogInfo(@"%@ toggled callsAllowDirectConnection: %@", self.tag, enabled ? @"ON" : @"OFF");
+    [Environment.preferences setIsDirectCallConnectionAllowed:enabled];
 }
 
 #pragma mark - Log util

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 /* No comment provided by engineer. */
 "COUNTRYCODE_SELECT_TITLE" = "Select Country Code";
 
-/* Accessibility label for the create new group button. */
+/* Accessibility label for the create group new group button */
 "CREATE_NEW_GROUP" = "Create new group";
 
 /* {{number of days}} embedded in strings, e.g. 'Alice updated disappearing messages expiration to {{5 days}}'. See other *_TIME_AMOUNT strings */
@@ -253,6 +253,9 @@
 /* Generic notice when message failed to send. */
 "ERROR_DESCRIPTION_CLIENT_SENDING_FAILURE" = "Failed to send message.";
 
+/* Error mesage indicating that message send is disabled due to prekey update failures */
+"ERROR_DESCRIPTION_MESSAGE_SEND_DISABLED_PREKEY_UPDATE_FAILURES" = "ERROR_DESCRIPTION_MESSAGE_SEND_DISABLED_PREKEY_UPDATE_FAILURES";
+
 /* Generic error used whenver Signal can't contact the server */
 "ERROR_DESCRIPTION_NO_INTERNET" = "Signal was unable to connect to the internet. Please try from another WiFi network or use mobile data.";
 
@@ -348,9 +351,6 @@
 
 /* No comment provided by engineer. */
 "GROUP_REMOVING_FAILED" = "Failed to leave group";
-
-/* Accessibilty label for group settings */
-"GROUP_SETTINGS_LABEL" = "Group settings";
 
 /* No comment provided by engineer. */
 "GROUP_TITLE_CHANGED" = "Title is now '%@'. ";
@@ -567,7 +567,8 @@
 /* No comment provided by engineer. */
 "OK" = "Ok";
 
-/* Button text which opens the settings app */
+/* Button text which opens the settings app
+   Label for button which opens the settings UI */
 "OPEN_SETTINGS_BUTTON" = "Settings";
 
 /* Info Message when {{other user}} disables or doesn't support disappearing messages */
@@ -783,8 +784,14 @@
 /* Table cell label */
 "SETTINGS_BLOCK_ON_IDENTITY_CHANGE_TITLE" = "Require Approval on Change";
 
-/* Settings button accessibility hint */
+/* Accessibility hint for the settings button */
 "SETTINGS_BUTTON_ACCESSIBILITY" = "Settings";
+
+/* User settings section footer, a detailed explanation */
+"SETTINGS_CALLING_ALLOW_DIRECT_CONNECTION_DESCRIPTION" = "Increases call quality, but may share your IP address with people who call you, provided they are in your contacts, and people you call.";
+
+/* Table cell label */
+"SETTINGS_CALLING_ALLOW_DIRECT_CONNECTION_TITLE" = "Allow Direct Connection";
 
 /* No comment provided by engineer. */
 "SETTINGS_CLEAR_HISTORY" = "Clear History Logs";


### PR DESCRIPTION
Now, by default, we only use TURN for incoming calls from unknown
contacts. We will potentially directly connect for outgoing calls and
for incoming calls from known contacts.

Optionally, the user can disable direct connection altogether, at the
cost of some call quality.

PTAL @charlesmchen 
