### PR TITLE
Resolve the menu item conflicts between message view and media view.

### DIFF
--- a/Signal/src/ViewControllers/FullImageViewController.m
+++ b/Signal/src/ViewControllers/FullImageViewController.m
@@ -60,6 +60,7 @@
 @property (nonatomic) id<OWSMessageData> messageItem;
 
 @property (nonatomic) UIToolbar *footerBar;
+@property (nonatomic) NSArray *oldMenuItems;
 
 @end
 
@@ -257,6 +258,9 @@
                                [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_SHARE_ACTION", @"Short name for edit menu item to share contents of media message.")
                                                           action:@selector(shareAttachment:)],
                                ];
+        if (!self.oldMenuItems) {
+            self.oldMenuItems = [UIMenuController sharedMenuController].menuItems;
+        }
         [UIMenuController sharedMenuController].menuItems = menuItems;
         CGPoint location = [sender locationInView:self.view];
         CGRect targetRect = CGRectMake(location.x,
@@ -342,6 +346,12 @@
 }
 
 - (void)dismiss {
+
+    // Restore the edit menu items if necessary.
+    if (self.oldMenuItems) {
+        [UIMenuController sharedMenuController].menuItems = self.oldMenuItems;
+    }
+
     self.view.userInteractionEnabled = NO;
     [UIView animateWithDuration:0.25f
         delay:0

--- a/Signal/src/ViewControllers/MessagesViewController.m
+++ b/Signal/src/ViewControllers/MessagesViewController.m
@@ -556,13 +556,20 @@ typedef enum : NSUInteger {
     // need to set them every time we enter this view.
     SEL saveSelector = NSSelectorFromString(@"save:");
     SEL shareSelector = NSSelectorFromString(@"share:");
-    [UIMenuController sharedMenuController].menuItems = @[ [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_SAVE_ACTION",
-                                                                                                               @"Short name for edit menu item to save contents of media message.")
-                                                                                      action:saveSelector],
-                                                           [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_SHARE_ACTION",
-                                                                                                               @"Short name for edit menu item to share contents of media message.")
-                                                                                      action:shareSelector],
-                                                           ];
+    [UIMenuController sharedMenuController].menuItems = @[
+        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_SAVE_ACTION",
+                                              @"Short name for edit menu item to save contents of media message.")
+                                   action:saveSelector],
+        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_SHARE_ACTION",
+                                              @"Short name for edit menu item to share contents of media message.")
+                                   action:shareSelector],
+        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_COPY_ACTION",
+                                              @"Short name for edit menu item to copy contents of media message.")
+                                   action:@selector(copy:)],
+        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_DELETE_ACTION",
+                                              @"Short name for edit menu item to delete contents of media message.")
+                                   action:@selector(delete:)],
+    ];
 
     [self ensureBlockStateIndicator];
 
@@ -1720,7 +1727,7 @@ typedef enum : NSUInteger {
                                                              messageItem:messageItem
                                                              isAnimated:NO];
 
-                            [vc presentFromViewController:self.navigationController];
+                            [vc presentFromViewController:self];
                         }
                     }
                 } else if ([[messageItem media] isKindOfClass:[TSAnimatedAdapter class]]) {
@@ -1749,7 +1756,7 @@ typedef enum : NSUInteger {
                                                                  forInteraction:interaction
                                                                     messageItem:messageItem
                                                                      isAnimated:YES];
-                            [vc presentFromViewController:self.navigationController];
+                            [vc presentFromViewController:self];
                         }
                     }
                 } else if ([[messageItem media] isKindOfClass:[TSVideoAttachmentAdapter class]]) {

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -325,6 +325,9 @@
 /* Short name for edit menu item to share contents of media message. */
 "EDIT_ITEM_SHARE_ACTION" = "Share";
 
+/* Short name for edit menu item to share contents of media message. */
+"EDIT_ITEM_DELETE_ACTION" = "Delete";
+
 /* body of email sent to contacts when inviting to install Signal. Embeds {{link to install Signal}} and {{link to WhisperSystems home page}} */
 "EMAIL_INVITE_BODY" = "Hey,\n\nLately I've been using Signal to keep the conversations on my iPhone private. I'd like you to install it too, so we can be confident that only you and I can read our messages or hear our calls.\n\nSignal is available for iPhones and Android. Get it here: %@\n\nSignal works like your existing messaging app. We can send pictures and video, make calls, and start group chats. The best part is, no one else can see any of it, not even the people who make Signal!\n\nYou can read more about Open Whisper Systems, the people who make Signal, here: %@";
 

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -319,14 +319,14 @@
 /* Short name for edit menu item to copy contents of media message. */
 "EDIT_ITEM_COPY_ACTION" = "Copy";
 
+/* Short name for edit menu item to delete contents of media message. */
+"EDIT_ITEM_DELETE_ACTION" = "Delete";
+
 /* Short name for edit menu item to save contents of media message. */
 "EDIT_ITEM_SAVE_ACTION" = "Save";
 
 /* Short name for edit menu item to share contents of media message. */
 "EDIT_ITEM_SHARE_ACTION" = "Share";
-
-/* Short name for edit menu item to share contents of media message. */
-"EDIT_ITEM_DELETE_ACTION" = "Delete";
 
 /* body of email sent to contacts when inviting to install Signal. Embeds {{link to install Signal}} and {{link to WhisperSystems home page}} */
 "EMAIL_INVITE_BODY" = "Hey,\n\nLately I've been using Signal to keep the conversations on my iPhone private. I'd like you to install it too, so we can be confident that only you and I can read our messages or hear our calls.\n\nSignal is available for iPhones and Android. Get it here: %@\n\nSignal works like your existing messaging app. We can send pictures and video, make calls, and start group chats. The best part is, no one else can see any of it, not even the people who make Signal!\n\nYou can read more about Open Whisper Systems, the people who make Signal, here: %@";


### PR DESCRIPTION
`UIMenuController` has a horrible API.  Which menu items _might_ appear is a function of the last value written to its `menuItems` property, but which menu items you want to appear is contextual, so it's last-writer-wins without any good hook to update the menu items based on the context of the current user action.  

I've made MessagesVC a bit more defensive and made the media view a bit more polite.

PTAL @michaelkirk 