### PR TITLE
Fix non-contact lookup for non-US users.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -136,7 +136,7 @@ CHECKOUT OPTIONS:
     :commit: a3c843cc8a423c5924c663490978f81dba34d04e
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: ca81e139bbe968dbaf41445ea4c92d45f57f6f5f
+    :commit: 312f398dddb5eac902ae5a7739f0ae814caa7912
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 877ac7438be3ad0b45ef5ca3969574e4b97112bf
@@ -169,4 +169,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7088298933b189805c955880c8d1be86da3078af
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.1.1

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -35,10 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 // A list of possible phone numbers parsed from the search text as
 // E164 values.
-@property (nonatomic) NSArray *searchPhoneNumbers;
+@property (nonatomic) NSArray<NSString *> *searchPhoneNumbers;
 // A list of possible phone numbers parsed from the search text
 // that correspond to known accounts as E164 values.
-@property (nonatomic) NSArray *searchPhoneNumberWithAccounts;
+@property (nonatomic) NSArray<NSString *> *searchPhoneNumberWithAccounts;
 // This dictionary is used to cache the set of phone numbers
 // which are known to correspond to Signal accounts.
 @property (nonatomic, nonnull, readonly) NSMutableSet *phoneNumberAccountSet;
@@ -63,7 +63,6 @@ typedef NS_ENUM(NSInteger, AdvancedSettingsTableViewControllerSection) {
     MessageComposeTableViewControllerSection_Count // meta section
 };
 
-NSString *const MessageComposeTableViewControllerCellInvite = @"ContactTableInviteCell";
 NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableViewCell";
 
 @implementation MessageComposeTableViewController
@@ -350,7 +349,7 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
     OWSContactsSearcher *contactsSearcher = [[OWSContactsSearcher alloc] initWithContacts: self.contacts];
     self.searchResults = [contactsSearcher filterWithString:searchText];
 
-    NSMutableArray *searchPhoneNumbers = [NSMutableArray new];
+    NSMutableArray<NSString *> *searchPhoneNumbers = [NSMutableArray new];
     for (PhoneNumber *phoneNumber in [PhoneNumber tryParsePhoneNumbersFromsUserSpecifiedText:searchText
                                                                            clientPhoneNumber:[TSStorageManager localNumber]]) {
         [searchPhoneNumbers addObject:phoneNumber.toE164];
@@ -398,7 +397,7 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
                                               }];
 }
 
-- (void)setSearchPhoneNumbers:(NSArray *)searchPhoneNumbers {
+- (void)setSearchPhoneNumbers:(NSArray<NSString *> *)searchPhoneNumbers {
     if ([_searchPhoneNumbers isEqual:searchPhoneNumbers]) {
         return;
     }
@@ -411,16 +410,17 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
 }
 
 - (void)ensureSearchPhoneNumberWithAccounts {
-    NSMutableArray *searchPhoneNumberWithAccounts = [NSMutableArray new];
+    NSMutableArray<NSString *> *searchPhoneNumberWithAccounts = [NSMutableArray new];
     for (NSString *phoneNumber in self.searchPhoneNumbers) {
-        if ([self.phoneNumberAccountSet containsObject:phoneNumber]) {
+        if ([self.phoneNumberAccountSet containsObject:phoneNumber] &&
+            ![searchPhoneNumberWithAccounts containsObject:phoneNumber]) {
             [searchPhoneNumberWithAccounts addObject:phoneNumber];
         }
     }
     self.searchPhoneNumberWithAccounts = searchPhoneNumberWithAccounts;
 }
 
-- (void)setSearchPhoneNumberWithAccounts:(NSArray *)searchPhoneNumberWithAccounts {
+- (void)setSearchPhoneNumberWithAccounts:(NSArray<NSString *> *)searchPhoneNumberWithAccounts {
     if ([_searchPhoneNumberWithAccounts isEqual:searchPhoneNumberWithAccounts]) {
         return;
     }
@@ -604,6 +604,7 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
         
         ContactTableViewCell *cell = (ContactTableViewCell *)[tableView
             dequeueReusableCellWithIdentifier:MessageComposeTableViewControllerCellContact];
+        cell.hidden = NO;
 
         [cell configureWithContact:[self contactForIndexPath:indexPath] contactsManager:self.contactsManager];
 


### PR DESCRIPTION
https://github.com/WhisperSystems/SignalServiceKit/pull/130

* Modify `PhoneNumber` to identify possibly multiple phone numbers for given user input by trying to prepend:
  * "+" 
  * The country code for the current user's phone number.
  * The country code that corresponds to the phone's default region.
* Surface multiple possible matches as "invite via SMS".
* Check multiple possible matches for Signal accounts and show "start conversation with X".

Note that these screenshots were all taken on a device registered in UK (+44).

![img_0010](https://cloud.githubusercontent.com/assets/625803/23970534/da9bbbd8-09a8-11e7-8bdf-8552f9a917d8.PNG)
![img_0009](https://cloud.githubusercontent.com/assets/625803/23970535/dac5ba46-09a8-11e7-9328-251674bb0131.PNG)
![img_0008](https://cloud.githubusercontent.com/assets/625803/23970536/dae21fc4-09a8-11e7-84a4-a3128a7f74fa.PNG)
![img_0007](https://cloud.githubusercontent.com/assets/625803/23970537/dae61138-09a8-11e7-9afb-afe6fa720877.PNG)
![img_0006](https://cloud.githubusercontent.com/assets/625803/23970538/dae8eac0-09a8-11e7-9c31-ad4d5048f72a.PNG)

PTAL @michaelkirk 

Fixes: https://github.com/WhisperSystems/Signal-iOS/issues/1833
