### PR TITLE
Dismiss keyboard if user scrolls in “new 1:1 conversation” view.

### DIFF
--- a/Signal/src/ViewControllers/MessageComposeTableViewController.m
+++ b/Signal/src/ViewControllers/MessageComposeTableViewController.m
@@ -777,6 +777,13 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
     return 20;
 }
 
+#pragma mark - UIScrollViewDelegate
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+    [self.searchController.searchBar resignFirstResponder];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Same fix, another view.

PTAL @michaelkirk 