### PR TITLE
Reload data and invalidate layout whenever message view returns from …

### DIFF
--- a/Signal/src/ViewControllers/DebugUITableViewController.m
+++ b/Signal/src/ViewControllers/DebugUITableViewController.m
@@ -48,6 +48,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                           [DebugUITableViewController sendTextMessage:100
                                                                                                thread:thread];
                                                       }],
+                                      [OWSTableItem itemWithTitle:@"Send 1,000 messages (1/sec.)"
+                                                      actionBlock:^{
+                                                          [DebugUITableViewController sendTextMessage:1000
+                                                                                               thread:thread];
+                                                      }],
                                       [OWSTableItem itemWithTitle:@"Send text/x-signal-plain"
                                                       actionBlock:^{
                                                           [DebugUITableViewController sendOversizeTextMessage:thread];

--- a/Signal/src/ViewControllers/MessagesViewController.m
+++ b/Signal/src/ViewControllers/MessagesViewController.m
@@ -447,6 +447,10 @@ typedef enum : NSUInteger {
                                                      name:UIApplicationWillEnterForegroundNotification
                                                    object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(resetContentAndLayout)
+                                                     name:UIApplicationWillEnterForegroundNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(cancelReadTimer)
                                                      name:UIApplicationDidEnterBackgroundNotification
                                                    object:nil];
@@ -525,6 +529,11 @@ typedef enum : NSUInteger {
 
     [self ensureBlockStateIndicator];
 
+    [self resetContentAndLayout];
+}
+
+- (void)resetContentAndLayout
+{
     // Avoid layout corrupt issues and out-of-date message subtitles.
     [self.collectionView.collectionViewLayout invalidateLayout];
     [self.collectionView reloadData];


### PR DESCRIPTION
…background.

While writing the test plan I realized that we should also do this when the app returns from the background.

PTAL @michaelkirk 