### PR TITLE
Fix assert in conversation settings view.

### DIFF
--- a/Signal/src/ViewControllers/OWSTableViewController.m
+++ b/Signal/src/ViewControllers/OWSTableViewController.m
@@ -183,7 +183,7 @@ NSString * const kOWSTableCellIdentifier = @"kOWSTableCellIdentifier";
         return self;
     }
 
-    [self commonInit];
+    [self owsTableCommonInit];
 
     return self;
 }
@@ -195,7 +195,7 @@ NSString * const kOWSTableCellIdentifier = @"kOWSTableCellIdentifier";
         return self;
     }
 
-    [self commonInit];
+    [self owsTableCommonInit];
 
     return self;
 }
@@ -207,12 +207,12 @@ NSString * const kOWSTableCellIdentifier = @"kOWSTableCellIdentifier";
         return self;
     }
 
-    [self commonInit];
+    [self owsTableCommonInit];
 
     return self;
 }
 
-- (void)commonInit
+- (void)owsTableCommonInit
 {
     _contents = [OWSTableContents new];
     self.tableViewStyle = UITableViewStyleGrouped;


### PR DESCRIPTION
The problem with the `commonInit` pattern is that if a superclass and subclass both use the pattern, the subclass's implementation won't know to call superclass's implementation since it's a private implementation detail.

PTAL @michaelkirk 