### PR TITLE
use updated localizable strings linter

### DIFF
--- a/Signal/translations/bin/pull-translations
+++ b/Signal/translations/bin/pull-translations
@@ -33,6 +33,14 @@ done
 
 # Get and build iStringsCheck from https://github.com/FredericJacobs/iStringsCheck
 # This does some checks to make sure all strings are present and that interpolated strings have the right number of arguments
-../../../iStringsCheck/target/debug/iStringsCheck en.lproj/Localizable.strings .
+LINT_CMD=../../../l10n_lint/target/debug/l10n_lint
+
+if [ -e $LINT_CMD ]
+then
+  $LINT_CMD en.lproj/Localizable.strings .
+else
+  echo "Missing string linter. See: https://github.com:WhisperSystems/l10n_lint"
+  exit 1
+fi
 
 echo "Make sure you register any new localizations in XCode! (Go to Project > Signal > Localizations > Add Localizations)"


### PR DESCRIPTION
this script checks to make sure the proper number of format characters
appear in our translated strings.

See: https://github.com/WhisperSystems/l10n_lint

PTAL @charlesmchen 
