### PR TITLE
Charlesmchen/stretched images

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSAnimatedAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSAnimatedAdapter.m
@@ -88,8 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
         FLAnimatedImageView *imageView = [[FLAnimatedImageView alloc] init];
         imageView.animatedImage        = animatedGif;
         CGSize size                    = [self mediaViewDisplaySize];
-        imageView.frame                = CGRectMake(0.0, 0.0, size.width, size.height);
         imageView.contentMode          = UIViewContentModeScaleAspectFill;
+        imageView.frame                = CGRectMake(0.0, 0.0, size.width, size.height);
         imageView.clipsToBounds        = YES;
         [JSQMessagesMediaViewBubbleImageMasker applyBubbleImageMaskToMediaView:imageView
                                                                     isOutgoing:self.appliesMediaViewMaskAsOutgoing];

--- a/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSPhotoAdapter.m
@@ -67,8 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.cachedImageView == nil) {
         CGSize size             = [self mediaViewDisplaySize];
         UIImageView *imageView  = [[UIImageView alloc] initWithImage:self.image];
-        imageView.frame         = CGRectMake(0.0f, 0.0f, size.width, size.height);
         imageView.contentMode   = UIViewContentModeScaleAspectFill;
+        imageView.frame         = CGRectMake(0.0f, 0.0f, size.width, size.height);
         imageView.clipsToBounds = YES;
         // Use trilinear filters for better scaling quality at
         // some performance cost.

--- a/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
@@ -121,8 +121,8 @@ NS_ASSUME_NONNULL_BEGIN
     if ([self isVideo]) {
         if (self.cachedImageView == nil) {
             UIImageView *imageView  = [[UIImageView alloc] initWithImage:self.image];
-            imageView.frame         = CGRectMake(0.0f, 0.0f, size.width, size.height);
             imageView.contentMode   = UIViewContentModeScaleAspectFill;
+            imageView.frame         = CGRectMake(0.0f, 0.0f, size.width, size.height);
             imageView.clipsToBounds = YES;
             [JSQMessagesMediaViewBubbleImageMasker applyBubbleImageMaskToMediaView:imageView
                                                                         isOutgoing:self.appliesMediaViewMaskAsOutgoing];


### PR DESCRIPTION
Fixes the long-standing and highly irritating "portrait images often appear stretched in messages view" bug.

Apparently there's a bug in UIKit and views which a) use contentMode b) reside inside a UIScrollView must have their frame set _after_ their contentMode is set.

The repro was: send or receive a portrait image.  Go to conversation settings, return to messages view _or_  open attachments action sheet -> camera roll view, hit cancel to return to messages view.

PTAL @michaelkirk 