### PR TITLE
Fix flicker of "no contacts" screen on message compose

### DIFF
--- a/Signal/src/ViewControllers/ContactsViewHelper.h
+++ b/Signal/src/ViewControllers/ContactsViewHelper.h
@@ -40,6 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSDictionary<NSString *, SignalAccount *> *signalAccountMap;
 @property (nonatomic, readonly) NSArray<SignalAccount *> *signalAccounts;
 
+// Useful to differentiate between having no signal accounts vs. haven't checked yet
+@property (nonatomic, readonly) BOOL hasUpdatedContactsAtLeastOnce;
+
 @property (nonatomic, readonly) NSArray<NSString *> *blockedPhoneNumbers;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Signal/src/ViewControllers/ContactsViewHelper.m
+++ b/Signal/src/ViewControllers/ContactsViewHelper.m
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSArray<NSString *> *blockedPhoneNumbers;
 
 @property (nonatomic) BOOL shouldNotifyDelegateOfUpdatedContacts;
+@property (nonatomic) BOOL hasUpdatedContactsAtLeastOnce;
 
 @end
 
@@ -164,6 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Don't fire delegate "change" events during initialization.
     if (!self.shouldNotifyDelegateOfUpdatedContacts) {
         [self.delegate contactsViewHelperDidUpdateContacts];
+        self.hasUpdatedContactsAtLeastOnce = YES;
     }
 }
 

--- a/Signal/src/ViewControllers/MessageComposeTableViewController.m
+++ b/Signal/src/ViewControllers/MessageComposeTableViewController.m
@@ -397,7 +397,7 @@ NS_ASSUME_NONNULL_BEGIN
         // No Contacts
 
         if (self.contactsViewHelper.contactsManager.isSystemContactsAuthorized
-            && self.contactsViewHelper.contactsManager.hasFetchedSignalAccountsAtLeastOnce) {
+            && self.contactsViewHelper.hasUpdatedContactsAtLeastOnce) {
             [section addItem:[OWSTableItem itemWithCustomCellBlock:^{
                 UITableViewCell *cell = [UITableViewCell new];
                 cell.textLabel.text = NSLocalizedString(
@@ -463,7 +463,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showContactAppropriateViews
 {
     if (self.contactsViewHelper.contactsManager.isSystemContactsAuthorized) {
-        if (self.contactsViewHelper.contactsManager.hasFetchedSignalAccountsAtLeastOnce
+        if (self.contactsViewHelper.hasUpdatedContactsAtLeastOnce
             && self.contactsViewHelper.signalAccounts.count < 1
             && ![[Environment preferences] hasDeclinedNoContactsView]) {
             self.isNoContactsModeActive = YES;

--- a/Signal/src/contact/OWSContactsManager.h
+++ b/Signal/src/contact/OWSContactsManager.h
@@ -27,9 +27,6 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 @property (atomic, readonly) NSDictionary<NSString *, SignalAccount *> *signalAccountMap;
 @property (atomic, readonly) NSArray<SignalAccount *> *signalAccounts;
 
-// Useful to differentiate between having no signal accounts vs. haven't checked yet
-@property (atomic, readonly) BOOL hasFetchedSignalAccountsAtLeastOnce;
-
 - (nullable SignalAccount *)signalAccountForRecipientId:(NSString *)recipientId;
 
 - (Contact *)getOrBuildContactForPhoneIdentifier:(NSString *)identifier;

--- a/Signal/src/contact/OWSContactsManager.m
+++ b/Signal/src/contact/OWSContactsManager.m
@@ -25,7 +25,6 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification =
 @property (atomic) NSArray<Contact *> *allContacts;
 @property (atomic) NSDictionary<NSString *, Contact *> *allContactsMap;
 @property (atomic) NSArray<SignalAccount *> *signalAccounts;
-@property (atomic) BOOL hasFetchedSignalAccountsAtLeastOnce;
 @property (atomic) NSDictionary<NSString *, SignalAccount *> *signalAccountMap;
 @property (nonatomic, readonly) SystemContactsFetcher *systemContactsFetcher;
 @end
@@ -184,7 +183,6 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification =
         dispatch_async(dispatch_get_main_queue(), ^{
             self.signalAccountMap = [signalAccountMap copy];
             self.signalAccounts = [signalAccounts copy];
-            self.hasFetchedSignalAccountsAtLeastOnce = YES;
             [[NSNotificationCenter defaultCenter]
                 postNotificationName:OWSContactsManagerSignalAccountsDidChangeNotification
                               object:nil];


### PR DESCRIPTION
The previous check was a little too early. There is a brief window between when the contacts manager has updated it's contacts and when the contactsHelper (which is where our viewcontroller accesses it's contacts) has updated.

PTAL @charlesmchen 