### PR TITLE
Streamline observation of database modifications in home view.

### DIFF
--- a/Signal/src/ViewControllers/ThreadViewHelper.m
+++ b/Signal/src/ViewControllers/ThreadViewHelper.m
@@ -28,10 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
         return self;
     }
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(yapDatabaseModified:)
-                                                 name:TSUIDatabaseConnectionDidUpdateNotification
-                                               object:nil];
     [self initializeMapping];
 
     return self;


### PR DESCRIPTION
`yapDatabaseModified:` methods are expensive.  Home view doesn't need to observe database changes when its not the frontmost view or when the app is in the background.  

PTAL @michaelkirk 