### PR TITLE
ensure session reset is decryptable

### DIFF
--- a/Signal/src/Jobs/SessionResetJob.swift
+++ b/Signal/src/Jobs/SessionResetJob.swift
@@ -1,5 +1,6 @@
-//  Created by Michael Kirk on 10/31/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 import Foundation
 import PromiseKit
@@ -37,19 +38,14 @@ class SessionResetJob: NSObject {
             message.save()
         }, failure: {error in
             Logger.error("\(self.TAG) failed to send EndSesionMessage with error: \(error.localizedDescription)")
-        });
+        })
     }
 
-    class func run(corruptedMessage: TSErrorMessage, contactThread: TSContactThread, messageSender: MessageSender, storageManager: TSStorageManager) {
+    class func run(contactThread: TSContactThread, messageSender: MessageSender, storageManager: TSStorageManager) {
         let job = self.init(recipientId: contactThread.contactIdentifier(),
                             thread: contactThread,
                             messageSender: messageSender,
                             storageManager: storageManager)
-        job.run()
-    }
-
-    class func run(recipientId: String, thread: TSThread, messageSender: MessageSender, storageManager: TSStorageManager) {
-        let job = self.init(recipientId: recipientId, thread: thread, messageSender: messageSender, storageManager: storageManager)
         job.run()
     }
 }

--- a/Signal/src/ViewControllers/MessagesViewController.m
+++ b/Signal/src/ViewControllers/MessagesViewController.m
@@ -2002,10 +2002,10 @@ typedef enum : NSUInteger {
                                                                             return;
                                                                     }
                                                                     TSContactThread *contactThread = (TSContactThread *)self.thread;
-                                                                    [OWSSessionResetJob runWithCorruptedMessage:message
-                                                                                                  contactThread:contactThread
-                                                                                                  messageSender:self.messageSender
-                                                                                                 storageManager:self.storageManager];
+                                                                    [OWSSessionResetJob
+                                                                        runWithContactThread:contactThread
+                                                                               messageSender:self.messageSender
+                                                                              storageManager:self.storageManager];
                                                                }];
     [alertController addAction:resetSessionAction];
     


### PR DESCRIPTION
This is based on #1941. It's related UX-wise, but not actually caused by the same issue.

Typically we're sending an EndSession message because our session has
diverged from the remote party's session. So if we send an EndSession
message, but ~~decrypt~~ encrypt it with our old out-of-sync session, how can we
expect them to be able to decrypt it?

Instead, by deleting the existing sessions, we'll fetch a new PreKey before sending, 
then start fresh with the remote side.

PTAL @charlesmchen