### PR TITLE
when generating strings verify that SSK is on master

### DIFF
--- a/Signal/translations/bin/auto-genstrings
+++ b/Signal/translations/bin/auto-genstrings
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 
 set -e
-set -x
 
-TARGETS="Signal/src ../SignalServiceKit/src"
+SSK_DIR="../SignalServiceKit/src"
+
+pushd $SSK_DIR
+CURRENT_SSK_BRANCH=$(git status|awk 'NR==1{print $3}')
+if [ $CURRENT_SSK_BRANCH != "master" ]
+then
+  echo "[!] Error - SSK must be on master to be sure we're generating up-to-date strings"
+  exit 1
+fi
+popd
+
+TARGETS="Signal/src ${SSK_DIR}"
 TMP="$(mktemp -d)"
 STRINGFILE="Signal/translations/en.lproj/Localizable.strings"
 


### PR DESCRIPTION
Otherwise it's really easy to generate strings from the wrong branch

PTAL @charlesmchen 