### PR TITLE
Fix speakerphone vs. WebRTC AND Fix CallService edge cases.

### DIFF
--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -944,14 +944,15 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
             self.dismiss(animated: false, completion:completion)
         }
     }
-    
+
     // MARK: - CallServiceObserver
 
     internal func didUpdateCall(call: SignalCall?) {
         // Do nothing.
     }
 
-    internal func didUpdateVideoTracks(localVideoTrack: RTCVideoTrack?,
+    internal func didUpdateVideoTracks(call: SignalCall?,
+                                       localVideoTrack: RTCVideoTrack?,
                                        remoteVideoTrack: RTCVideoTrack?) {
         AssertIsOnMainThread()
 

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -87,7 +87,13 @@ import AVFoundation
         ensureIsEnabled(call: call)
     }
 
-    private func ensureIsEnabled(call: SignalCall) {
+    private func ensureIsEnabled(call: SignalCall?) {
+        guard let call = call else {
+            setAudioSession(category: AVAudioSessionCategoryPlayback,
+                            mode: AVAudioSessionModeDefault)
+            return
+        }
+
         // Auto-enable speakerphone when local video is enabled.
         if call.hasLocalVideo {
             setAudioSession(category: AVAudioSessionCategoryPlayAndRecord,
@@ -104,6 +110,12 @@ import AVFoundation
     }
 
     // MARK: - Service action handlers
+
+    public func didUpdateVideoTracks(call: SignalCall?) {
+        Logger.verbose("\(TAG) in \(#function)")
+
+        self.ensureIsEnabled(call: call)
+    }
 
     public func handleState(call: SignalCall) {
         assert(Thread.isMainThread)
@@ -151,6 +163,7 @@ import AVFoundation
     private func handleAnswering(call: SignalCall) {
         Logger.debug("\(TAG) \(#function)")
         stopPlayingAnySounds()
+        self.ensureIsEnabled(call: call)
     }
 
     private func handleRemoteRinging(call: SignalCall) {

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -91,7 +91,8 @@ protocol CallServiceObserver: class {
     /**
      * Fired whenever the local or remote video track become active or inactive.
      */
-    func didUpdateVideoTracks(localVideoTrack: RTCVideoTrack?,
+    func didUpdateVideoTracks(call: SignalCall?,
+                              localVideoTrack: RTCVideoTrack?,
                               remoteVideoTrack: RTCVideoTrack?)
 }
 
@@ -896,13 +897,6 @@ protocol CallServiceObserver: class {
     func setIsMuted(isMuted: Bool) {
         AssertIsOnMainThread()
 
-        guard let peerConnectionClient = self.peerConnectionClient else {
-            // This should never happen; return to a known good state.
-            assertionFailure("\(TAG) peerConnectionClient was unexpectedly nil in \(#function)")
-            handleFailedCurrentCall(error: .assertionError(description:"\(TAG) peerConnectionClient unexpectedly nil in \(#function)"))
-            return
-        }
-
         guard let call = self.call else {
             // This should never happen; return to a known good state.
             assertionFailure("\(TAG) call was unexpectedly nil in \(#function)")
@@ -911,6 +905,12 @@ protocol CallServiceObserver: class {
         }
 
         call.isMuted = isMuted
+
+        guard let peerConnectionClient = self.peerConnectionClient else {
+            // The peer connection might not be created yet.
+            return
+        }
+
         peerConnectionClient.setAudioEnabled(enabled: !isMuted)
     }
 
@@ -952,13 +952,6 @@ protocol CallServiceObserver: class {
             return
         }
 
-        guard let peerConnectionClient = self.peerConnectionClient else {
-            // This should never happen; return to a known good state.
-            assertionFailure("\(TAG) peerConnectionClient was unexpectedly nil in \(#function)")
-            handleFailedCurrentCall(error: .assertionError(description:"\(TAG) peerConnectionClient unexpectedly nil in \(#function)"))
-            return
-        }
-
         guard let call = self.call else {
             // This should never happen; return to a known good state.
             assertionFailure("\(TAG) call was unexpectedly nil in \(#function)")
@@ -967,6 +960,12 @@ protocol CallServiceObserver: class {
         }
 
         call.hasLocalVideo = hasLocalVideo
+
+        guard let peerConnectionClient = self.peerConnectionClient else {
+            // The peer connection might not be created yet.
+            return
+        }
+
         peerConnectionClient.setLocalVideoEnabled(enabled: shouldHaveLocalVideoTrack())
     }
 
@@ -1288,9 +1287,11 @@ protocol CallServiceObserver: class {
         observers.append(Weak(value: observer))
 
         // Synchronize observer with current call state
+        let call = self.call
         let localVideoTrack = self.localVideoTrack
         let remoteVideoTrack = self.isRemoteVideoEnabled ? self.remoteVideoTrack : nil
-        observer.didUpdateVideoTracks(localVideoTrack:localVideoTrack,
+        observer.didUpdateVideoTracks(call:call,
+                                      localVideoTrack:localVideoTrack,
                                       remoteVideoTrack:remoteVideoTrack)
     }
 
@@ -1313,11 +1314,13 @@ protocol CallServiceObserver: class {
     private func fireDidUpdateVideoTracks() {
         AssertIsOnMainThread()
 
+        let call = self.call
         let localVideoTrack = self.localVideoTrack
         let remoteVideoTrack = self.isRemoteVideoEnabled ? self.remoteVideoTrack : nil
 
         for observer in observers {
-            observer.value?.didUpdateVideoTracks(localVideoTrack:localVideoTrack,
+            observer.value?.didUpdateVideoTracks(call:call,
+                                                 localVideoTrack:localVideoTrack,
                                                  remoteVideoTrack:remoteVideoTrack)
         }
     }

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -217,11 +217,11 @@ extension CallUIAdaptee {
         call?.addObserverAndSyncState(observer: audioService)
     }
 
-    internal func didUpdateVideoTracks(localVideoTrack: RTCVideoTrack?,
+    internal func didUpdateVideoTracks(call: SignalCall?,
+                                       localVideoTrack: RTCVideoTrack?,
                                        remoteVideoTrack: RTCVideoTrack?) {
         AssertIsOnMainThread()
 
-        // Do nothing.
+        audioService.didUpdateVideoTracks(call:call)
     }
-
 }


### PR DESCRIPTION
* Speakerphone is being disabled around the time that the video and audio tracks become active. It's not on our side. I'm guessing that WebRTC sets the category for AVAudioSession and - not knowing that speaker phone has been enabled - disables speakerphone.  It's an unfortunate side effects of AVAudioSession's "last writer wins" API.  The solution is to update AVAudioSession after the video tracks become active.
* If you enable mute or video while in connecting, you would hit an assert. In production the call would be hung up.  

PTAL @michaelkirk 