### PR TITLE
ui bugfix for draft messages

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -2441,6 +2441,7 @@ typedef enum : NSUInteger {
           dispatch_async(dispatch_get_main_queue(), ^{
             [self.inputToolbar.contentView.textView setText:placeholder];
             [self textViewDidChange:self.inputToolbar.contentView.textView];
+            [self reloadInputToolbarSizeIfNeeded];
           });
         }];
 }


### PR DESCRIPTION
update height of input bar after adding draft to input bar.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 5
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Bug:
1. Create a draft longer than one line of text.
2. Click 'back' to view of all messages.
3. Click back into conversation.
The input bar will only be one line of text, and it only grows if you add more text, super annoying, especially if you are going between two conversations happening at the same time :-( My biggest peeve.

I've attached screenshots of before and after this change. I said it in my other pull request but if i'm doing anything wrong or could be coding this / doing git things better please let me know! Thank!

![img_0540](https://cloud.githubusercontent.com/assets/9736319/24115845/0ec6e1be-0d7b-11e7-92d2-2e1846dc59cf.jpg)
![img_0541](https://cloud.githubusercontent.com/assets/9736319/24115846/0ec8333e-0d7b-11e7-879a-edd41d8503a7.jpg)



