### PR TITLE
Mkirk/polite intersection

### DIFF
--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -283,8 +283,10 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
     MessageComposeTableViewController *viewController = [MessageComposeTableViewController new];
 
     [self.contactsManager requestSystemContactsOnceWithCompletion:^(NSError *_Nullable error) {
-        DDLogError(@"%@ Error when requesting contacts: %@", self.tag, error);
-        // Even if there was an error fetching contacts we proceed to the next screen.
+        if (error) {
+            DDLogError(@"%@ Error when requesting contacts: %@", self.tag, error);
+        }
+        // Even if there is an error fetching contacts we proceed to the next screen.
         // As the compose view will present the proper thing depending on contact access.
         //
         // We just want to make sure contact access is *complete* before showing the compose


### PR DESCRIPTION
Be more careful about when we do contact intersections.

**Always:** whenever the system sends a contact-changed notification

**Sometimes:** when the app becomes active

1. If the contacts changed since we last checked - we won't always get a notification when contacts change, e.g. if the app was suspended

2. If 12 hours has passed (in line with Android)


PTAL @charlesmchen 

