### PR TITLE
unregistered user aka "one way messaging"

### DIFF
--- a/Signal/src/Models/SyncPushTokensJob.swift
+++ b/Signal/src/Models/SyncPushTokensJob.swift
@@ -1,11 +1,12 @@
-//  Created by Michael Kirk on 10/26/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 import Foundation
 import PromiseKit
 
 @objc(OWSSyncPushTokensJob)
-class SyncPushTokensJob : NSObject {
+class SyncPushTokensJob: NSObject {
     let TAG = "[SyncPushTokensJob]"
     let pushManager: PushManager
     let accountManager: AccountManager
@@ -67,7 +68,7 @@ class SyncPushTokensJob : NSObject {
                     fulfill((pushToken:pushToken, voipToken:voipToken))
                 },
                 failure: reject
-            );
+            )
         }
     }
 
@@ -76,15 +77,14 @@ class SyncPushTokensJob : NSObject {
 
         if (pushToken != self.preferences.getPushToken()) {
             Logger.info("\(TAG) Recording new plain push token")
-            self.preferences.setPushToken(pushToken);
+            self.preferences.setPushToken(pushToken)
         }
 
         if (voipToken != self.preferences.getVoipToken()) {
             Logger.info("\(TAG) Recording new voip token")
-            self.preferences.setVoipToken(voipToken);
+            self.preferences.setVoipToken(voipToken)
         }
 
-        // TODO code cleanup: convert to `return Promise(value: nil)` and test.
-        return Promise { fulfill, reject in  fulfill(); }
+        return Promise(value: ())
     }
 }


### PR DESCRIPTION
When we don't have an active set of push credentials for a user, we consider them "not a signal user". So if someone fails to upload push credentials, no one will be able to message them.

fixes https://github.com/WhisperSystems/Signal-iOS/issues/1618

This was a retention bug - nothing was retaining the promise returned by PushTokensJob, so it might be GC'd before it was completed.

I suspect there are more of these, so going to do an audit of our Promise usage.

PTAL @charlesmchen 