### PR TITLE
Limit size of outgoing text messages.

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -853,6 +853,29 @@ typedef enum : NSUInteger {
          senderDisplayName:(NSString *)senderDisplayName
                       date:(NSDate *)date
 {
+    text = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+    // Limit outgoing text messages to 64kb.
+    //
+    // TODO: Convert large text messages to attachments
+    // which are presented as normal text messages.
+    const NSUInteger kMaxTextMessageSize = 64 * 1024;
+    if (text.length > kMaxTextMessageSize) {
+        UIAlertController *controller =
+        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"CONVERSATION_VIEW_TEXT_MESSAGE_TOO_LARGE_ALERT_TITLE",
+                                                                      @"The title of the 'text message too large' alert.")
+                                            message:NSLocalizedString(@"CONVERSATION_VIEW_TEXT_MESSAGE_TOO_LARGE_ALERT_MESSAGE",
+                                                                      @"The message of the 'text message too large' alert.")
+                                     preferredStyle:UIAlertControllerStyleAlert];
+        [controller addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                       style:UIAlertActionStyleDefault
+                                                     handler:nil]];
+        [self presentViewController:controller
+                           animated:YES
+                         completion:nil];
+        return;
+    }
+    
     if (text.length > 0) {
         if ([Environment.preferences soundInForeground]) {
             [JSQSystemSoundPlayer jsq_playMessageSentSound];

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -860,7 +860,7 @@ typedef enum : NSUInteger {
     // TODO: Convert large text messages to attachments
     // which are presented as normal text messages.
     const NSUInteger kMaxTextMessageSize = 64 * 1024;
-    if (text.length > kMaxTextMessageSize) {
+    if ([text lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > kMaxTextMessageSize) {
         UIAlertController *controller =
         [UIAlertController alertControllerWithTitle:NSLocalizedString(@"CONVERSATION_VIEW_TEXT_MESSAGE_TOO_LARGE_ALERT_TITLE",
                                                                       @"The title of the 'text message too large' alert.")

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -52,9 +52,6 @@
 /* No comment provided by engineer. */
 "ATTACHMENT" = "Attachment";
 
-/* Label for 'cancel' button in the 'attachment approval' dialog. */
-"ATTACHMENT_APPROVAL_CANCEL_BUTTON" = "Cancel";
-
 /* Title for the 'attachment approval' dialog. */
 "ATTACHMENT_APPROVAL_DIALOG_TITLE" = "Attachment";
 
@@ -147,6 +144,12 @@
 
 /* title for conversation settings screen */
 "CONVERSATION_SETTINGS" = "Conversation Settings";
+
+/* The message of the 'text message too large' alert. */
+"CONVERSATION_VIEW_TEXT_MESSAGE_TOO_LARGE_ALERT_MESSAGE" = "This message is too long to send.";
+
+/* The title of the 'text message too large' alert. */
+"CONVERSATION_VIEW_TEXT_MESSAGE_TOO_LARGE_ALERT_TITLE" = "Error";
 
 /* ActionSheet title */
 "CORRUPTED_SESSION_DESCRIPTION" = "Resetting your session will allow you to receive future messages from %@, but it will not recover any already corrupted messages.";


### PR DESCRIPTION
Easy way to test to send some large text (e.g. http://norvig.com/big.txt ) from desktop, copy & paste in iOS, try to send.

<img width="345" alt="screen shot 2017-03-14 at 12 19 38 pm" src="https://cloud.githubusercontent.com/assets/625803/23907635/83a2978c-08b0-11e7-96e6-ff273762f6fc.png">

PTAL @michaelkirk 