### PR TITLE
Charlesmchen/failed attachment downloads

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -131,7 +131,7 @@ CHECKOUT OPTIONS:
     :commit: 23a5d1b67afc4dd028198202e25fd2e06ce396d7
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :commit: fbd3859a850fc7cd187ffabef9108f88f787a832
+    :commit: 7bbbd2fb9da67eafe5309a8e6348ea5680ce5404
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 877ac7438be3ad0b45ef5ca3969574e4b97112bf

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -25,6 +25,7 @@
 #import <AxolotlKit/SessionCipher.h>
 #import <PromiseKit/AnyPromise.h>
 #import <SignalServiceKit/OWSDisappearingMessagesJob.h>
+#import <SignalServiceKit/OWSFailedAttachmentDownloadsJob.h>
 #import <SignalServiceKit/OWSFailedMessagesJob.h>
 #import <SignalServiceKit/OWSIncomingMessageReadObserver.h>
 #import <SignalServiceKit/OWSMessageSender.h>
@@ -176,6 +177,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
         // Mark all "attempting out" messages as "unsent", i.e. any messages that were not successfully
         // sent before the app exited should be marked as failures.
         [[[OWSFailedMessagesJob alloc] initWithStorageManager:[TSStorageManager sharedManager]] run];
+        [[[OWSFailedAttachmentDownloadsJob alloc] initWithStorageManager:[TSStorageManager sharedManager]] run];
 
         [AppStoreRating setupRatingLibrary];
     }];

--- a/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
@@ -155,12 +155,16 @@
                     TSAttachmentPointer *pointer = (TSAttachmentPointer *)attachment;
                     adapter.messageType          = TSInfoMessageAdapter;
 
-                    if (pointer.isDownloading) {
-                        adapter.messageBody = NSLocalizedString(@"ATTACHMENT_DOWNLOADING", nil);
-                    } else if (pointer.hasFailed) {
-                        adapter.messageBody = NSLocalizedString(@"ATTACHMENT_DOWNLOAD_FAILED", nil);
-                    } else {
-                        adapter.messageBody = NSLocalizedString(@"ATTACHMENT_QUEUED", nil);
+                    switch (pointer.state) {
+                        case TSAttachmentPointerStateEnqueued:
+                            adapter.messageBody = NSLocalizedString(@"ATTACHMENT_QUEUED", nil);
+                            break;
+                        case TSAttachmentPointerStateDownloading:
+                            adapter.messageBody = NSLocalizedString(@"ATTACHMENT_DOWNLOADING", nil);
+                            break;
+                        case TSAttachmentPointerStateFailed:
+                            adapter.messageBody = NSLocalizedString(@"ATTACHMENT_DOWNLOAD_FAILED", nil);
+                            break;
                     }
                 } else {
                     DDLogError(@"We retrieved an attachment that doesn't have a known type : %@",

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -1586,7 +1586,7 @@ typedef enum : NSUInteger {
 
                 // FIXME possible for pointer to get stuck in isDownloading state if app is closed while downloading.
                 // see: https://github.com/WhisperSystems/Signal-iOS/issues/1254
-                if (!pointer.isDownloading) {
+                if (pointer.state != TSAttachmentPointerStateDownloading) {
                     OWSAttachmentsProcessor *processor =
                         [[OWSAttachmentsProcessor alloc] initWithAttachmentPointer:pointer
                                                                     networkManager:self.networkManager];


### PR DESCRIPTION
* Convert TSAttachmentPointer state to an enum.
* Ensure all pre-change attachment downloads are marked as failed.
* Ensure all attachment downloads from previous app sessions are marked as failed.

PTAL @michaelkirk 

See: https://github.com/WhisperSystems/SignalServiceKit/pull/150
