### PR TITLE
Insist upon an "ordered" TCP data channel for delivery reliability.

### DIFF
--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -166,8 +166,11 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
     private func createSignalingDataChannel() {
         AssertIsOnMainThread()
 
+        let configuration = RTCDataChannelConfiguration()
+        // Insist upon an "ordered" TCP data channel for delivery reliability.
+        configuration.isOrdered = true
         let dataChannel = peerConnection.dataChannel(forLabel: Identifiers.dataChannelSignaling.rawValue,
-                                                     configuration: RTCDataChannelConfiguration())
+                                                     configuration: configuration)
         dataChannel.delegate = self
 
         assert(self.dataChannel == nil)
@@ -577,7 +580,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         }
         let remoteVideoTrack = stream.videoTracks[0]
         Logger.debug("\(self.TAG) didAdd stream:\(stream) video tracks: \(stream.videoTracks.count) audio tracks: \(stream.audioTracks.count)")
-        
+
         // See the comments on the remoteVideoTrack property.
         //
         // We only set the remoteVideoTrack property if peerConnection is non-nil.
@@ -596,7 +599,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             if let delegate = self.delegate {
                 DispatchQueue.main.async { [weak self] in
                     guard let strongSelf = self else { return }
-                    
+
                     // See the comments on the remoteVideoTrack property.
                     //
                     // We only access the remoteVideoTrack property if peerConnection is non-nil.


### PR DESCRIPTION
PTAL @michaelkirk 