### PR TITLE
Add explanation messages to the “block user alert” and the block sect…

### DIFF
--- a/Signal/src/ViewControllers/BlockListUIUtils.m
+++ b/Signal/src/ViewControllers/BlockListUIUtils.m
@@ -99,7 +99,10 @@ typedef void (^BlockAlertCompletionBlock)();
                                 [self formatDisplayNameForAlertTitle:displayName]];
 
     UIAlertController *actionSheetController =
-        [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+        [UIAlertController alertControllerWithTitle:title
+                                            message:NSLocalizedString(@"BLOCK_LIST_BLOCK_ALERT_MESSAGE",
+                                                        @"The message of the 'block user' action sheet.")
+                                     preferredStyle:UIAlertControllerStyleActionSheet];
 
     UIAlertAction *unblockAction = [UIAlertAction
         actionWithTitle:NSLocalizedString(@"BLOCK_LIST_BLOCK_BUTTON", @"Button label for the 'block' button")

--- a/Signal/src/ViewControllers/BlockListUIUtils.m
+++ b/Signal/src/ViewControllers/BlockListUIUtils.m
@@ -100,8 +100,8 @@ typedef void (^BlockAlertCompletionBlock)();
 
     UIAlertController *actionSheetController =
         [UIAlertController alertControllerWithTitle:title
-                                            message:NSLocalizedString(@"BLOCK_LIST_BLOCK_ALERT_MESSAGE",
-                                                        @"The message of the 'block user' action sheet.")
+                                            message:NSLocalizedString(@"BLOCK_BEHAVIOR_EXPLANATION",
+                                                                      @"An explanation of the consequences of blocking another user.")
                                      preferredStyle:UIAlertControllerStyleActionSheet];
 
     UIAlertAction *unblockAction = [UIAlertAction

--- a/Signal/src/ViewControllers/BlockListViewController.m
+++ b/Signal/src/ViewControllers/BlockListViewController.m
@@ -100,8 +100,9 @@ typedef NS_ENUM(NSInteger, BlockListViewControllerSection) {
 {
     switch (section) {
         case BlockListViewControllerSection_Add:
-            return NSLocalizedString(@"SETTINGS_BLOCK_LIST_FOOTER_TITLE", @"A footer title for the block list table.");
-        default:
+            return NSLocalizedString(@"BLOCK_BEHAVIOR_EXPLANATION",
+                                     @"An explanation of the consequences of blocking another user.");
+       default:
             return nil;
     }
 }

--- a/Signal/src/ViewControllers/OWSConversationSettingsTableViewController.m
+++ b/Signal/src/ViewControllers/OWSConversationSettingsTableViewController.m
@@ -261,8 +261,8 @@ static NSString *const OWSConversationSettingsTableViewControllerSegueShowGroupM
                                                                items:@[
                                                                    item,
                                                                ]];
-        section.footerTitle = NSLocalizedString(@"CONVERSATION_SETTINGS_BLOCK_FOOTER_TITLE",
-            @"A footer title for the block user option in the conversation settings");
+        section.footerTitle = NSLocalizedString(@"BLOCK_BEHAVIOR_EXPLANATION",
+            @"An explanation of the consequences of blocking another user.");
         [contents addSection:section];
     }
 

--- a/Signal/src/ViewControllers/OWSConversationSettingsTableViewController.m
+++ b/Signal/src/ViewControllers/OWSConversationSettingsTableViewController.m
@@ -194,6 +194,8 @@ static NSString *const OWSConversationSettingsTableViewControllerSegueShowGroupM
 
     __weak OWSConversationSettingsTableViewController *weakSelf = self;
 
+    // First section.
+
     NSMutableArray *firstSectionItems = [NSMutableArray new];
     if (!self.isGroupThread && self.thread.hasSafetyNumbers) {
         [firstSectionItems addObject:[OWSTableItem itemWithCustomCellBlock:^{
@@ -209,10 +211,30 @@ static NSString *const OWSConversationSettingsTableViewControllerSegueShowGroupM
                                          }]];
     }
 
+    [firstSectionItems addObject:[OWSTableItem itemWithCustomCellBlock:^{
+        weakSelf.toggleDisappearingMessagesCell.selectionStyle = UITableViewCellSelectionStyleNone;
+        return weakSelf.toggleDisappearingMessagesCell;
+    }
+                                                       customRowHeight:108.f
+                                                           actionBlock:nil]];
+
+    if (self.disappearingMessagesSwitch.isOn) {
+        [firstSectionItems addObject:[OWSTableItem itemWithCustomCellBlock:^{
+            weakSelf.disappearingMessagesDurationCell.selectionStyle = UITableViewCellSelectionStyleNone;
+            return weakSelf.disappearingMessagesDurationCell;
+        }
+                                                           customRowHeight:76.f
+                                                               actionBlock:nil]];
+    }
+
+    [contents addSection:[OWSTableSection sectionWithTitle:nil items:firstSectionItems]];
+
+    // Second section.
+
     if (!self.isGroupThread) {
         BOOL isBlocked = [[_blockingManager blockedPhoneNumbers] containsObject:self.signalId];
 
-        [firstSectionItems addObject:[OWSTableItem itemWithCustomCellBlock:^{
+        OWSTableItem *item = [OWSTableItem itemWithCustomCellBlock:^{
             UITableViewCell *cell = [UITableViewCell new];
             cell.textLabel.text = NSLocalizedString(
                 @"CONVERSATION_SETTINGS_BLOCK_THIS_USER", @"table cell label in conversation settings");
@@ -234,26 +256,17 @@ static NSString *const OWSConversationSettingsTableViewControllerSegueShowGroupM
             cell.accessoryView = blockUserSwitch;
             return cell;
         }
-                                                               actionBlock:nil]];
+                                                       actionBlock:nil];
+        OWSTableSection *section = [OWSTableSection sectionWithTitle:nil
+                                                               items:@[
+                                                                   item,
+                                                               ]];
+        section.footerTitle = NSLocalizedString(@"CONVERSATION_SETTINGS_BLOCK_FOOTER_TITLE",
+            @"A footer title for the block user option in the conversation settings");
+        [contents addSection:section];
     }
 
-    [firstSectionItems addObject:[OWSTableItem itemWithCustomCellBlock:^{
-        weakSelf.toggleDisappearingMessagesCell.selectionStyle = UITableViewCellSelectionStyleNone;
-        return weakSelf.toggleDisappearingMessagesCell;
-    }
-                                                       customRowHeight:108.f
-                                                           actionBlock:nil]];
-
-    if (self.disappearingMessagesSwitch.isOn) {
-        [firstSectionItems addObject:[OWSTableItem itemWithCustomCellBlock:^{
-            weakSelf.disappearingMessagesDurationCell.selectionStyle = UITableViewCellSelectionStyleNone;
-            return weakSelf.disappearingMessagesDurationCell;
-        }
-                                                           customRowHeight:76.f
-                                                               actionBlock:nil]];
-    }
-
-    [contents addSection:[OWSTableSection sectionWithTitle:nil items:firstSectionItems]];
+    // Third section.
 
     if (self.isGroupThread) {
         NSArray *groupItems = @[

--- a/Signal/src/ViewControllers/OWSTableViewController.h
+++ b/Signal/src/ViewControllers/OWSTableViewController.h
@@ -21,9 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OWSTableSection : NSObject
 
-@property (nonatomic, nullable) NSString *title;
+@property (nonatomic, nullable) NSString *headerTitle;
+@property (nonatomic, nullable) NSString *footerTitle;
 
-+ (OWSTableSection *)sectionWithTitle:(NSString *)title items:(NSArray<OWSTableItem *> *)items;
++ (OWSTableSection *)sectionWithTitle:(nullable NSString *)title items:(NSArray<OWSTableItem *> *)items;
 
 - (void)addItem:(OWSTableItem *)item;
 

--- a/Signal/src/ViewControllers/OWSTableViewController.m
+++ b/Signal/src/ViewControllers/OWSTableViewController.m
@@ -45,10 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OWSTableSection
 
-+ (OWSTableSection *)sectionWithTitle:(NSString *)title items:(NSArray<OWSTableItem *> *)items
++ (OWSTableSection *)sectionWithTitle:(nullable NSString *)title items:(NSArray<OWSTableItem *> *)items
 {
     OWSTableSection *section = [OWSTableSection new];
-    section.title = title;
+    section.headerTitle = title;
     section.items = [items mutableCopy];
     return section;
 }
@@ -224,7 +224,13 @@ NSString * const kOWSTableCellIdentifier = @"kOWSTableCellIdentifier";
 - (nullable NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)sectionIndex
 {
     OWSTableSection *section = [self sectionForIndex:sectionIndex];
-    return section.title;
+    return section.headerTitle;
+}
+
+- (nullable NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)sectionIndex
+{
+    OWSTableSection *section = [self sectionForIndex:sectionIndex];
+    return section.footerTitle;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -97,6 +97,9 @@
 /* No comment provided by engineer. */
 "ATTACHMENT_QUEUED" = "New attachment queued for retrieval.";
 
+/* The message of the 'block user' action sheet. */
+"BLOCK_LIST_BLOCK_ALERT_MESSAGE" = "Blocked users will not be able to call you or send you messages.";
+
 /* Button label for the 'block' button */
 "BLOCK_LIST_BLOCK_BUTTON" = "Block";
 
@@ -216,6 +219,9 @@
 
 /* title for conversation settings screen */
 "CONVERSATION_SETTINGS" = "Conversation Settings";
+
+/* A footer title for the block user option in the conversation settings */
+"CONVERSATION_SETTINGS_BLOCK_FOOTER_TITLE" = "Blocked users will not be able to call you or send you messages.";
 
 /* table cell label in conversation settings */
 "CONVERSATION_SETTINGS_BLOCK_THIS_USER" = "Block this user";

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -97,8 +97,8 @@
 /* No comment provided by engineer. */
 "ATTACHMENT_QUEUED" = "New attachment queued for retrieval.";
 
-/* The message of the 'block user' action sheet. */
-"BLOCK_LIST_BLOCK_ALERT_MESSAGE" = "Blocked users will not be able to call you or send you messages.";
+/* An explanation of the consequences of blocking another user. */
+"BLOCK_BEHAVIOR_EXPLANATION" = "Blocked users will not be able to call you or send you messages.";
 
 /* Button label for the 'block' button */
 "BLOCK_LIST_BLOCK_BUTTON" = "Block";
@@ -219,9 +219,6 @@
 
 /* title for conversation settings screen */
 "CONVERSATION_SETTINGS" = "Conversation Settings";
-
-/* A footer title for the block user option in the conversation settings */
-"CONVERSATION_SETTINGS_BLOCK_FOOTER_TITLE" = "Blocked users will not be able to call you or send you messages.";
 
 /* table cell label in conversation settings */
 "CONVERSATION_SETTINGS_BLOCK_THIS_USER" = "Block this user";
@@ -888,9 +885,6 @@
 
 /* A label for the 'add phone number' button in the block list table. */
 "SETTINGS_BLOCK_LIST_ADD_BUTTON" = "Add…";
-
-/* A footer title for the block list table. */
-"SETTINGS_BLOCK_LIST_FOOTER_TITLE" = "Blocked users will not be able to call you or send you messages.";
 
 /* A label that indicates the user has no Signal contacts. */
 "SETTINGS_BLOCK_LIST_NO_CONTACTS" = "You have no contacts on Signal.";


### PR DESCRIPTION
…ion of the 1:1 conversation settings view.

PTAL @michaelkirk 

I also moved the "block" row of the 1:1 conversation settings view to its own group, to "set it apart" since it's destructive.

![screen shot 2017-04-10 at 3 57 27 pm](https://cloud.githubusercontent.com/assets/625803/24879981/9e7f3036-1e06-11e7-9756-d309a9b78e5c.png)

![screen shot 2017-04-10 at 3 57 23 pm](https://cloud.githubusercontent.com/assets/625803/24879980/9e69b896-1e06-11e7-8374-76c0f4ca77ba.png)

