### PR TITLE
right align blocked indicator

### DIFF
--- a/Signal/src/views/ContactTableViewCell.m
+++ b/Signal/src/views/ContactTableViewCell.m
@@ -71,16 +71,19 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableAttributedString *attributedText =
         [[contactsManager formattedFullNameForContact:contact font:self.nameLabel.font] mutableCopy];
     if (self.isBlocked) {
-        // Add whitespace between the contact name and the blocked indicator.
-        [attributedText appendAttributedString:[[NSAttributedString alloc] initWithString:@" " attributes:nil]];
-        [attributedText appendAttributedString:[[NSAttributedString alloc]
-                                                   initWithString:NSLocalizedString(@"CONTACT_BLOCKED_INDICATOR",
-                                                                      @"An indicator that a contact has been blocked.")
-                                                       attributes:@{
-                                                           NSFontAttributeName : [UIFont
-                                                               ows_mediumFontWithSize:self.nameLabel.font.pointSize],
-                                                           NSForegroundColorAttributeName : [UIColor blackColor],
-                                                       }]];
+        UILabel *blockedLabel = [[UILabel alloc] init];
+        blockedLabel.textAlignment = NSTextAlignmentRight;
+        blockedLabel.text
+            = NSLocalizedString(@"CONTACT_BLOCKED_INDICATOR", @"An indicator that a contact has been blocked.");
+        blockedLabel.font = [UIFont ows_mediumFontWithSize:self.nameLabel.font.pointSize];
+        blockedLabel.textColor = [UIColor blackColor];
+        [self addSubview:blockedLabel];
+        [blockedLabel sizeToFit];
+        [blockedLabel autoVCenterInSuperview];
+        [blockedLabel autoPinEdgeToSuperviewMargin:ALEdgeRight];
+        [blockedLabel autoPinEdge:ALEdgeLeft toEdge:ALEdgeRight ofView:self.textLabel];
+
+        self.accessoryView = blockedLabel;
     }
     self.nameLabel.attributedText = attributedText;
     self.avatarView.image =


### PR DESCRIPTION
A proposed addendum to #1934 

My concern is that in the existing approach "(Blocked)" looks like someone's last name, as opposed to part of the interface. And in the case of mr. "Michael Really Long Last Name" I can't see that he's blocked, since it's truncated.

We might go even farther:

- color the text differently,
- size it smaller
- move it vertically out of line with the name
- add an icon


## Before:

![before](https://cloud.githubusercontent.com/assets/217057/24725840/3c2649e2-1a1e-11e7-986c-dcf874fd6725.png)

## After:

![after](https://cloud.githubusercontent.com/assets/217057/24725846/3e6676e6-1a1e-11e7-9c1d-b5224d2e3994.png)



WDYT @charlesmchen ?
