### PR TITLE
Don't show "no signal accounts" until contact intersection has completed

### DIFF
--- a/Signal/src/ViewControllers/MessageComposeTableViewController.m
+++ b/Signal/src/ViewControllers/MessageComposeTableViewController.m
@@ -396,7 +396,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (!hasSearchText && helper.signalAccounts.count < 1) {
         // No Contacts
 
-        if (self.contactsViewHelper.contactsManager.isSystemContactsAuthorized) {
+        if (self.contactsViewHelper.contactsManager.isSystemContactsAuthorized
+            && self.contactsViewHelper.contactsManager.hasFetchedSignalAccountsAtLeastOnce) {
             [section addItem:[OWSTableItem itemWithCustomCellBlock:^{
                 UITableViewCell *cell = [UITableViewCell new];
                 cell.textLabel.text = NSLocalizedString(
@@ -462,10 +463,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showContactAppropriateViews
 {
     if (self.contactsViewHelper.contactsManager.isSystemContactsAuthorized) {
-        BOOL hasNoContacts = self.contactsViewHelper.signalAccounts.count < 1;
-        self.isNoContactsModeActive = (hasNoContacts && ![[Environment preferences] hasDeclinedNoContactsView]);
-        [self showContactsPermissionReminder:NO];
+        if (self.contactsViewHelper.contactsManager.hasFetchedSignalAccountsAtLeastOnce
+            && self.contactsViewHelper.signalAccounts.count < 1
+            && ![[Environment preferences] hasDeclinedNoContactsView]) {
+            self.isNoContactsModeActive = YES;
+        } else {
+            self.isNoContactsModeActive = NO;
+        }
 
+        [self showContactsPermissionReminder:NO];
         [self showSearchBar:YES];
     } else {
         // don't show "no signal contacts", show "no contact access"

--- a/Signal/src/contact/OWSContactsManager.h
+++ b/Signal/src/contact/OWSContactsManager.h
@@ -27,6 +27,9 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 @property (atomic, readonly) NSDictionary<NSString *, SignalAccount *> *signalAccountMap;
 @property (atomic, readonly) NSArray<SignalAccount *> *signalAccounts;
 
+// Useful to differentiate between having no signal accounts vs. haven't checked yet
+@property (atomic, readonly) BOOL hasFetchedSignalAccountsAtLeastOnce;
+
 - (nullable SignalAccount *)signalAccountForRecipientId:(NSString *)recipientId;
 
 - (Contact *)getOrBuildContactForPhoneIdentifier:(NSString *)identifier;

--- a/Signal/src/contact/OWSContactsManager.m
+++ b/Signal/src/contact/OWSContactsManager.m
@@ -25,6 +25,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification =
 @property (atomic) NSArray<Contact *> *allContacts;
 @property (atomic) NSDictionary<NSString *, Contact *> *allContactsMap;
 @property (atomic) NSArray<SignalAccount *> *signalAccounts;
+@property (atomic) BOOL hasFetchedSignalAccountsAtLeastOnce;
 @property (atomic) NSDictionary<NSString *, SignalAccount *> *signalAccountMap;
 @property (nonatomic, readonly) SystemContactsFetcher *systemContactsFetcher;
 @end
@@ -183,7 +184,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification =
         dispatch_async(dispatch_get_main_queue(), ^{
             self.signalAccountMap = [signalAccountMap copy];
             self.signalAccounts = [signalAccounts copy];
-
+            self.hasFetchedSignalAccountsAtLeastOnce = YES;
             [[NSNotificationCenter defaultCenter]
                 postNotificationName:OWSContactsManagerSignalAccountsDidChangeNotification
                               object:nil];


### PR DESCRIPTION
at least once

PTAL @charlesmchen 