### PR TITLE
Add explicit calling code state to registration view.

### DIFF
--- a/Signal/src/ViewControllers/RegistrationViewController.m
+++ b/Signal/src/ViewControllers/RegistrationViewController.m
@@ -16,6 +16,8 @@ static NSString *const kCodeSentSegue = @"codeSent";
 
 @interface RegistrationViewController ()
 
+@property (nonatomic) NSString *lastCallingCode;
+
 @end
 
 @implementation RegistrationViewController
@@ -70,6 +72,9 @@ static NSString *const kCodeSentSegue = @"codeSent";
 - (void)updateCountryWithName:(NSString *)countryName
                   callingCode:(NSString *)callingCode
                   countryCode:(NSString *)countryCode {
+
+    _lastCallingCode = callingCode;
+
     NSString *title = [NSString stringWithFormat:@"%@ (%@)",
                        callingCode,
                        countryCode.uppercaseString];
@@ -123,8 +128,7 @@ static NSString *const kCodeSentSegue = @"codeSent";
 }
 
 - (IBAction)sendCodeAction:(id)sender {
-    NSString *phoneNumber =
-        [NSString stringWithFormat:@"%@%@", _countryCodeButton.titleLabel.text, _phoneNumberTextField.text];
+    NSString *phoneNumber = [NSString stringWithFormat:@"%@%@", _lastCallingCode, _phoneNumberTextField.text];
     PhoneNumber *localNumber = [PhoneNumber tryParsePhoneNumberFromUserSpecifiedText:phoneNumber];
 
     [_sendCodeButton setEnabled:NO];


### PR DESCRIPTION
We need to separate "view state" from "view model state" in registration view, i.e. the current calling code (e.g. "+44") from how it is presented (e.g. "+44 (UK)").  We should be used the raw calling code when constructing the phone number to verify.  

This bug doesn't have any effect in production which is how it slipped through testing, but it's not right.

PTAL @michaelkirk 