### PR TITLE
Adjust some constants to never cut off audio playback length

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
@@ -170,9 +170,9 @@
         _durationLabel.text   = [self formatDuration:player.duration];
         _durationLabel.font   = [UIFont systemFontOfSize:14];
         [_durationLabel sizeToFit];
-        _durationLabel.frame = CGRectMake((size.width - _durationLabel.frame.size.width) - 10,
+        _durationLabel.frame = CGRectMake((size.width - _durationLabel.frame.size.width) - 16,
                                           _durationLabel.frame.origin.y,
-                                          _durationLabel.frame.size.width,
+                                          _durationLabel.frame.size.width + 8,
                                           AUDIO_BAR_HEIGHT);
         _durationLabel.backgroundColor = [UIColor clearColor];
         _durationLabel.textColor       = [UIColor whiteColor];


### PR DESCRIPTION


### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE, iOS 10.2.1
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
This fixes one of the several issues I have with playback of Audio messages, I ran into roadblocks fixing the hitbox for the play button for example. These are before and after of the same timestamp. I played with the constants until something was about to count down from 1:32 to 0:00 without being hidden and didn't look too terrible. Powers of 2 all the way.

![before](https://cloud.githubusercontent.com/assets/2245080/23911980/5ace3412-08d6-11e7-9418-b7bec2599ecf.jpg)
![after](https://cloud.githubusercontent.com/assets/2245080/23911979/5acc23e8-08d6-11e7-9aca-50497f661f32.jpg)


