### PR TITLE
do not use phone data detectors

### DIFF
--- a/Signal/src/views/JSQMessagesCollectionViewCell+OWS.m
+++ b/Signal/src/views/JSQMessagesCollectionViewCell+OWS.m
@@ -1,5 +1,6 @@
-//  Created by Michael Kirk on 11/13/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "JSQMessagesCollectionViewCell+OWS.h"
 #import "UIColor+OWS.h"
@@ -22,8 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
     };
 
     self.textView.dataDetectorTypes
-        = (UIDataDetectorTypePhoneNumber | UIDataDetectorTypeLink | UIDataDetectorTypeAddress
-            | UIDataDetectorTypeCalendarEvent);
+        = (UIDataDetectorTypeLink | UIDataDetectorTypeAddress | UIDataDetectorTypeCalendarEvent);
 }
 
 @end


### PR DESCRIPTION
The actions offered by the phone number data detectors are confusing
within the context of a messaging app - e.g. people might assume that
the "call" action corresponds to a Signal call.

PTAL @charlesmchen 