### PR TITLE
registration: clarify verification process

### DIFF
--- a/Signal/src/ViewControllers/CodeVerificationViewController.m
+++ b/Signal/src/ViewControllers/CodeVerificationViewController.m
@@ -126,11 +126,15 @@ NSString *const kCompletedRegistrationSegue = @"CompletedRegistration";
     _phoneNumberLabel = [UILabel new];
     _phoneNumberLabel.textColor = [UIColor ows_darkGrayColor];
     _phoneNumberLabel.font = [UIFont ows_regularFontWithSize:20.f];
+    _phoneNumberLabel.numberOfLines = 2;
+    _phoneNumberLabel.adjustsFontSizeToFitWidth = YES;
     [self.view addSubview:_phoneNumberLabel];
-    [_phoneNumberLabel autoHCenterInSuperview];
-    [_phoneNumberLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:header
-                          withOffset:ScaleFromIPhone5To7Plus(25, 100)];
-    
+    [_phoneNumberLabel autoPinWidthToSuperviewWithMargin:ScaleFromIPhone5(32)];
+    [_phoneNumberLabel autoPinEdge:ALEdgeTop
+                            toEdge:ALEdgeBottom
+                            ofView:header
+                        withOffset:ScaleFromIPhone5To7Plus(30, 100)];
+
     const CGFloat kHMargin = 36;
     
     _challengeTextField = [UITextField new];

--- a/Signal/src/ViewControllers/CodeVerificationViewController.m
+++ b/Signal/src/ViewControllers/CodeVerificationViewController.m
@@ -104,7 +104,7 @@ NSString *const kCompletedRegistrationSegue = @"CompletedRegistration";
 
     UILabel *titleLabel = [UILabel new];
     titleLabel.textColor = [UIColor whiteColor];
-    titleLabel.text = NSLocalizedString(@"VERIFICATION_HEADER", @"Navigation title in the registration flow - during the sms code verification process.");
+    titleLabel.text = [self phoneNumberText];
     titleLabel.font = [UIFont ows_mediumFontWithSize:20.f];
     [header addSubview:titleLabel];
     [titleLabel autoPinToTopLayoutGuideOfViewController:self withInset:0];
@@ -231,12 +231,18 @@ NSString *const kCompletedRegistrationSegue = @"CompletedRegistration";
     [_requestCallSpinner autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:kSpinnerSpacing];
 }
 
-- (void)updatePhoneNumberLabel {
-    NSString *phoneNumber = [PhoneNumber bestEffortFormatPartialUserSpecifiedTextToLookLikeAPhoneNumber:[TSAccountManager localNumber]];
+- (NSString *)phoneNumberText
+{
     OWSAssert([TSAccountManager localNumber] != nil);
-    _phoneNumberLabel.text = [NSString stringWithFormat:NSLocalizedString(@"VERIFICATION_PHONE_NUMBER_FORMAT",
-                                                                         @"Label indicating the phone number currently being verified."),
-                             phoneNumber];
+    return [PhoneNumber bestEffortFormatPartialUserSpecifiedTextToLookLikeAPhoneNumber:[TSAccountManager localNumber]];
+}
+
+- (void)updatePhoneNumberLabel
+{
+    _phoneNumberLabel.text =
+        [NSString stringWithFormat:NSLocalizedString(@"VERIFICATION_PHONE_NUMBER_FORMAT",
+                                       @"Label indicating the phone number currently being verified."),
+                  [self phoneNumberText]];
 }
 
 - (void)startActivityIndicator

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1088,7 +1088,7 @@
 "VERIFICATION_HEADER" = "Verify";
 
 /* Label indicating the phone number currently being verified. */
-"VERIFICATION_PHONE_NUMBER_FORMAT" = "Verifying: %@";
+"VERIFICATION_PHONE_NUMBER_FORMAT" = "Enter the verification code we sent to %@.";
 
 /* table cell label in conversation settings */
 "VERIFY_PRIVACY" = "Verify Safety Number";

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -130,7 +130,7 @@
 /* The title of the 'user blocked' alert. */
 "BLOCK_LIST_VIEW_BLOCKED_ALERT_TITLE" = "User Blocked";
 
-/* The title of the 'You can't block yourself' alert. */
+/* The message of the 'You can't block yourself' alert. */
 "BLOCK_LIST_VIEW_CANT_BLOCK_SELF_ALERT_MESSAGE" = "You can't block yourself.";
 
 /* The title of the 'You can't block yourself' alert. */
@@ -1083,9 +1083,6 @@
 
 /* button text during registration to submit your SMS verification code */
 "VERIFICATION_CHALLENGE_SUBMIT_CODE" = "Submit Verification Code";
-
-/* Navigation title in the registration flow - during the sms code verification process. */
-"VERIFICATION_HEADER" = "Verify";
 
 /* Label indicating the phone number currently being verified. */
 "VERIFICATION_PHONE_NUMBER_FORMAT" = "Enter the verification code we sent to %@.";


### PR DESCRIPTION
Two simple changes to make our verification screen a little more intuitive and useful.

5c
<img width="355" alt="screen shot 2017-04-11 at 1 49 52 pm" src="https://cloud.githubusercontent.com/assets/217057/24922883/cc2682a2-1ebd-11e7-87ff-dd00f959e1ec.png">

7+
<img width="423" alt="screen shot 2017-04-11 at 1 48 50 pm" src="https://cloud.githubusercontent.com/assets/217057/24922840/a93ddca4-1ebd-11e7-88b4-5adfdb41287b.png">

PTAL @charlesmchen 