### PR TITLE
Don’t load contact store twice.

### DIFF
--- a/Signal/src/contact/OWSContactsManager.m
+++ b/Signal/src/contact/OWSContactsManager.m
@@ -87,7 +87,8 @@ NSString *const OWSContactsManagerSignalRecipientsDidChangeNotification =
 }
 
 - (void)doAfterEnvironmentInitSetup {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(9, 0)) {
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(9, 0) &&
+        !self.contactStore) {
         OWSAssert(!self.contactStore);
         self.contactStore = [[CNContactStore alloc] init];
         [self.contactStore requestAccessForEntityType:CNEntityTypeContacts


### PR DESCRIPTION
`[SignalsViewController didAppearForNewlyRegisteredUser]` is doing its work every time the user returns to the home view.  It should probably only be called once.  

This PR only resolves the worse symptom - every time a newly-registered user returns to the home view, a new contacts store was being created.  I've opened a card for the bigger issue.

PTAL @michaelkirk 