### PR TITLE
fix tests / CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Carthage"]
 	path = Carthage
-	url = git@github.com:WhisperSystems/Signal-Carthage.git
+	url = https://github.com/WhisperSystems/Signal-Carthage.git

--- a/Signal/test/call/PeerConnectionClientTest.swift
+++ b/Signal/test/call/PeerConnectionClientTest.swift
@@ -55,7 +55,7 @@ class PeerConnectionClientTest: XCTestCase {
 
         let iceServers = [RTCIceServer]()
         clientDelegate = FakePeerConnectionClientDelegate()
-        client = PeerConnectionClient(iceServers: iceServers, delegate: clientDelegate, callDirection: .outgoing)
+        client = PeerConnectionClient(iceServers: iceServers, delegate: clientDelegate, callDirection: .outgoing, useTurnOnly: false)
         peerConnection = client.peerConnectionForTests()
         dataChannel = client.dataChannelForTests()
     }


### PR DESCRIPTION
partial revert of 8b3b283

Easier for travis to fetch from https URL. If you as a developer want to
push to the submodule via git (maintainers only) you'll have to modify
your local git remotes after checkout:

    cd Carthage
    git remote origin set-url git@github.com:WhisperSystems/Signal-Carthage.git


PTAL @charlesmchen 