### PR TITLE
requestAccessForMediaType completionHandler to be called in UI thread…

### DIFF
--- a/Signal/src/util/UIViewController+CameraPermissions.m
+++ b/Signal/src/util/UIViewController+CameraPermissions.m
@@ -46,7 +46,9 @@ NS_ASSUME_NONNULL_BEGIN
     } else if (status == AVAuthorizationStatusNotDetermined) {
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
             if (granted) {
-                permissionsGrantedCallback();
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    permissionsGrantedCallback();
+                });
             }
         }];
     } else {


### PR DESCRIPTION
…. This leads to inconsistent behaviour once the permission is given

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6S Plus, iOS 9.3.5
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
fixes #1588, completion handler of requestAccessForMediaTypeVideo to be called in main thread
Since completion handler not called in main thread able to see the behaviour mentioned in #1588. After the fix works as expected 