### PR TITLE
Show verification state banner. Show verification state in conversati…

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		34DFCB851E8E04B500053165 /* AddToBlockListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 34DFCB841E8E04B500053165 /* AddToBlockListViewController.m */; };
 		34E3E5681EC4B19400495BAC /* AudioProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E3E5671EC4B19400495BAC /* AudioProgressView.swift */; };
 		34E8BF381EE9E2FD00F5F4CA /* FingerprintViewScanController.m in Sources */ = {isa = PBXBuildFile; fileRef = 34E8BF371EE9E2FD00F5F4CA /* FingerprintViewScanController.m */; };
+		34E8BF3B1EEB208E00F5F4CA /* DebugUIVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = 34E8BF3A1EEB208E00F5F4CA /* DebugUIVerification.m */; };
 		34F3089C1ECA4CDB00BB7697 /* TSUnreadIndicatorInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F3089B1ECA4CDB00BB7697 /* TSUnreadIndicatorInteraction.m */; };
 		34F3089F1ECA580B00BB7697 /* OWSUnreadIndicatorCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F3089E1ECA580B00BB7697 /* OWSUnreadIndicatorCell.m */; };
 		34F308A21ECB469700BB7697 /* OWSBezierPathView.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F308A11ECB469700BB7697 /* OWSBezierPathView.m */; };
@@ -494,6 +495,8 @@
 		34E3E5671EC4B19400495BAC /* AudioProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioProgressView.swift; sourceTree = "<group>"; };
 		34E8BF361EE9E2FD00F5F4CA /* FingerprintViewScanController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FingerprintViewScanController.h; sourceTree = "<group>"; };
 		34E8BF371EE9E2FD00F5F4CA /* FingerprintViewScanController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FingerprintViewScanController.m; sourceTree = "<group>"; };
+		34E8BF391EEB208E00F5F4CA /* DebugUIVerification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DebugUIVerification.h; sourceTree = "<group>"; };
+		34E8BF3A1EEB208E00F5F4CA /* DebugUIVerification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DebugUIVerification.m; sourceTree = "<group>"; };
 		34F3089A1ECA4CDB00BB7697 /* TSUnreadIndicatorInteraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSUnreadIndicatorInteraction.h; sourceTree = "<group>"; };
 		34F3089B1ECA4CDB00BB7697 /* TSUnreadIndicatorInteraction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSUnreadIndicatorInteraction.m; sourceTree = "<group>"; };
 		34F3089D1ECA580B00BB7697 /* OWSUnreadIndicatorCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OWSUnreadIndicatorCell.h; sourceTree = "<group>"; };
@@ -1030,10 +1033,12 @@
 				34D8C02A1ED3685800188D7C /* DebugUIContacts.m */,
 				34D8C0231ED3673300188D7C /* DebugUIMessages.h */,
 				34D8C0241ED3673300188D7C /* DebugUIMessages.m */,
-				34D8C0251ED3673300188D7C /* DebugUITableViewController.h */,
-				34D8C0261ED3673300188D7C /* DebugUITableViewController.m */,
 				452037CF1EE84975004E4CDF /* DebugUISessionState.h */,
 				452037D01EE84975004E4CDF /* DebugUISessionState.m */,
+				34D8C0251ED3673300188D7C /* DebugUITableViewController.h */,
+				34D8C0261ED3673300188D7C /* DebugUITableViewController.m */,
+				34E8BF391EEB208E00F5F4CA /* DebugUIVerification.h */,
+				34E8BF3A1EEB208E00F5F4CA /* DebugUIVerification.m */,
 			);
 			path = DebugUI;
 			sourceTree = "<group>";
@@ -2099,6 +2104,7 @@
 				34B3F8931E8DF1710035BE1A /* SignalsNavigationController.m in Sources */,
 				76EB063A18170B33006006FC /* FunctionalUtil.m in Sources */,
 				34F308A21ECB469700BB7697 /* OWSBezierPathView.m in Sources */,
+				34E8BF3B1EEB208E00F5F4CA /* DebugUIVerification.m in Sources */,
 				76EB058A18170B33006006FC /* Release.m in Sources */,
 				45D231771DC7E8F10034FA89 /* SessionResetJob.swift in Sources */,
 				450873C71D9D867B006B54F2 /* OWSIncomingMessageCollectionViewCell.m in Sources */,

--- a/Signal/src/ViewControllers/ContactsViewHelper.m
+++ b/Signal/src/ViewControllers/ContactsViewHelper.m
@@ -79,18 +79,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)signalAccountsDidChange:(NSNotification *)notification
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self updateContacts];
-    });
+    OWSAssert([NSThread isMainThread]);
+
+    [self updateContacts];
 }
 
 - (void)blockedPhoneNumbersDidChange:(id)notification
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.blockedPhoneNumbers = [_blockingManager blockedPhoneNumbers];
+    OWSAssert([NSThread isMainThread]);
 
-        [self updateContacts];
-    });
+    self.blockedPhoneNumbers = [_blockingManager blockedPhoneNumbers];
+
+    [self updateContacts];
 }
 
 #pragma mark - Contacts

--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -1273,11 +1273,7 @@ typedef enum : NSUInteger {
     // return from FingerprintViewController.
     [self dismissKeyBoard];
 
-    FingerprintViewController *fingerprintViewController = [FingerprintViewController new];
-    [fingerprintViewController configureWithRecipientId:recipientId];
-    UINavigationController *navigationController =
-        [[UINavigationController alloc] initWithRootViewController:fingerprintViewController];
-    [self presentViewController:navigationController animated:YES completion:nil];
+    [FingerprintViewController showVerificationViewFromViewController:self recipientId:recipientId];
 }
 
 #pragma mark - Calls

--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -182,7 +182,7 @@ typedef enum : NSUInteger {
 @property (nonatomic) UILabel *navigationBarTitleLabel;
 @property (nonatomic) UILabel *navigationBarSubtitleLabel;
 @property (nonatomic) UIButton *attachButton;
-@property (nonatomic) UIView *blockStateIndicator;
+@property (nonatomic) UIView *bannerView;
 
 // Back Button Unread Count
 @property (nonatomic, readonly) UIView *backButtonUnreadCountView;
@@ -294,9 +294,9 @@ typedef enum : NSUInteger {
 
 - (void)blockedPhoneNumbersDidChange:(id)notification
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self ensureBlockStateIndicator];
-    });
+    OWSAssert([NSThread isMainThread]);
+
+    [self ensureBannerState];
 }
 
 - (void)identityStateDidChange:(NSNotification *)notification
@@ -304,6 +304,7 @@ typedef enum : NSUInteger {
     OWSAssert([NSThread isMainThread]);
 
     [self updateNavigationBarSubtitleLabel];
+    [self ensureBannerState];
 }
 
 - (void)peekSetup
@@ -543,7 +544,7 @@ typedef enum : NSUInteger {
     // Triggering modified notification renders "call notification" when leaving full screen call view
     [self.thread touch];
 
-    [self ensureBlockStateIndicator];
+    [self ensureBannerState];
 
     [self resetContentAndLayout];
 
@@ -671,17 +672,49 @@ typedef enum : NSUInteger {
 {
     _userHasScrolled = userHasScrolled;
 
-    [self ensureBlockStateIndicator];
+    [self ensureBannerState];
 }
 
-- (void)ensureBlockStateIndicator
+- (void)ensureBannerState
 {
     // This method should be called rarely, so it's simplest to discard and
     // rebuild the indicator view every time.
-    [self.blockStateIndicator removeFromSuperview];
-    self.blockStateIndicator = nil;
+    [self.bannerView removeFromSuperview];
+    self.bannerView = nil;
 
     if (self.userHasScrolled) {
+        return;
+    }
+
+    // A collection of the group members who are "no longer verified".
+    NSMutableArray<NSString *> *noLongerVerifiedRecipientIds = [NSMutableArray new];
+    for (NSString *recipientId in self.thread.recipientIdentifiers) {
+        if ([[OWSIdentityManager sharedManager] verificationStateForRecipientId:recipientId]
+            == OWSVerificationStateNoLongerVerified) {
+            [noLongerVerifiedRecipientIds addObject:recipientId];
+        }
+    }
+    if (noLongerVerifiedRecipientIds.count > 0) {
+        NSString *message;
+        if (noLongerVerifiedRecipientIds.count > 1) {
+            message = NSLocalizedString(@"MESSAGES_VIEW_N_MEMBERS_NO_LONGER_VERIFIED",
+                @"Indicates that more than one member of this group conversation is no longer verified.");
+        } else {
+            NSString *recipientId = [noLongerVerifiedRecipientIds firstObject];
+            NSString *displayName = [self.contactsManager displayNameForPhoneIdentifier:recipientId];
+            NSString *format
+                = (self.isGroupConversation ? NSLocalizedString(@"MESSAGES_VIEW_1_MEMBER_NO_LONGER_VERIFIED_FORMAT",
+                                                  @"Indicates that one member of this group conversation is no longer "
+                                                  @"verified. Embeds {{user's name or phone number}}.")
+                                            : NSLocalizedString(@"MESSAGES_VIEW_CONTACT_NO_LONGER_VERIFIED_FORMAT",
+                                                  @"Indicates that this 1:1 conversation is no longer verified. Embeds "
+                                                  @"{{user's name or phone number}}."));
+            message = [NSString stringWithFormat:format, displayName];
+        }
+
+        [self createBannerWithTitle:message
+                        bannerColor:[UIColor ows_destructiveRedColor]
+                        tapSelector:@selector(noLongerVerifiedBannerViewWasTapped:)];
         return;
     }
 
@@ -704,41 +737,61 @@ typedef enum : NSUInteger {
     }
 
     if (blockStateMessage) {
-        UILabel *label = [UILabel new];
-        label.font = [UIFont ows_mediumFontWithSize:14.f];
-        label.text = blockStateMessage;
-        label.textColor = [UIColor whiteColor];
-
-        UIView *blockStateIndicator = [UIView new];
-        blockStateIndicator.backgroundColor = [UIColor ows_redColor];
-        blockStateIndicator.layer.cornerRadius = 2.5f;
-
-        // Use a shadow to "pop" the indicator above the other views.
-        blockStateIndicator.layer.shadowColor = [UIColor blackColor].CGColor;
-        blockStateIndicator.layer.shadowOffset = CGSizeMake(2, 3);
-        blockStateIndicator.layer.shadowRadius = 2.f;
-        blockStateIndicator.layer.shadowOpacity = 0.35f;
-
-        [blockStateIndicator addSubview:label];
-        [label autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:5];
-        [label autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:5];
-        [label autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:15];
-        [label autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:15];
-
-        [blockStateIndicator addGestureRecognizer:[[UITapGestureRecognizer alloc]
-                                                      initWithTarget:self
-                                                              action:@selector(blockStateIndicatorWasTapped:)]];
-
-        [self.view addSubview:blockStateIndicator];
-        [blockStateIndicator autoHCenterInSuperview];
-        [blockStateIndicator autoPinToTopLayoutGuideOfViewController:self withInset:10];
-        [self.view layoutSubviews];
-
-        self.blockStateIndicator = blockStateIndicator;
+        [self createBannerWithTitle:blockStateMessage
+                        bannerColor:[UIColor ows_destructiveRedColor]
+                        tapSelector:@selector(blockBannerViewWasTapped:)];
     }
 }
 
-- (void)blockStateIndicatorWasTapped:(UIGestureRecognizer *)sender
+- (void)createBannerWithTitle:(NSString *)title bannerColor:(UIColor *)bannerColor tapSelector:(SEL)tapSelector
+{
+    OWSAssert(title.length > 0);
+    OWSAssert(bannerColor);
+
+    UILabel *label = [UILabel new];
+    label.font = [UIFont ows_mediumFontWithSize:14.f];
+    label.text = title;
+    label.textColor = [UIColor whiteColor];
+    label.numberOfLines = 0;
+    label.lineBreakMode = NSLineBreakByWordWrapping;
+    label.textAlignment = NSTextAlignmentCenter;
+
+    UIView *bannerView = [UIView new];
+    bannerView.backgroundColor = bannerColor;
+    bannerView.layer.cornerRadius = 2.5f;
+
+    // Use a shadow to "pop" the indicator above the other views.
+    bannerView.layer.shadowColor = [UIColor blackColor].CGColor;
+    bannerView.layer.shadowOffset = CGSizeMake(2, 3);
+    bannerView.layer.shadowRadius = 2.f;
+    bannerView.layer.shadowOpacity = 0.35f;
+
+    [bannerView addSubview:label];
+    [label autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:5];
+    [label autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:5];
+    const CGFloat kBannerHPadding = 15.f;
+    [label autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:kBannerHPadding];
+    [label autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:kBannerHPadding];
+
+    [bannerView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:tapSelector]];
+
+    [self.view addSubview:bannerView];
+    [bannerView autoPinToTopLayoutGuideOfViewController:self withInset:10];
+    [bannerView autoHCenterInSuperview];
+
+    CGFloat labelDesiredWidth = [label sizeThatFits:CGSizeZero].width;
+    CGFloat bannerDesiredWidth = labelDesiredWidth + kBannerHPadding * 2.f;
+    const CGFloat kMinBannerHMargin = 20.f;
+    if (bannerDesiredWidth + kMinBannerHMargin * 2.f >= self.view.width) {
+        [bannerView autoPinWidthToSuperviewWithMargin:kMinBannerHMargin];
+    }
+
+    [self.view layoutSubviews];
+
+    self.bannerView = bannerView;
+}
+
+- (void)blockBannerViewWasTapped:(UIGestureRecognizer *)sender
 {
     if (sender.state != UIGestureRecognizerStateRecognized) {
         return;
@@ -755,6 +808,13 @@ typedef enum : NSUInteger {
             BlockListViewController *vc = [[BlockListViewController alloc] init];
             [self.navigationController pushViewController:vc animated:YES];
         }
+    }
+}
+
+- (void)noLongerVerifiedBannerViewWasTapped:(UIGestureRecognizer *)sender
+{
+    if (sender.state == UIGestureRecognizerStateRecognized) {
+        [self showConversationSettingsAndShowVerification:YES];
     }
 }
 
@@ -1793,6 +1853,11 @@ typedef enum : NSUInteger {
 
 - (void)showConversationSettings
 {
+    [self showConversationSettingsAndShowVerification:NO];
+}
+
+- (void)showConversationSettingsAndShowVerification:(BOOL)showVerification
+{
     if (self.userLeftGroup) {
         DDLogDebug(@"%@ Ignoring request to show conversation settings, since user left group", self.tag);
         return;
@@ -1801,6 +1866,7 @@ typedef enum : NSUInteger {
     OWSConversationSettingsTableViewController *settingsVC = [OWSConversationSettingsTableViewController new];
     settingsVC.conversationSettingsViewDelegate = self;
     [settingsVC configureWithThread:self.thread];
+    settingsVC.showVerificationOnAppear = showVerification;
     [self.navigationController pushViewController:settingsVC animated:YES];
 }
 

--- a/Signal/src/ViewControllers/DebugUI/DebugUIVerification.h
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIVerification.h
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "OWSTableViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class TSContactThread;
+
+@interface DebugUIVerification : NSObject
+
++ (OWSTableSection *)sectionForThread:(TSContactThread *)thread;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/src/ViewControllers/DebugUI/DebugUIVerification.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIVerification.m
@@ -1,0 +1,77 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "DebugUIVerification.h"
+#import "DebugUIMessages.h"
+#import "Signal-Swift.h"
+#import <SignalServiceKit/OWSIdentityManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation DebugUIVerification
+
+#pragma mark - Logging
+
++ (NSString *)tag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag
+{
+    return self.class.tag;
+}
+
+#pragma mark - Factory Methods
+
++ (OWSTableSection *)sectionForThread:(TSContactThread *)thread
+{
+    OWSAssert(thread);
+
+    NSString *recipientId = thread.contactIdentifier;
+    OWSAssert(recipientId.length > 0);
+
+    return [OWSTableSection
+        sectionWithTitle:@"Verification"
+                   items:@[
+                       [OWSTableItem itemWithTitle:@"Default"
+                                       actionBlock:^{
+                                           [DebugUIVerification setVerificationState:OWSVerificationStateDefault
+                                                                         recipientId:recipientId];
+                                       }],
+                       [OWSTableItem itemWithTitle:@"Verified"
+                                       actionBlock:^{
+                                           [DebugUIVerification setVerificationState:OWSVerificationStateVerified
+                                                                         recipientId:recipientId];
+                                       }],
+                       [OWSTableItem itemWithTitle:@"No Longer Verified"
+                                       actionBlock:^{
+                                           [DebugUIVerification
+                                               setVerificationState:OWSVerificationStateNoLongerVerified
+                                                        recipientId:recipientId];
+                                       }],
+                   ]];
+}
+
++ (void)setVerificationState:(OWSVerificationState)verificationState recipientId:(NSString *)recipientId
+{
+    OWSAssert(recipientId.length > 0);
+
+    OWSRecipientIdentity *_Nullable recipientIdentity =
+        [[OWSIdentityManager sharedManager] recipientIdentityForRecipientId:recipientId];
+    OWSAssert(recipientIdentity);
+    // By capturing the identity key when we enter these views, we prevent the edge case
+    // where the user verifies a key that we learned about while this view was open.
+    NSData *identityKey = recipientIdentity.identityKey;
+    OWSAssert(identityKey.length > 0);
+
+    [OWSIdentityManager.sharedManager setVerificationState:verificationState
+                                               identityKey:identityKey
+                                               recipientId:recipientId
+                                           sendSyncMessage:verificationState != OWSVerificationStateNoLongerVerified];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/src/ViewControllers/FingerprintViewController.h
+++ b/Signal/src/ViewControllers/FingerprintViewController.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FingerprintViewController : UIViewController
 
-- (void)configureWithRecipientId:(NSString *)recipientId NS_SWIFT_NAME(configure(recipientId:));
++ (void)showVerificationViewFromViewController:(UIViewController *)viewController recipientId:(NSString *)recipientId;
 
 @end
 

--- a/Signal/src/ViewControllers/FingerprintViewController.m
+++ b/Signal/src/ViewControllers/FingerprintViewController.m
@@ -89,6 +89,27 @@ typedef void (^CustomLayoutBlock)();
 
 @implementation FingerprintViewController
 
++ (void)showVerificationViewFromViewController:(UIViewController *)viewController recipientId:(NSString *)recipientId
+{
+    OWSAssert(recipientId.length > 0);
+
+    OWSRecipientIdentity *_Nullable recipientIdentity =
+        [[OWSIdentityManager sharedManager] recipientIdentityForRecipientId:recipientId];
+    if (!recipientIdentity) {
+        [OWSAlerts showAlertWithTitle:NSLocalizedString(@"CANT_VERIFY_IDENTITY_ALERT_TITLE",
+                                          @"Title for alert explaining that a user cannot be verified.")
+                              message:NSLocalizedString(@"CANT_VERIFY_IDENTITY_ALERT_MESSAGE",
+                                          @"Message for alert explaining that a user cannot be verified.")];
+        return;
+    }
+
+    FingerprintViewController *fingerprintViewController = [FingerprintViewController new];
+    [fingerprintViewController configureWithRecipientId:recipientId];
+    UINavigationController *navigationController =
+        [[UINavigationController alloc] initWithRootViewController:fingerprintViewController];
+    [viewController presentViewController:navigationController animated:YES completion:nil];
+}
+
 - (instancetype)init
 {
     self = [super init];
@@ -493,6 +514,8 @@ typedef void (^CustomLayoutBlock)();
                                 :self.identityKey
                      recipientId:self.recipientId
                  sendSyncMessage:YES];
+
+        [self dismissViewControllerAnimated:YES completion:nil];
     }
 }
 

--- a/Signal/src/ViewControllers/OWSConversationSettingsTableViewController.h
+++ b/Signal/src/ViewControllers/OWSConversationSettingsTableViewController.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<OWSConversationSettingsViewDelegate> conversationSettingsViewDelegate;
 
+@property (nonatomic) BOOL showVerificationOnAppear;
+
 - (void)configureWithThread:(TSThread *)thread;
 
 @end

--- a/Signal/src/ViewControllers/SafetyNumberConfirmationAlert.swift
+++ b/Signal/src/ViewControllers/SafetyNumberConfirmationAlert.swift
@@ -63,7 +63,7 @@ class SafetyNumberConfirmationAlert: NSObject {
         }
         actionSheetController.addAction(confirmAction)
 
-        let showSafetyNumberAction = UIAlertAction(title: NSLocalizedString("VERIFY_PRIVACY", comment: "Action sheet item"), style: .default) { _ in
+        let showSafetyNumberAction = UIAlertAction(title: NSLocalizedString("VERIFY_PRIVACY", comment: "Label for button or row which allows users to verify the safety number of another user."), style: .default) { _ in
             Logger.info("\(self.TAG) Opted to show Safety Number for identity: \(untrustedIdentity)")
 
             self.presentSafetyNumberViewController(theirIdentityKey: untrustedIdentity.identityKey,
@@ -82,10 +82,11 @@ class SafetyNumberConfirmationAlert: NSObject {
     }
 
     public func presentSafetyNumberViewController(theirIdentityKey: Data, theirRecipientId: String, theirDisplayName: String, completion: (() -> Void)? = nil) {
-        let fingerprintViewController = FingerprintViewController()
-        fingerprintViewController.configure(recipientId: theirRecipientId)
-        let navigationController = UINavigationController(rootViewController:fingerprintViewController)
-        UIApplication.shared.frontmostViewController?.present(navigationController, animated: true, completion: completion)
+        guard let fromViewController = UIApplication.shared.frontmostViewController else {
+            Logger.info("\(self.TAG) Missing frontmostViewController")
+            return
+        }
+        FingerprintViewController.showVerificationView(from:fromViewController, recipientId:theirRecipientId)
     }
 
     private func untrustedIdentityForSending(recipientIds: [String]) -> OWSRecipientIdentity? {

--- a/Signal/src/ViewControllers/ShowGroupMembersViewController.m
+++ b/Signal/src/ViewControllers/ShowGroupMembersViewController.m
@@ -274,6 +274,14 @@ NS_ASSUME_NONNULL_BEGIN
                                              handler:^(UIAlertAction *_Nonnull action) {
                                                  [self callMember:recipientId];
                                              }]];
+        [actionSheetController
+            addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"VERIFY_PRIVACY",
+                                                         @"Label for button or row which allows users to verify the "
+                                                         @"safety number of another user.")
+                                               style:UIAlertActionStyleDefault
+                                             handler:^(UIAlertAction *_Nonnull action) {
+                                                 [self verifySafetyNumber:recipientId];
+                                             }]];
     }
 
     UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"TXT_CANCEL_TITLE", @"")
@@ -303,6 +311,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)callMember:(NSString *)recipientId
 {
     [Environment callUserWithIdentifier:recipientId];
+}
+
+- (void)verifySafetyNumber:(NSString *)recipientId
+{
+    OWSAssert(recipientId.length > 0);
+
+    [FingerprintViewController showVerificationViewFromViewController:self recipientId:recipientId];
 }
 
 #pragma mark - ContactsViewHelperDelegate

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -132,18 +132,18 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
 
 - (void)blockedPhoneNumbersDidChange:(id)notification
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        _blockedPhoneNumberSet = [NSSet setWithArray:[_blockingManager blockedPhoneNumbers]];
-        
-        [self.tableView reloadData];
-    });
+    OWSAssert([NSThread isMainThread]);
+
+    _blockedPhoneNumberSet = [NSSet setWithArray:[_blockingManager blockedPhoneNumbers]];
+
+    [self.tableView reloadData];
 }
 
 - (void)signalAccountsDidChange:(id)notification
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.tableView reloadData];
-    });
+    OWSAssert([NSThread isMainThread]);
+
+    [self.tableView reloadData];
 }
 
 #pragma mark - View Life Cycle

--- a/Signal/src/util/OWSContactsSyncing.m
+++ b/Signal/src/util/OWSContactsSyncing.m
@@ -61,9 +61,9 @@ NSString *const kTSStorageManagerOWSContactsSyncingLastMessageKey =
 
 - (void)signalAccountsDidChange:(id)notification
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self sendSyncContactsMessageIfPossible];
-    });
+    OWSAssert([NSThread isMainThread]);
+
+    [self sendSyncContactsMessageIfPossible];
 }
 
 #pragma mark - Methods

--- a/Signal/src/views/ContactTableViewCell.h
+++ b/Signal/src/views/ContactTableViewCell.h
@@ -33,6 +33,8 @@ extern NSString *const kContactsTable_CellReuseIdentifier;
 
 - (void)configureWithThread:(TSThread *)thread contactsManager:(OWSContactsManager *)contactsManager;
 
+- (void)addVerifiedSubtitle;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Signal/src/views/ContactTableViewCell.m
+++ b/Signal/src/views/ContactTableViewCell.m
@@ -23,6 +23,7 @@ const NSUInteger kContactTableViewCellAvatarSize = 40;
 
 @property (nonatomic) IBOutlet UILabel *nameLabel;
 @property (nonatomic) IBOutlet UIImageView *avatarView;
+@property (nonatomic, nullable) UILabel *subtitle;
 
 @end
 
@@ -144,11 +145,67 @@ const NSUInteger kContactTableViewCellAvatarSize = 40;
     [self layoutSubviews];
 }
 
+- (void)addVerifiedSubtitle
+{
+    [self.subtitle removeFromSuperview];
+
+    const CGFloat kSubtitlePointSize = 10.f;
+    NSMutableAttributedString *text = [NSMutableAttributedString new];
+    // "checkmark"
+    [text appendAttributedString:[[NSAttributedString alloc]
+                                     initWithString:@"\uf00c "
+                                         attributes:@{
+                                             NSFontAttributeName : [UIFont ows_fontAwesomeFont:kSubtitlePointSize],
+                                         }]];
+    [text appendAttributedString:[[NSAttributedString alloc]
+                                     initWithString:NSLocalizedString(@"PRIVACY_IDENTITY_IS_VERIFIED_BADGE",
+                                                        @"Badge indicating that the user is verified.")]];
+    self.subtitle = [UILabel new];
+    self.subtitle.font = [UIFont ows_regularFontWithSize:kSubtitlePointSize];
+    self.subtitle.textColor = [UIColor ows_darkGrayColor];
+    self.subtitle.attributedText = text;
+    [self.subtitle sizeToFit];
+    [self.contentView addSubview:self.subtitle];
+
+    [self setNeedsLayout];
+}
+
+- (void)setFrame:(CGRect)frame
+{
+    [super setFrame:frame];
+
+    [self layoutSubviews];
+}
+
+- (void)setBounds:(CGRect)bounds
+{
+    [super setBounds:bounds];
+
+    [self layoutSubviews];
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+
+    if (self.subtitle) {
+        OWSAssert(self.nameLabel.superview == self.contentView);
+        const CGFloat kSubtitleVMargin
+            = ((self.contentView.height - self.nameLabel.font.lineHeight) * 0.5f - self.subtitle.height) * 0.5f;
+        self.subtitle.frame = CGRectMake(self.nameLabel.left,
+            round((self.contentView.height - self.subtitle.height) - kSubtitleVMargin),
+            self.subtitle.width,
+            self.subtitle.height);
+    }
+}
+
 - (void)prepareForReuse
 {
     self.accessoryMessage = nil;
     self.accessoryView = nil;
     self.accessoryType = UITableViewCellAccessoryNone;
+    [self.subtitle removeFromSuperview];
+    self.subtitle = nil;
 }
 
 @end

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -715,8 +715,14 @@
 /* message footer while attachment is uploading */
 "MESSAGE_STATUS_UPLOADING" = "Uploading…";
 
+/* Indicates that one member of this group conversation is no longer verified. Embeds {{user's name or phone number}}. */
+"MESSAGES_VIEW_1_MEMBER_NO_LONGER_VERIFIED_FORMAT" = "%@ is no longer verified.";
+
 /* Indicates that this 1:1 conversation has been blocked. */
 "MESSAGES_VIEW_CONTACT_BLOCKED" = "You Blocked this User";
+
+/* Indicates that this 1:1 conversation is no longer verified. Embeds {{user's name or phone number}}. */
+"MESSAGES_VIEW_CONTACT_NO_LONGER_VERIFIED_FORMAT" = "%@ is no longer verified.";
 
 /* Action sheet title after tapping on failed download. */
 "MESSAGES_VIEW_FAILED_DOWNLOAD_ACTIONSHEET_TITLE" = "Download Failed.";
@@ -729,6 +735,9 @@
 
 /* Indicates that some members of this group has been blocked. Embeds {{the number of blocked users in this group}}. */
 "MESSAGES_VIEW_GROUP_N_MEMBERS_BLOCKED_FORMAT" = "You Blocked %d Members of this Group";
+
+/* Indicates that more than one member of this group conversation is no longer verified. */
+"MESSAGES_VIEW_N_MEMBERS_NO_LONGER_VERIFIED" = "More than one member of this group is no longer verified.";
 
 /* The subtitle for the messages view title indicates that the title can be tapped to access settings for this conversation. */
 "MESSAGES_VIEW_TITLE_SUBTITLE" = "Tap here for settings";
@@ -942,6 +951,9 @@
 
 /* Label indicating that the user is not verified. Embeds {{the user's name or phone number}}. */
 "PRIVACY_IDENTITY_IS_NOT_VERIFIED_FORMAT" = "%@ is not verified.";
+
+/* Badge indicating that the user is verified. */
+"PRIVACY_IDENTITY_IS_VERIFIED_BADGE" = "Verified";
 
 /* Label indicating that the user is verified. Embeds {{the user's name or phone number}}. */
 "PRIVACY_IDENTITY_IS_VERIFIED_FORMAT" = "%@ is verified.";

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -226,6 +226,12 @@
 /* The generic name used for calls if CallKit privacy is enabled */
 "CALLKIT_ANONYMOUS_CONTACT_NAME" = "Signal User";
 
+/* Message for alert explaining that a user cannot be verified. */
+"CANT_VERIFY_IDENTITY_ALERT_MESSAGE" = "This user can't be verified until you've exchanged messages with them.";
+
+/* Title for alert explaining that a user cannot be verified. */
+"CANT_VERIFY_IDENTITY_ALERT_TITLE" = "Error";
+
 /* Title for the 'censorship circumvention country' view. */
 "CENSORSHIP_CIRCUMVENTION_COUNTRY_VIEW_TITLE" = "Select Country";
 
@@ -1438,8 +1444,7 @@
 /* Generic message indicating that verification state changed for a given user. */
 "VERIFICATION_STATE_CHANGE_GENERIC" = "Verification state changed.";
 
-/* Action sheet item
-   table cell label in conversation settings */
+/* Label for button or row which allows users to verify the safety number of another user. */
 "VERIFY_PRIVACY" = "Show Safety Number";
 
 /* Indicates how to cancel a voice message. */


### PR DESCRIPTION
…on settings view.

* Show verification state banner. 
* Show verification state in conversation settings view.
* Check for identity key before presenting fingerprint view.
* Show verification state in a separate subtitle in conversation view.
* Let users verify from group members view.

PTAL @michaelkirk 

### Let users verify from group members view.

![screen shot 2017-06-09 at 4 55 06 pm](https://user-images.githubusercontent.com/625803/26994330-39bb24f8-4d35-11e7-8bed-d88662aada1e.png)

### Show verification state in conversation settings view (contact has name).

![screen shot 2017-06-09 at 4 52 22 pm](https://user-images.githubusercontent.com/625803/26994331-39bc8f00-4d35-11e7-9d97-86712afbe347.png)

### Show verification state in conversation settings view (contact has no name).

![screen shot 2017-06-09 at 4 16 23 pm](https://user-images.githubusercontent.com/625803/26993160-e80f6894-4d2f-11e7-83db-c37b0624c492.png)

### Verification banner (1:1 conversation).

![screen shot 2017-06-09 at 4 07 40 pm](https://user-images.githubusercontent.com/625803/26993161-e80f8978-4d2f-11e7-81a2-69ab8fd073e0.png)

### Verification banner (group, 1 no longer verified group member).

![screen shot 2017-06-09 at 4 08 06 pm](https://user-images.githubusercontent.com/625803/26993162-e81be6f0-4d2f-11e7-8468-eecd2eabcd56.png)

### Verification banner (group, more than one no longer verified group member).

![screen shot 2017-06-09 at 4 07 33 pm](https://user-images.githubusercontent.com/625803/26993159-e80f3eaa-4d2f-11e7-84b2-9ee4aab82d55.png)

### Show verification state in group members view.

![screen shot 2017-06-09 at 4 07 24 pm](https://user-images.githubusercontent.com/625803/26993158-e80ef738-4d2f-11e7-8d61-3b2d06f8b074.png)





Note: Some of the copy changed after I took these screenshots.
