### PR TITLE
[JSQMVC] Fixes "floating" edit menu for narrow media items

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,8 @@ target 'Signal' do
     #pod 'SignalServiceKit',           path: '../SignalServiceKit'
     pod 'OpenSSL'
     pod 'SCWaveformView',             '~> 1.0'
-    pod 'JSQMessagesViewController'
+    pod 'JSQMessagesViewController',  git: 'https://github.com/WhisperSystems/JSQMessagesViewController.git', branch: 'mkirk/position-edit-menu'
+    #pod 'JSQMessagesViewController'   path: '../JSQMessagesViewController'
     pod 'PureLayout'
     target 'SignalTests' do
         inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -112,7 +112,7 @@ PODS:
 
 DEPENDENCIES:
   - AxolotlKit (from `https://github.com/WhisperSystems/SignalProtocolKit.git`)
-  - JSQMessagesViewController
+  - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController.git`, branch `mkirk/position-edit-menu`)
   - OpenSSL
   - PureLayout
   - SCWaveformView (~> 1.0)
@@ -122,6 +122,9 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   AxolotlKit:
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
+  JSQMessagesViewController:
+    :branch: mkirk/position-edit-menu
+    :git: https://github.com/WhisperSystems/JSQMessagesViewController.git
   SignalServiceKit:
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
@@ -131,6 +134,9 @@ CHECKOUT OPTIONS:
   AxolotlKit:
     :commit: 139bde37738ccb6ebcc68bf1b02c8a28400b6760
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
+  JSQMessagesViewController:
+    :commit: 7054e4b13ee5bcd6d524adb6dc9a726e8c466308
+    :git: https://github.com/WhisperSystems/JSQMessagesViewController.git
   SignalServiceKit:
     :commit: 19d8a32022187932d5b5ad22039de54bbca1bdaf
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
@@ -161,6 +167,6 @@ SPEC CHECKSUMS:
   UnionFind: c33be5adb12983981d6e827ea94fc7f9e370f52d
   YapDatabase: b1e43555a34a5298e23a045be96817a5ef0da58f
 
-PODFILE CHECKSUM: a060377074cb361576f346a58d1503b3bd708440
+PODFILE CHECKSUM: d4f237ca4bd0b71e488d29b1e38dc31d06e45a52
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
previously, edit menu was only positioned correctly for text bubbles,
and centered for media bubbles.

It wasn't that noticeable for images/videos since those usually extended
to the middle of the conversation view, but with narrower media bubbles
(like arbitrary attachments) this became a bigger problem.

upstream PR: https://github.com/jessesquires/JSQMessagesViewController/pull/2069

PTAL @charlesmchen 