### PR TITLE
Check microphone permissions before starting a call FREEBIE

### DIFF
--- a/Signal/src/call/OutboundCallInitiator.swift
+++ b/Signal/src/call/OutboundCallInitiator.swift
@@ -46,7 +46,27 @@ import Foundation
             return false
         }
 
-        callUIAdapter.startAndShowOutgoingCall(recipientId: recipientId)
+        // Check for microphone permissions
+        AVAudioSession.sharedInstance().requestRecordPermission { status in
+            // Here the permissions are either granted or denied
+            guard status == true else {
+                Logger.warn("\(self.TAG) aborting due to missing microphone permissions.")
+                self.showAlertNoPermission()
+                return
+            }
+            callUIAdapter.startAndShowOutgoingCall(recipientId: recipientId)
+        }
         return true
+    }
+    
+    /// Cleanup and present alert for no permissions
+    private func showAlertNoPermission() {
+        let alertTitle = NSLocalizedString("CALL_AUDIO_PERMISSION_TITLE", comment:"Alert Title")
+        let alertMessage = NSLocalizedString("CALL_AUDIO_PERMISSION_MESSAGE", comment:"Alert message")
+        let alertController = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        let dismiss = NSLocalizedString("DISMISS_BUTTON_TEXT", comment: "Generic short text for button to dismiss a dialog")
+        let dismissAction = UIAlertAction(title: dismiss, style: .default)
+        alertController.addAction(dismissAction)
+        UIApplication.shared.keyWindow?.rootViewController?.present(alertController, animated: true, completion: nil)
     }
 }

--- a/Signal/src/call/OutboundCallInitiator.swift
+++ b/Signal/src/call/OutboundCallInitiator.swift
@@ -46,10 +46,13 @@ import Foundation
             return false
         }
 
+        
         // Check for microphone permissions
-        AVAudioSession.sharedInstance().requestRecordPermission { status in
+        // Alternative way without prompting for permissions:
+        // if AVAudioSession.sharedInstance().recordPermission() == .denied {
+        AVAudioSession.sharedInstance().requestRecordPermission { isGranted in
             // Here the permissions are either granted or denied
-            guard status == true else {
+            guard isGranted == true else {
                 Logger.warn("\(self.TAG) aborting due to missing microphone permissions.")
                 self.showAlertNoPermission()
                 return

--- a/Signal/src/call/OutboundCallInitiator.swift
+++ b/Signal/src/call/OutboundCallInitiator.swift
@@ -54,7 +54,7 @@ import Foundation
             // Here the permissions are either granted or denied
             guard isGranted == true else {
                 Logger.warn("\(self.TAG) aborting due to missing microphone permissions.")
-                self.showAlertNoPermission()
+                self.showNoMicrophonePermissionAlert()
                 return
             }
             callUIAdapter.startAndShowOutgoingCall(recipientId: recipientId)
@@ -63,13 +63,18 @@ import Foundation
     }
     
     /// Cleanup and present alert for no permissions
-    private func showAlertNoPermission() {
+    private func showNoMicrophonePermissionAlert() {
         let alertTitle = NSLocalizedString("CALL_AUDIO_PERMISSION_TITLE", comment:"Alert Title")
         let alertMessage = NSLocalizedString("CALL_AUDIO_PERMISSION_MESSAGE", comment:"Alert message")
         let alertController = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
         let dismiss = NSLocalizedString("DISMISS_BUTTON_TEXT", comment: "Generic short text for button to dismiss a dialog")
         let dismissAction = UIAlertAction(title: dismiss, style: .default)
+        let settingsString = NSLocalizedString("CALL_VIEW_SETTINGS_NAG_SHOW_CALL_SETTINGS", comment: "Settings button text")
+        let settingsAction = UIAlertAction(title: settingsString, style: .default) { _ in
+            UIApplication.shared.openURL(URL(string: UIApplicationOpenSettingsURLString)!)
+        }
         alertController.addAction(dismissAction)
-        UIApplication.shared.keyWindow?.rootViewController?.present(alertController, animated: true, completion: nil)
+        alertController.addAction(settingsAction)
+        UIApplication.shared.frontmostViewController?.present(alertController, animated: true, completion: nil)
     }
 }

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -79,6 +79,12 @@
 /* No comment provided by engineer. */
 "AUDIO_PERMISSION_MESSAGE" = "Signal requires access to your microphone to work properly. You can grant this permission in the Settings app >> Privacy >> Microphone >> Signal";
 
+/* Alert message when calling and permissions for microphone are missing */
+"CALL_AUDIO_PERMISSION_MESSAGE" = "Signal requires access to your microphone to make calls. You can grant this permission in the Settings app >> Privacy >> Microphone >> Signal";
+
+/* Alert title when calling and permissions for microphone are missing */
+"CALL_AUDIO_PERMISSION_TITLE" = "Call failed";
+
 /* Title for call interstitial view */
 "CALL_INTERSTITIAL_CALLING_LABEL" = "Calling...";
 

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -80,7 +80,7 @@
 "AUDIO_PERMISSION_MESSAGE" = "Signal requires access to your microphone to work properly. You can grant this permission in the Settings app >> Privacy >> Microphone >> Signal";
 
 /* Alert message when calling and permissions for microphone are missing */
-"CALL_AUDIO_PERMISSION_MESSAGE" = "Signal requires access to your microphone to make calls. You can grant this permission in the Settings app >> Privacy >> Microphone >> Signal";
+"CALL_AUDIO_PERMISSION_MESSAGE" = "Signal requires access to your microphone to make calls. You can grant this permission in the Settings app";
 
 /* Alert title when calling and permissions for microphone are missing */
 "CALL_AUDIO_PERMISSION_TITLE" = "Call failed";


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [X] My commits are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 6, iOS 10.2.1
 - [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description

Fixes #1886.

- Checks for microphone permissions before a call is placed. 
- When the permissions are disabled, an alert is shown with information on how to enable access.
- This will present a permission dialog on first access.
- Required strings for the alert are added to Localizable.strings