### PR TITLE
confirm before sending to untrusted identity

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -136,7 +136,7 @@ CHECKOUT OPTIONS:
     :commit: 7054e4b13ee5bcd6d524adb6dc9a726e8c466308
     :git: https://github.com/WhisperSystems/JSQMessagesViewController.git
   SignalServiceKit:
-    :commit: 0201fa34ce760351149dd33674353d9e7edea32f
+    :commit: 0eef7ccb8fdaad7a119468b4b66f6bc565cfa346
     :git: https://github.com/WhisperSystems/SignalServiceKit.git
   SocketRocket:
     :commit: 877ac7438be3ad0b45ef5ca3969574e4b97112bf

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -241,6 +241,12 @@
 /* Button text */
 "CONFIRM_LINK_NEW_DEVICE_ACTION" = "Link New Device";
 
+/* Action sheet body presented when a users's SN have recently changed. Embeds {{contact's name or phone number}} */
+"CONFIRM_SENDING_TO_CHANGED_IDENTITY_BODY_FORMAT" = "%@ may have reinstalled or changed devices. Verify your Safety Number with them to ensure privacy.";
+
+/* Action sheet title presented when a users's SN have recently changed. Embeds {{contact's name or phone number}} */
+"CONFIRM_SENDING_TO_CHANGED_IDENTITY_TITLE_FORMAT" = "Safety Number with %@ has Changed";
+
 /* No comment provided by engineer. */
 "CONFIRMATION_TITLE" = "Confirm";
 
@@ -1036,6 +1042,9 @@
 /* Generic text for button that retries whatever the last action was. */
 "RETRY_BUTTON_TEXT" = "Retry";
 
+/* button title to confirm sending to a recipient whose safety number recently changed */
+"SAFETY_NUMBER_CHANGED_CONFIRM_SEND_ACTION" = "Confirm and Send";
+
 /* Snippet to share {{safety number}} with a friend. sent e.g. via SMS */
 "SAFETY_NUMBER_SHARE_FORMAT" = "Our Signal Safety Number:\n%@";
 
@@ -1346,7 +1355,7 @@
 "VERIFICATION_PHONE_NUMBER_FORMAT" = "Enter the verification code we sent to %@.";
 
 /* table cell label in conversation settings */
-"VERIFY_PRIVACY" = "Verify Safety Number";
+"VERIFY_PRIVACY" = "Show Safety Number";
 
 /* Indicates how to cancel a voice message. */
 "VOICE_MESSAGE_CANCEL_INSTRUCTIONS" = "Slide to Cancel";


### PR DESCRIPTION
Based on #2153, so feel free to review that first, but the changes can be seen pretty clearly in: 
 https://github.com/WhisperSystems/Signal-iOS/commit/c34462fb540f3671bde131e13644c40da81fd89d

requisite SSK: https://github.com/WhisperSystems/SignalServiceKit/pull/232

![screen shot 2017-05-25 at 4 56 57 pm](https://cloud.githubusercontent.com/assets/217057/26475287/bab16ba6-416b-11e7-99f8-77078f9658cd.png)
