### PR TITLE
support arbitrary extensions in UIDocumentPicker

### DIFF
--- a/Signal/src/ViewControllers/SignalAttachment.swift
+++ b/Signal/src/ViewControllers/SignalAttachment.swift
@@ -12,7 +12,6 @@ enum SignalAttachmentError: Error {
     case couldNotParseImage
     case couldNotConvertToJpeg
     case invalidFileFormat
-    case unknownType
 }
 
 extension SignalAttachmentError: LocalizedError {
@@ -30,8 +29,6 @@ extension SignalAttachmentError: LocalizedError {
             return NSLocalizedString("ATTACHMENT_ERROR_COULD_NOT_CONVERT_TO_JPEG", comment: "Attachment error message for image attachments which could not be converted to JPEG")
         case .invalidFileFormat:
             return NSLocalizedString("ATTACHMENT_ERROR_INVALID_FILE_FORMAT", comment: "Attachment error message for attachments with an invalid file format")
-        case .unknownType:
-            return NSLocalizedString("ATTACHMENT_ERROR_UNKNOWN_TYPE", comment: "Attachment error message for attachments with an invalid file format")
         }
     }
 }
@@ -114,10 +111,6 @@ class SignalAttachment: NSObject {
         self.dataUTI = dataUTI
         self.filename = filename
         super.init()
-
-        if self.mimeType == nil {
-            error = .unknownType
-        }
     }
 
     // MARK: Methods
@@ -174,7 +167,7 @@ class SignalAttachment: NSObject {
 
     // Returns the MIME type for this attachment or nil if no MIME type
     // can be identified.
-    var mimeType: String? {
+    var mimeType: String {
         if dataUTI == SignalAttachment.kOversizeTextAttachmentUTI {
             return OWSMimeTypeOversizeTextMessage
         }
@@ -182,7 +175,7 @@ class SignalAttachment: NSObject {
             return OWSMimeTypeUnknownForTests
         }
         guard let mimeType = UTTypeCopyPreferredTagWithClass(dataUTI as CFString, kUTTagClassMIMEType) else {
-            return nil
+            return OWSMimeTypeApplicationOctetStream
         }
         return mimeType.takeRetainedValue() as String
     }

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -106,6 +106,12 @@
 /* Alert title when picking a document fails for an unknown reason */
 "ATTACHMENT_PICKER_DOCUMENTS_FAILED_ALERT_TITLE" = "Failed to choose document.";
 
+/* Alert body when picking a document fails because user picked a directory/bundle */
+"ATTACHMENT_PICKER_DOCUMENTS_PICKED_DIRECTORY_FAILED_ALERT_BODY" = "Signal can't handle that file as is. Try zipping it before sending.";
+
+/* Alert title when picking a document fails because user picked a directory/bundle */
+"ATTACHMENT_PICKER_DOCUMENTS_PICKED_DIRECTORY_FAILED_ALERT_TITLE" = "Unsupported File";
+
 /* An explanation of the consequences of blocking another user. */
 "BLOCK_BEHAVIOR_EXPLANATION" = "Blocked users will not be able to call you or send you messages.";
 


### PR DESCRIPTION
1. Make sure we can pick any-ole file extension, like "foo.aslkdjhaskjdhsad"

2. We don't support sending bundles (i.e. directories). Instead of making them unselectable, in the DocumentPicker, let the user pick it, but then show them a message that tells them how to fix the problem (zip the file first).


PTAL @charlesmchen 
