### PR TITLE
Convert "is logging enabled" methods to class methods so that they ca…

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -83,7 +83,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     loggingIsEnabled = TRUE;
     [DebugLogger.sharedLogger enableTTYLogging];
 #elif RELEASE
-    loggingIsEnabled = Environment.preferences.loggingIsEnabled;
+    loggingIsEnabled = PropertyListPreferences.loggingIsEnabled;
 #endif
     if (loggingIsEnabled) {
         [DebugLogger.sharedLogger enableFileLogging];
@@ -134,8 +134,9 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     self.window.rootViewController = [storyboard instantiateInitialViewController];
     [self.window makeKeyAndVisible];
 
-    [VersionMigrations performUpdateCheck]; // this call must be made after environment has been initialized because in
-                                            // general upgrade may depend on environment
+    // performUpdateCheck must be invoked after Environment has been initialized because
+    // upgrade process may depend on Environment.
+    [VersionMigrations performUpdateCheck];
 
     // Accept push notification when app is not open
     NSDictionary *remoteNotif = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];

--- a/Signal/src/environment/Environment.m
+++ b/Signal/src/environment/Environment.m
@@ -244,6 +244,8 @@ static Environment *environment = nil;
 
 + (PropertyListPreferences *)preferences
 {
+    OWSAssert([Environment getCurrent] != nil);
+    OWSAssert([Environment getCurrent].preferences != nil);
     return [Environment getCurrent].preferences;
 }
 

--- a/Signal/src/environment/Migrations/OWS102MoveLoggingPreferenceToUserDefaults.m
+++ b/Signal/src/environment/Migrations/OWS102MoveLoggingPreferenceToUserDefaults.m
@@ -27,7 +27,7 @@ static NSString *const OWS102MoveLoggingPreferenceToUserDefaultsMigrationId = @"
 
     if (existingValue) {
         DDLogInfo(@"%@ assigning existing value: %@", self.tag, existingValue);
-        [[Environment preferences] setLoggingEnabled:[existingValue boolValue]];
+        [PropertyListPreferences setLoggingEnabled:[existingValue boolValue]];
 
         if (![existingValue boolValue]) {
             DDLogInfo(@"%@ Disabling file logger after one-time log settings migration.", self.tag);

--- a/Signal/src/environment/PropertyListPreferences.h
+++ b/Signal/src/environment/PropertyListPreferences.h
@@ -43,8 +43,8 @@ extern NSString *const PropertyListPreferencesKeyEnableDebugLog;
 - (BOOL)getHasArchivedAMessage;
 - (void)setHasArchivedAMessage:(BOOL)enabled;
 
-- (BOOL)loggingIsEnabled;
-- (void)setLoggingEnabled:(BOOL)flag;
++ (BOOL)loggingIsEnabled;
++ (void)setLoggingEnabled:(BOOL)flag;
 
 - (BOOL)screenSecurityIsEnabled;
 - (void)setScreenSecurity:(BOOL)flag;
@@ -61,8 +61,8 @@ extern NSString *const PropertyListPreferencesKeyEnableDebugLog;
 
 - (TSImageQuality)imageUploadQuality;
 
-- (nullable NSString *)lastRanVersion;
-- (NSString *)setAndGetCurrentVersion;
++ (nullable NSString *)lastRanVersion;
++ (NSString *)setAndGetCurrentVersion;
 
 #pragma mark - Calling
 

--- a/Signal/src/environment/PropertyListPreferences.m
+++ b/Signal/src/environment/PropertyListPreferences.m
@@ -127,7 +127,7 @@ NSString *const PropertyListPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddr
     [self setValueForKey:PropertyListPreferencesKeyHasRegisteredVoipPush toValue:@(enabled)];
 }
 
-- (BOOL)loggingIsEnabled
++ (BOOL)loggingIsEnabled
 {
     NSNumber *preference = [NSUserDefaults.standardUserDefaults objectForKey:PropertyListPreferencesKeyEnableDebugLog];
 
@@ -138,18 +138,13 @@ NSString *const PropertyListPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddr
     }
 }
 
-- (void)setLoggingEnabled:(BOOL)flag
++ (void)setLoggingEnabled:(BOOL)flag
 {
     // Logging preferences are stored in UserDefaults instead of the database, so that we can (optionally) start
     // logging before the database is initialized. This is important because sometimes there are problems *with* the
     // database initialization, and without logging it would be hard to track down.
     [NSUserDefaults.standardUserDefaults setObject:@(flag) forKey:PropertyListPreferencesKeyEnableDebugLog];
     [NSUserDefaults.standardUserDefaults synchronize];
-}
-
-- (nullable NSString *)lastRanVersion
-{
-    return [NSUserDefaults.standardUserDefaults objectForKey:PropertyListPreferencesKeyLastRunSignalVersion];
 }
 
 - (void)setHasSentAMessage:(BOOL)enabled
@@ -162,7 +157,12 @@ NSString *const PropertyListPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddr
     [self setValueForKey:PropertyListPreferencesKeyHasArchivedAMessage toValue:@(enabled)];
 }
 
-- (NSString *)setAndGetCurrentVersion
++ (nullable NSString *)lastRanVersion
+{
+    return [NSUserDefaults.standardUserDefaults objectForKey:PropertyListPreferencesKeyLastRunSignalVersion];
+}
+
++ (NSString *)setAndGetCurrentVersion
 {
     NSString *currentVersion =
         [NSString stringWithFormat:@"%@", NSBundle.mainBundle.infoDictionary[@"CFBundleVersion"]];

--- a/Signal/src/environment/VersionMigrations.m
+++ b/Signal/src/environment/VersionMigrations.m
@@ -31,7 +31,11 @@
 
 + (void)performUpdateCheck
 {
-    NSString *previousVersion = Environment.preferences.lastRanVersion;
+    // performUpdateCheck must be invoked after Environment has been initialized because
+    // upgrade process may depend on Environment.
+    OWSAssert([Environment getCurrent]);
+
+    NSString *previousVersion = PropertyListPreferences.lastRanVersion;
     NSString *currentVersion =
         [NSString stringWithFormat:@"%@", NSBundle.mainBundle.infoDictionary[@"CFBundleVersion"]];
 
@@ -43,7 +47,7 @@
         OWSDatabaseMigrationRunner *runner =
             [[OWSDatabaseMigrationRunner alloc] initWithStorageManager:[TSStorageManager sharedManager]];
         [runner assumeAllExistingMigrationsRun];
-        [Environment.preferences setAndGetCurrentVersion];
+        [PropertyListPreferences setAndGetCurrentVersion];
         return;
     }
 
@@ -90,7 +94,7 @@
     }
 
     [[[OWSDatabaseMigrationRunner alloc] initWithStorageManager:[TSStorageManager sharedManager]] runAllOutstanding];
-    [Environment.preferences setAndGetCurrentVersion];
+    [PropertyListPreferences setAndGetCurrentVersion];
 }
 
 + (BOOL)isVersion:(NSString *)thisVersionString

--- a/Signal/src/view controllers/AdvancedSettingsTableViewController.m
+++ b/Signal/src/view controllers/AdvancedSettingsTableViewController.m
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSInteger, AdvancedSettingsTableViewControllerSection) {
     self.enableLogCell.textLabel.text         = NSLocalizedString(@"SETTINGS_ADVANCED_DEBUGLOG", @"");
     self.enableLogCell.userInteractionEnabled = YES;
     self.enableLogSwitch = [[UISwitch alloc] initWithFrame:CGRectZero];
-    [self.enableLogSwitch setOn:[Environment.preferences loggingIsEnabled]];
+    [self.enableLogSwitch setOn:[PropertyListPreferences loggingIsEnabled]];
     [self.enableLogSwitch addTarget:self
                              action:@selector(didToggleEnableLogSwitch:)
                    forControlEvents:UIControlEventTouchUpInside];
@@ -161,7 +161,7 @@ typedef NS_ENUM(NSInteger, AdvancedSettingsTableViewControllerSection) {
         [[DebugLogger sharedLogger] enableFileLogging];
     }
     
-    [Environment.preferences setLoggingEnabled:sender.isOn];
+    [PropertyListPreferences setLoggingEnabled:sender.isOn];
     [self.tableView reloadData];
 }
 


### PR DESCRIPTION
…n safely be used before Environment has been initialized.

Fixes: https://github.com/WhisperSystems/Signal-iOS/issues/1708

PTAL @michaelkirk 