### PR TITLE
compose w/o contacts

### DIFF
--- a/Signal/src/ViewControllers/ContactsPicker.swift
+++ b/Signal/src/ViewControllers/ContactsPicker.swift
@@ -145,20 +145,27 @@ open class ContactsPicker: UIViewController, UITableViewDelegate, UITableViewDat
     func getContacts(onError errorHandler: @escaping (_ error: Error) -> Void) {
         switch CNContactStore.authorizationStatus(for: CNEntityType.contacts) {
             case CNAuthorizationStatus.denied, CNAuthorizationStatus.restricted:
+                let title = NSLocalizedString("INVITE_FLOW_REQUIRES_CONTACT_ACCESS_TITLE", comment: "Alert title when contacts disabled while trying to invite contacts to signal")
+                let body = NSLocalizedString("INVITE_FLOW_REQUIRES_CONTACT_ACCESS_BODY", comment: "Alert body when contacts disabled while trying to invite contacts to signal")
 
-                let title = NSLocalizedString("AB_PERMISSION_MISSING_TITLE", comment: "Alert title when contacts disabled")
-                let body = NSLocalizedString("ADDRESSBOOK_RESTRICTED_ALERT_BODY", comment: "Alert body when contacts disabled")
                 let alert = UIAlertController(title: title, message: body, preferredStyle: UIAlertControllerStyle.alert)
 
-                let dismissText = NSLocalizedString("DISMISS_BUTTON_TEXT", comment:"")
+                let dismissText = NSLocalizedString("TXT_CANCEL_TITLE", comment:"")
 
-                let okAction = UIAlertAction(title: dismissText, style: UIAlertActionStyle.default, handler: {  _ in
+                let cancelAction = UIAlertAction(title: dismissText, style: .cancel, handler: {  _ in
                     let error = NSError(domain: "contactsPickerErrorDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "No Contacts Access"])
                     self.contactsPickerDelegate?.contactsPicker(self, didContactFetchFailed: error)
                     errorHandler(error)
                     self.dismiss(animated: true, completion: nil)
                 })
-                alert.addAction(okAction)
+                alert.addAction(cancelAction)
+
+                let settingsText = NSLocalizedString("OPEN_SETTINGS_BUTTON", comment:"Button text which opens the settings app")
+                let openSettingsAction = UIAlertAction(title: settingsText, style: .default, handler: { (_) in
+                    UIApplication.shared.openSystemSettings()
+                })
+                alert.addAction(openSettingsAction)
+
                 self.present(alert, animated: true, completion: nil)
 
             case CNAuthorizationStatus.notDetermined:
@@ -207,6 +214,10 @@ open class ContactsPicker: UIViewController, UITableViewDelegate, UITableViewDat
 
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let dataSource = filteredSections
+
+        guard section < dataSource.count else {
+            return 0
+        }
 
         return dataSource[section].count
     }
@@ -274,15 +285,15 @@ open class ContactsPicker: UIViewController, UITableViewDelegate, UITableViewDat
     open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let dataSource = filteredSections
 
-        guard dataSource.count >= section else {
+        guard section < dataSource.count else {
             return nil
         }
-        
+
         if dataSource[section].count > 0 {
-            guard collation.sectionTitles.count >= section else {
+            guard section < collation.sectionTitles.count else {
                 return nil
             }
-            
+
             return collation.sectionTitles[section]
         } else {
             return nil

--- a/Signal/src/ViewControllers/ContactsPicker.swift
+++ b/Signal/src/ViewControllers/ContactsPicker.swift
@@ -274,7 +274,15 @@ open class ContactsPicker: UIViewController, UITableViewDelegate, UITableViewDat
     open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let dataSource = filteredSections
 
+        guard dataSource.count >= section else {
+            return nil
+        }
+        
         if dataSource[section].count > 0 {
+            guard collation.sectionTitles.count >= section else {
+                return nil
+            }
+            
             return collation.sectionTitles[section]
         } else {
             return nil

--- a/Signal/src/ViewControllers/MessageComposeTableViewController.m
+++ b/Signal/src/ViewControllers/MessageComposeTableViewController.m
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     UIButton *inviteContactsButton = [UIButton buttonWithType:UIButtonTypeCustom];
     [inviteContactsButton setTitle:NSLocalizedString(@"INVITE_FRIENDS_CONTACT_TABLE_BUTTON",
-                                       "Text for button at the top of the contact picker")
+                                       "Label for the cell that presents the 'invite contacts' workflow.")
                           forState:UIControlStateNormal];
     [inviteContactsButton setTitleColor:[UIColor ows_materialBlueColor] forState:UIControlStateNormal];
     [inviteContactsButton.titleLabel setFont:[UIFont ows_regularFontWithSize:17.f]];
@@ -420,6 +420,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)showNoContactsModeIfNecessary
 {
+    if (!self.contactsViewHelper.contactsManager.isSystemContactsAuthorized) {
+        return;
+    }
+    
     BOOL hasNoContacts = self.contactsViewHelper.signalAccounts.count < 1;
     self.isNoContactsModeActive = (hasNoContacts && ![[Environment preferences] hasDeclinedNoContactsView]);
 }

--- a/Signal/src/ViewControllers/MessageComposeTableViewController.m
+++ b/Signal/src/ViewControllers/MessageComposeTableViewController.m
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self.navigationController.navigationBar setTranslucent:NO];
 
-    [self showNoContactsModeIfNecessary];
+    [self showContactAppropriateViews];
 }
 
 #pragma mark - Table Contents
@@ -439,7 +439,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     [[Environment preferences] setHasDeclinedNoContactsView:YES];
 
-    [self showNoContactsModeIfNecessary];
+    [self showContactAppropriateViews];
 }
 
 - (void)presentInviteFlow
@@ -450,7 +450,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self presentViewController:inviteFlow.actionSheetController animated:YES completion:nil];
 }
 
-- (void)showNoContactsModeIfNecessary
+- (void)showContactAppropriateViews
 {
     if (self.contactsViewHelper.contactsManager.isSystemContactsAuthorized) {
         BOOL hasNoContacts = self.contactsViewHelper.signalAccounts.count < 1;
@@ -626,7 +626,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     [self updateTableContents];
 
-    [self showNoContactsModeIfNecessary];
+    [self showContactAppropriateViews];
 }
 
 - (BOOL)shouldHideLocalNumber

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -279,9 +279,18 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
 - (IBAction)composeNew
 {
     MessageComposeTableViewController *viewController = [MessageComposeTableViewController new];
-    UINavigationController *navigationController =
-        [[UINavigationController alloc] initWithRootViewController:viewController];
-    [self presentTopLevelModalViewController:navigationController animateDismissal:YES animatePresentation:YES];
+
+    [self.contactsManager requestSystemContactsOnceWithCompletion:^(NSError *_Nullable error) {
+        DDLogError(@"%@ Error when requesting contacts: %@", self.tag, error);
+        // Even if there was an error fetching contacts we proceed to the next screen.
+        // As the compose view will present the proper thing depending on contact access.
+        //
+        // We just want to make sure contact access is *complete* before showing the compose
+        // screen to avoid flicker.
+        UINavigationController *navigationController =
+            [[UINavigationController alloc] initWithRootViewController:viewController];
+        [self presentTopLevelModalViewController:navigationController animateDismissal:YES animatePresentation:YES];
+    }];
 }
 
 - (void)swappedSegmentedControl {

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -168,7 +168,8 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
         @"SETTINGS_BUTTON_ACCESSIBILITY", @"Accessibility hint for the settings button");
 
 
-    self.missingContactsPermissionView.text = NSLocalizedString(@"INBOX_VIEW_MISSING_CONTACTS_PERMISSION", @"Multi line label explainging how to show names instead of phone numbers in your inbox");
+    self.missingContactsPermissionView.text = NSLocalizedString(@"INBOX_VIEW_MISSING_CONTACTS_PERMISSION",
+        @"Multiline label explaining how to show names instead of phone numbers in your inbox");
     self.missingContactsPermissionView.tapAction = ^{
         [[UIApplication sharedApplication] openSystemSettings];
     };

--- a/Signal/src/contact/OWSContactsManager.h
+++ b/Signal/src/contact/OWSContactsManager.h
@@ -39,6 +39,7 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 // Request systems contacts and start syncing changes. The user will see an alert
 // if they haven't previously.
 - (void)requestSystemContactsOnce;
+- (void)requestSystemContactsOnceWithCompletion:(void (^_Nullable)(NSError *_Nullable error))completion;
 
 // Ensure's the app has the latest contacts, but won't prompt the user for contact
 // access if they haven't granted it.

--- a/Signal/src/contact/OWSContactsManager.m
+++ b/Signal/src/contact/OWSContactsManager.m
@@ -54,8 +54,14 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification =
 // Request contacts access if you haven't asked recently.
 - (void)requestSystemContactsOnce
 {
-    [self.systemContactsFetcher requestOnce];
+    [self requestSystemContactsOnceWithCompletion:nil];
 }
+
+- (void)requestSystemContactsOnceWithCompletion:(void (^_Nullable)(NSError *_Nullable error))completion
+{
+    [self.systemContactsFetcher requestOnceWithCompletion:completion];
+}
+
 
 - (void)fetchSystemContactsIfAlreadyAuthorized
 {

--- a/Signal/src/contact/SystemContactsFetcher.swift
+++ b/Signal/src/contact/SystemContactsFetcher.swift
@@ -51,18 +51,21 @@ class SystemContactsFetcher: NSObject {
 
         switch authorizationStatus {
         case .notDetermined:
-            contactStore.requestAccess(for: .contacts, completionHandler: { (granted, error) in
+            contactStore.requestAccess(for: .contacts) { (granted, error) in
                 if let error = error {
                     Logger.error("\(self.TAG) error fetching contacts: \(error)")
                     assertionFailure()
                 }
 
-                if !granted {
+                guard granted else {
                     Logger.info("\(self.TAG) declined contact access.")
-                } else {
+                    return
+                }
+
+                DispatchQueue.main.async {
                     self.updateContacts()
                 }
-            })
+            }
         case .authorized:
             self.updateContacts()
         case .denied, .restricted:

--- a/Signal/src/contact/SystemContactsFetcher.swift
+++ b/Signal/src/contact/SystemContactsFetcher.swift
@@ -65,6 +65,7 @@ class SystemContactsFetcher: NSObject {
                     DispatchQueue.main.async {
                         completion?(error)
                     }
+                    return
                 }
 
                 guard granted else {

--- a/Signal/src/contact/SystemContactsFetcher.swift
+++ b/Signal/src/contact/SystemContactsFetcher.swift
@@ -58,15 +58,12 @@ class SystemContactsFetcher: NSObject {
                 }
 
                 if !granted {
-                    // TODO, make this a one time dismissable admonishment
-                    // e.g. remember across launches that the user has dismissed.
-                    self.displayMissingContactsPermissionAlert()
+                    Logger.info("\(self.TAG) declined contact access.")
                 } else {
                     self.updateContacts()
                 }
             })
         case .authorized:
-            // TODO reset onetime admonishment reminder, so that we remind user again (once) if they've since toggled permissions.
             self.updateContacts()
         case .denied, .restricted:
             Logger.debug("\(TAG) contacts were \(self.authorizationStatus)")
@@ -80,11 +77,6 @@ class SystemContactsFetcher: NSObject {
         }
 
         updateContacts()
-    }
-
-    private func displayMissingContactsPermissionAlert() {
-        let foo = UIApplication.shared.frontmostViewController
-        Logger.error("TODO")
     }
 
     private func updateContacts() {

--- a/Signal/src/views/ReminderView.swift
+++ b/Signal/src/views/ReminderView.swift
@@ -41,8 +41,9 @@ class ReminderView: UIView {
         setupSubviews()
     }
 
-    convenience init(tapAction: @escaping () -> Void) {
+    convenience init(text: String, tapAction: @escaping () -> Void) {
         self.init(frame: .zero)
+        self.text = text
         self.tapAction = tapAction
     }
 

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -217,6 +217,9 @@
 /* Activity Sheet label */
 "COMPARE_SAFETY_NUMBER_ACTION" = "Compare with Clipboard";
 
+/* Multiline label explaining why compose-screen contact picker is empty. */
+"COMPOSE_SCREEN_MISSING_CONTACTS_PERMISSION" = "To see which of your contacts are Signal users, enable contacts access in your system settings.";
+
 /* No comment provided by engineer. */
 "CONFIRM_ACCOUNT_DESTRUCTION_TEXT" = "This will reset the application by deleting your messages and unregister you with the server. The app will close after deletion of data.";
 
@@ -562,7 +565,7 @@
 /* Call setup status label */
 "IN_CALL_TERMINATED" = "Call Ended.";
 
-/* Multi line label explainging how to show names instead of phone numbers in your inbox */
+/* Multiline label explaining how to show names instead of phone numbers in your inbox */
 "INBOX_VIEW_MISSING_CONTACTS_PERMISSION" = "To see the names of your contacts, update your sytem settings to allow contact access.";
 
 /* notification body */

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Button text to dismiss missing contacts permission alert */
 "AB_PERMISSION_MISSING_ACTION_NOT_NOW" = "Not Now";
 
-/* Alert title when contacts disabled */
-"AB_PERMISSION_MISSING_TITLE" = "Sorry!";
-
 /* Action sheet item */
 "ACCEPT_NEW_IDENTITY_ACTION" = "Accept new safety number";
 
@@ -21,9 +18,6 @@
 
 /* Title for the 'add group member' view. */
 "ADD_GROUP_MEMBER_VIEW_TITLE" = "Add Member";
-
-/* Alert body when contacts disabled */
-"ADDRESSBOOK_RESTRICTED_ALERT_BODY" = "Signal requires access to your contacts. Access to contacts is restricted. Signal will close. You can disable the restriction temporarily to let Signal access your contacts by going the Settings app >> General >> Restrictions >> Contacts >> Allow Changes.";
 
 /* The label for the 'discard' button in alerts and action sheets. */
 "ALERT_DISCARD_BUTTON" = "Discard";
@@ -580,8 +574,13 @@
 /* No comment provided by engineer. */
 "INCOMING_INCOMPLETE_CALL" = "Incomplete incoming call from";
 
-/* Label for the cell that presents the 'invite contacts' workflow.
-   Text for button at the top of the contact picker */
+/* Alert body when contacts disabled while trying to invite contacts to signal */
+"INVITE_FLOW_REQUIRES_CONTACT_ACCESS_BODY" = "To invite your contacts, you need to allow Signal access to your contacts in the Settings app.";
+
+/* Alert title when contacts disabled while trying to invite contacts to signal */
+"INVITE_FLOW_REQUIRES_CONTACT_ACCESS_TITLE" = "Enable Contact Access";
+
+/* Label for the cell that presents the 'invite contacts' workflow. */
 "INVITE_FRIENDS_CONTACT_TABLE_BUTTON" = "Invite Friends to Signal";
 
 /* Search */


### PR DESCRIPTION
<img width="487" alt="screen shot 2017-05-05 at 6 22 22 pm" src="https://cloud.githubusercontent.com/assets/217057/25766326/e04ad25a-31bf-11e7-92c1-8df528ab8888.png">

As well as adding the banner, removed the irrelevant bits of the interface (e.g. search bar an Invite) which don't make sense without contact access.

PTAL @charlesmchen 
