### PR TITLE
Copy images to pasteboard as data, not UIImage.

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
@@ -113,6 +113,9 @@
     }
 
     if (action == @selector(copy:)) {
+        // We should always copy to the pasteboard as data, not an UIImage.
+        // The pasteboard should has as specific as UTI type as possible and
+        // data support should be far more general than UIImage support.
         OWSAssert(self.attachment.filePath.length > 0);
         NSString *fileExtension = [self.attachment.filePath pathExtension];
         NSArray *utiTypes = (__bridge_transfer NSArray *)UTTypeCreateAllIdentifiersForTag(

--- a/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
@@ -7,6 +7,7 @@
 #import "JSQMediaItem+OWS.h"
 #import "TSAttachmentStream.h"
 #import <JSQMessagesViewController/JSQMessagesMediaViewBubbleImageMasker.h>
+#import <MobileCoreServices/MobileCoreServices.h>
 
 @interface TSPhotoAdapter ()
 
@@ -112,7 +113,18 @@
     }
 
     if (action == @selector(copy:)) {
-        UIPasteboard.generalPasteboard.image = self.image;
+        OWSAssert(self.attachment.filePath.length > 0);
+        NSString *fileExtension = [self.attachment.filePath pathExtension];
+        NSArray *utiTypes = (__bridge_transfer NSArray *)UTTypeCreateAllIdentifiersForTag(
+            kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, (CFStringRef) @"public.image");
+        NSString *utiType = (NSString *)kUTTypeImage;
+        OWSAssert(utiTypes.count > 0);
+        if (utiTypes.count > 0) {
+            utiType = utiTypes[0];
+        }
+
+        NSData *data = [NSData dataWithContentsOfURL:self.attachment.mediaURL];
+        [UIPasteboard.generalPasteboard setData:data forPasteboardType:utiType];
         return;
     } else if (action == NSSelectorFromString(@"save:")) {
         UIImageWriteToSavedPhotosAlbum(self.image, nil, nil, nil);

--- a/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
@@ -246,6 +246,7 @@
     if ([self isVideo]) {
         if (action == @selector(copy:)) {
             NSData *data = [NSData dataWithContentsOfURL:self.fileURL];
+            // TODO: This assumes all videos are mp4.
             [UIPasteboard.generalPasteboard setData:data forPasteboardType:(NSString *)kUTTypeMPEG4];
             return;
         } else if (action == NSSelectorFromString(@"save:")) {
@@ -260,7 +261,6 @@
             NSData *data = [NSData dataWithContentsOfURL:self.fileURL];
 
             NSString *pasteboardType = [MIMETypeUtil getSupportedExtensionFromAudioMIMEType:self.contentType];
-            [UIPasteboard.generalPasteboard setData:data forPasteboardType:(NSString *)UIPasteboardNameGeneral];
 
             if ([pasteboardType isEqualToString:@"mp3"]) {
                 [UIPasteboard.generalPasteboard setData:data forPasteboardType:(NSString *)kUTTypeMP3];


### PR DESCRIPTION
This is why copy & paste of images on iOS 9 isn't working.

PTAL @michaelkirk 