### PR TITLE
Rework country views in registration view.

### DIFF
--- a/Signal/src/view controllers/CountryCodeViewController.h
+++ b/Signal/src/view controllers/CountryCodeViewController.h
@@ -1,3 +1,7 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
 #import <UIKit/UIKit.h>
 
 @class CountryCodeViewController;
@@ -18,6 +22,7 @@
 @property (nonatomic, strong) IBOutlet UITableView *countryCodeTableView;
 @property (nonatomic, strong) IBOutlet UISearchBar *searchBar;
 @property (nonatomic, assign) id<CountryCodeViewControllerDelegate> delegate;
+@property (nonatomic, strong) NSString *countryCodeSelected;
 @property (nonatomic, strong) NSString *callingCodeSelected;
 @property (nonatomic, strong) NSString *countryNameSelected;
 

--- a/Signal/src/view controllers/CountryCodeViewController.m
+++ b/Signal/src/view controllers/CountryCodeViewController.m
@@ -56,6 +56,7 @@ static NSString *const kUnwindToCountryCodeWasSelectedSegue = @"UnwindToCountryC
     NSString *countryCode = _countryCodes[(NSUInteger)indexPath.row];
     _callingCodeSelected  = [PhoneNumberUtil callingCodeFromCountryCode:countryCode];
     _countryNameSelected  = [PhoneNumberUtil countryNameFromCountryCode:countryCode];
+    _countryCodeSelected = countryCode;
     [self.searchBar resignFirstResponder];
     [self performSegueWithIdentifier:kUnwindToCountryCodeWasSelectedSegue sender:self];
 }


### PR DESCRIPTION
Previously, our registration view would show a "country code" label (without a country name) when using the default country (derived from the device's region setting) and show the "country name" if the country was changed.  

I've changed this to always show the "country code" label and to always show the actual country code after the calling code.  Country names tend to be long, so there isn't enough space to show the "country code" label, the country name and the calling code.

The goal is to be more consistent and to always indicate to the user their current state.

### Before (default)

![screen shot 2017-03-26 at 3 57 08 pm](https://cloud.githubusercontent.com/assets/625803/24334690/f1943fe4-123c-11e7-806a-5c8839e0d73f.png)

### Before (after country changed)

![screen shot 2017-03-26 at 3 57 15 pm](https://cloud.githubusercontent.com/assets/625803/24334689/f1935160-123c-11e7-8e67-09931832dbce.png)

### After

![screen shot 2017-03-26 at 3 56 21 pm](https://cloud.githubusercontent.com/assets/625803/24334691/f19495f2-123c-11e7-8cf0-68637fbab9bd.png)

PTAL @michaelkirk 