### PR TITLE
Remove invalid assert in case of legitimately stacking unicode

### DIFF
--- a/Signal/src/util/DisplayableTextFilter.swift
+++ b/Signal/src/util/DisplayableTextFilter.swift
@@ -17,7 +17,6 @@ import Foundation
         if (self.hasExcessiveDiacriticals(text: text)) {
             Logger.warn("\(TAG) filtering text for excessive diacriticals.")
             let filteredText = text.folding(options: .diacriticInsensitive, locale: .current)
-            assert(!self.hasExcessiveDiacriticals(text: filteredText))
             return filteredText
         }
 


### PR DESCRIPTION
This assert was being falsely triggered by legitimate unicode.

The current state of affairs (unchanged by this PR) is that all
diacriticals will be stripped from a message that also contains e.g. 3
flags in a sequence.

PTAL @charlesmchen 