### PR TITLE
make navbar legible when sharing via iMessage

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSMessageAdapter.m
@@ -312,6 +312,7 @@ NS_ASSUME_NONNULL_BEGIN
         actionString,
         self.interaction.uniqueId,
         [self.mediaItem class]);
+    OWSAssert(NO);
 }
 
 - (TSAttachmentStream *)attachmentStream

--- a/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
@@ -124,9 +124,10 @@ NS_ASSUME_NONNULL_BEGIN
         UIImageWriteToSavedPhotosAlbum(self.image, nil, nil, nil);
         return;
     }
-
+    
     // Shouldn't get here, as only supported actions should be exposed via canPerformEditingAction
     DDLogError(@"'%@' action unsupported for %@: attachmentId=%@", actionString, self.class, self.attachmentId);
+    OWSAssert(NO);
 }
 
 @end

--- a/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
@@ -275,6 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
         NSString *actionString = NSStringFromSelector(action);
         DDLogError(
             @"Unexpected action: %@ for VideoAttachmentAdapter with contentType: %@", actionString, self.contentType);
+        OWSAssert(NO);
     }
 }
 

--- a/Signal/src/ViewControllers/AttachmentSharing.m
+++ b/Signal/src/ViewControllers/AttachmentSharing.m
@@ -4,6 +4,7 @@
 
 #import "AttachmentSharing.h"
 #import "TSAttachmentStream.h"
+#import "UIUtil.h"
 
 @implementation AttachmentSharing
 
@@ -24,19 +25,22 @@
                                                                                                                   ]
                                                                                          applicationActivities:@[
                                                                                                                  ]];
-    
+
     [activityViewController setCompletionWithItemsHandler:^(UIActivityType __nullable activityType,
-                                                            BOOL completed,
-                                                            NSArray * __nullable returnedItems,
-                                                            NSError * __nullable activityError) {
-        
+        BOOL completed,
+        NSArray *__nullable returnedItems,
+        NSError *__nullable activityError) {
+
+        DDLogDebug(@"%@ applying signal appearence", self.tag);
+        [UIUtil applySignalAppearence];
+
         if (activityError) {
             DDLogInfo(@"%@ Failed to share with activityError: %@", self.tag, activityError);
         } else if (completed) {
             DDLogInfo(@"%@ Did share with activityType: %@", self.tag, activityType);
         }
     }];
-    
+
     // Find the frontmost presented UIViewController from which to present the
     // share view.
     UIWindow *window = [UIApplication sharedApplication].keyWindow;
@@ -47,7 +51,10 @@
     OWSAssert(fromViewController);
     [fromViewController presentViewController:activityViewController
                                      animated:YES
-                                   completion:nil];
+                                   completion:^{
+                                       DDLogDebug(@"%@ applying default system appearence", self.tag);
+                                       [UIUtil applyDefaultSystemAppearence];
+                                   }];
 }
 
 #pragma mark - Logging


### PR DESCRIPTION
When sharing out attachments, we can't control the style of the MFMessage navbar (AFAICT).

So the work around is to temporarily toggle styles so the buttons become legible. 

The appearance switch is a little jarring, but I'm not sure of a better approach.

![signal-2017-03-31-143606](https://cloud.githubusercontent.com/assets/217057/24920142/2e9c38a0-1eb4-11e7-81c0-030e7e44fb5b.png)
