### PR TITLE
Fix "Call failed" due to deadlock when immediately terminating call

### DIFF
--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -456,7 +456,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         AssertIsOnMainThread()
         Logger.debug("\(TAG) in \(#function)")
 
-        PeerConnectionClient.signalingQueue.sync {
+        PeerConnectionClient.signalingQueue.async {
             assert(self.peerConnection != nil)
             self.terminateInternal()
         }

--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -272,6 +272,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
         Logger.debug("\(TAG) Received \(#function) CXEndCallAction")
         guard let call = callManager.callWithLocalId(action.callUUID) else {
+            Logger.error("\(self.TAG) in \(#function) trying to end unknown call with localId: \(action.callUUID)")
             action.fail()
             return
         }
@@ -340,7 +341,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     func provider(_ provider: CXProvider, timedOutPerforming action: CXAction) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(TAG) Timed out \(#function)")
+        Logger.debug("\(TAG) Timed out \(#function) while performing \(action)")
 
         // React to the action timeout if necessary, such as showing an error UI.
     }


### PR DESCRIPTION
It's not clear why we were ever dispatching `sync` here.

Before this:

Place a call
See "connecting..."
Hang up
UI hangs for ~5 seconds
See "call failed" on CallKit screen
Press "cancel" on CallKit screen
returned to responsive app.

PTAL @charlesmchen 
