### PR TITLE
Charlesmchen/refine new conversation view

### DIFF
--- a/Signal/src/environment/PropertyListPreferences.h
+++ b/Signal/src/environment/PropertyListPreferences.h
@@ -55,6 +55,9 @@ extern NSString *const PropertyListPreferencesKeyEnableDebugLog;
 + (nullable NSString *)lastRanVersion;
 + (NSString *)setAndGetCurrentVersion;
 
+- (BOOL)hasDeclinedNoContactsView;
+- (void)setHasDeclinedNoContactsView:(BOOL)value;
+
 #pragma mark - Calling
 
 #pragma mark Callkit

--- a/Signal/src/environment/PropertyListPreferences.m
+++ b/Signal/src/environment/PropertyListPreferences.m
@@ -25,6 +25,7 @@ NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecorded
 NSString *const PropertyListPreferencesKeyCallKitEnabled = @"CallKitEnabled";
 NSString *const PropertyListPreferencesKeyCallKitPrivacyEnabled = @"CallKitPrivacyEnabled";
 NSString *const PropertyListPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddress";
+NSString *const PropertyListPreferencesKeyHasDeclinedNoContactsView = @"hasDeclinedNoContactsView";
 
 @implementation PropertyListPreferences
 
@@ -164,6 +165,18 @@ NSString *const PropertyListPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddr
                                             forKey:PropertyListPreferencesKeyLastRunSignalVersion];
     [NSUserDefaults.standardUserDefaults synchronize];
     return currentVersion;
+}
+
+- (BOOL)hasDeclinedNoContactsView
+{
+    NSNumber *preference = [self tryGetValueForKey:PropertyListPreferencesKeyHasDeclinedNoContactsView];
+    // Default to NO.
+    return preference ? [preference boolValue] : NO;
+}
+
+- (void)setHasDeclinedNoContactsView:(BOOL)value
+{
+    [self setValueForKey:PropertyListPreferencesKeyHasDeclinedNoContactsView toValue:@(value)];
 }
 
 #pragma mark - Calling

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -25,7 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) UISearchController *searchController;
 @property (nonatomic) UIActivityIndicatorView *activityIndicator;
-@property (nonatomic) UIBarButtonItem *addGroup;
 @property (nonatomic) UIView *loadingBackgroundView;
 
 @property (nonatomic, copy) NSArray<Contact *> *contacts;
@@ -240,35 +239,20 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
 
 - (void)showLoadingBackgroundView:(BOOL)show {
     if (show && !self.isBackgroundViewHidden) {
-        _addGroup = self.navigationItem.rightBarButtonItem != nil ? _addGroup : self.navigationItem.rightBarButtonItem;
-        self.navigationItem.rightBarButtonItem = nil;
         self.searchController.searchBar.hidden = YES;
         self.tableView.backgroundView          = _loadingBackgroundView;
         self.refreshControl                    = nil;
         self.tableView.backgroundView.opaque   = YES;
     } else {
         [self initializeRefreshControl];
-        self.navigationItem.rightBarButtonItem =
-            self.navigationItem.rightBarButtonItem != nil ? self.navigationItem.rightBarButtonItem : _addGroup;
         self.searchController.searchBar.hidden = NO;
         self.tableView.backgroundView          = nil;
     }
 }
 
-
 - (void)showEmptyBackgroundView:(BOOL)show {
     if (show) {
         self.refreshControl = nil;
-        _addGroup = self.navigationItem.rightBarButtonItem != nil ? _addGroup : self.navigationItem.rightBarButtonItem;
-        self.navigationItem.rightBarButtonItem =
-            [[UIBarButtonItem alloc] initWithImage:[[UIImage imageNamed:@"btnRefresh--white"]
-                                                       imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal]
-                                             style:UIBarButtonItemStylePlain
-                                            target:self
-                                            action:@selector(refreshContacts)];
-        self.navigationItem.rightBarButtonItem.imageInsets = UIEdgeInsetsMake(8, 8, 8, 8);
-
-
         self.inviteCell.hidden = YES;
         self.searchController.searchBar.hidden = YES;
         self.tableView.backgroundView = self.noSignalContactsView;
@@ -276,8 +260,6 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
     } else {
         [self initializeRefreshControl];
         self.refreshControl.enabled = YES;
-        self.navigationItem.rightBarButtonItem =
-            self.navigationItem.rightBarButtonItem != nil ? self.navigationItem.rightBarButtonItem : _addGroup;
         self.searchController.searchBar.hidden = NO;
         self.tableView.backgroundView          = nil;
         self.inviteCell.hidden = NO;
@@ -330,7 +312,6 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
 
     [self.tableView reloadData];
 }
-
 
 #pragma mark - UISearchBarDelegate
 

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -135,8 +135,8 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
     self.title = NSLocalizedString(@"MESSAGE_COMPOSEVIEW_TITLE", @"");
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
 
     if ([self.contacts count] == 0) {
         [self showEmptyBackgroundView:YES];

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -730,6 +730,7 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
 }
 
 - (IBAction)closeAction:(id)sender {
+    [self.searchController setActive:NO];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nonnull, readonly) NSMutableSet *phoneNumberAccountSet;
 
 @property (nonatomic) BOOL isNoContactsViewVisible;
+@property (nonatomic) UIBarButtonItem *createGroupBarButtonItem;
 
 @end
 
@@ -114,7 +115,8 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
 - (void)viewDidLoad {
     [super viewDidLoad];
     [self.navigationController.navigationBar setTranslucent:NO];
-    
+
+    self.createGroupBarButtonItem = self.navigationItem.rightBarButtonItem;
     self.navigationItem.rightBarButtonItem.accessibilityLabel = NSLocalizedString(
         @"CREATE_NEW_GROUP", @"Accessibility label for the create group new group button");
 
@@ -225,7 +227,6 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
 - (void)hideBackgroundView {
     [[Environment preferences] setHasDeclinedNoContactsView:YES];
     
-//    [self showEmptyBackgroundView:NO];
     [self showEmptyBackgroundViewIfNecessary];
 }
 
@@ -266,13 +267,15 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
         self.searchController.searchBar.hidden = YES;
         self.tableView.backgroundView = self.noSignalContactsView;
         self.tableView.backgroundView.opaque   = YES;
+        self.navigationItem.rightBarButtonItem = nil;
     } else {
         [self initializeRefreshControl];
         self.refreshControl.enabled = YES;
         self.searchController.searchBar.hidden = NO;
         self.tableView.backgroundView          = nil;
+        self.navigationItem.rightBarButtonItem = self.createGroupBarButtonItem;
     }
-    
+
     [self.tableView reloadData];
 }
 


### PR DESCRIPTION
A group of fixes to "new conversation" view.

* Fix issue where the "stop" button triggers a janky animation instead of dismissing the view.
* Once user has skipped the "no contacts" view, never show it again.
* Don't show "new group" button in "no contacts" view.
* Fix edge cases around "new conversation" table cells showing up while "no contacts" view is visible.
* Simplify the "no contacts" state and logic.
  * Remove the "hide cells" logic and use a "is no contacts view visible" flag to hide all sections of the "new conversation" view's table.

PTAL @michaelkirk 