### PR TITLE
Don’t auto-scroll after “loading more messages” unless we have “more …

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -2184,6 +2184,9 @@ typedef enum : NSUInteger {
                              header:(JSQMessagesLoadEarlierHeaderView *)headerView
     didTapLoadEarlierMessagesButton:(UIButton *)sender
 {
+    OWSAssert(!self.isUserScrolling);
+
+    BOOL hasMoreUnseenMessages = self.dynamicInteractions.hasMoreUnseenMessages;
 
     // We want to restore the current scroll state after we update the range, update
     // the dynamic interactions and re-layout.  Here we take a "before" snapshot.
@@ -2229,13 +2232,16 @@ typedef enum : NSUInteger {
     [self.collectionView layoutSubviews];
 
     self.collectionView.contentOffset = CGPointMake(0, self.collectionView.contentSize.height - scrollDistanceToBottom);
+
     [self.scrollLaterTimer invalidate];
-    // We want to scroll to the bottom _after_ the layout has been updated.
-    self.scrollLaterTimer = [NSTimer weakScheduledTimerWithTimeInterval:0.001f
-                                                                 target:self
-                                                               selector:@selector(scrollToUnreadIndicatorAnimated)
-                                                               userInfo:nil
-                                                                repeats:NO];
+    if (hasMoreUnseenMessages) {
+        // We want to scroll to the bottom _after_ the layout has been updated.
+        self.scrollLaterTimer = [NSTimer weakScheduledTimerWithTimeInterval:0.001f
+                                                                     target:self
+                                                                   selector:@selector(scrollToUnreadIndicatorAnimated)
+                                                                   userInfo:nil
+                                                                    repeats:NO];
+    }
 
     [self updateLoadEarlierVisible];
 }

--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -2186,7 +2186,7 @@ typedef enum : NSUInteger {
 {
     OWSAssert(!self.isUserScrolling);
 
-    BOOL hasMoreUnseenMessages = self.dynamicInteractions.hasMoreUnseenMessages;
+    BOOL hasEarlierUnseenMessages = self.dynamicInteractions.hasMoreUnseenMessages;
 
     // We want to restore the current scroll state after we update the range, update
     // the dynamic interactions and re-layout.  Here we take a "before" snapshot.
@@ -2234,7 +2234,10 @@ typedef enum : NSUInteger {
     self.collectionView.contentOffset = CGPointMake(0, self.collectionView.contentSize.height - scrollDistanceToBottom);
 
     [self.scrollLaterTimer invalidate];
-    if (hasMoreUnseenMessages) {
+    // Don’t auto-scroll after “loading more messages” unless we have “more unseen messages”.
+    //
+    // Otherwise, tapping on "load more messages" autoscrolls you downward which is completely wrong.
+    if (hasEarlierUnseenMessages) {
         // We want to scroll to the bottom _after_ the layout has been updated.
         self.scrollLaterTimer = [NSTimer weakScheduledTimerWithTimeInterval:0.001f
                                                                      target:self

--- a/Signal/src/util/ThreadUtil.h
+++ b/Signal/src/util/ThreadUtil.h
@@ -36,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 // YES in ensureDynamicInteractionsForThread:...
 @property (nonatomic, nullable) NSNumber *firstUnseenInteractionTimestamp;
 
+@property (nonatomic) BOOL hasMoreUnseenMessages;
+
 - (void)clearUnreadIndicatorState;
 
 @end

--- a/Signal/src/util/ThreadUtil.h
+++ b/Signal/src/util/ThreadUtil.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 // This is used by MessageViewController to increase the
 // range size of the mappings (the load window of the conversation)
 // to include the unread indicator.
-@property (nonatomic, nullable) NSNumber *unreadIndicatorPosition;
+@property (nonatomic, nullable, readonly) NSNumber *unreadIndicatorPosition;
 
 // If there are unseen messages in the thread, this is the timestamp
 // of the oldest unseen messaage.
@@ -34,9 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 // repeatedly. The unread indicator should continue to show up until
 // it has been cleared, at which point hideUnreadMessagesIndicator is
 // YES in ensureDynamicInteractionsForThread:...
-@property (nonatomic, nullable) NSNumber *firstUnseenInteractionTimestamp;
+@property (nonatomic, nullable, readonly) NSNumber *firstUnseenInteractionTimestamp;
 
-@property (nonatomic) BOOL hasMoreUnseenMessages;
+@property (nonatomic, readonly) BOOL hasMoreUnseenMessages;
 
 - (void)clearUnreadIndicatorState;
 

--- a/Signal/src/util/ThreadUtil.m
+++ b/Signal/src/util/ThreadUtil.m
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     self.unreadIndicatorPosition = nil;
     self.firstUnseenInteractionTimestamp = nil;
+    self.hasMoreUnseenMessages = NO;
 }
 
 @end
@@ -200,7 +201,6 @@ NS_ASSUME_NONNULL_BEGIN
         // so that it can widen its "load window" to always show
         // the unread indicator.
         __block long visibleUnseenMessageCount = 0;
-        __block BOOL hasMoreUnseenMessages = NO;
         __block TSInteraction *interactionAfterUnreadIndicator = nil;
         NSUInteger missingUnseenSafetyNumberChangeCount = 0;
         if (result.firstUnseenInteractionTimestamp != nil) {
@@ -243,13 +243,13 @@ NS_ASSUME_NONNULL_BEGIN
                                   // messages view, show the unread indicator at the top of the
                                   // displayed messages.
                                   *stop = YES;
-                                  hasMoreUnseenMessages = YES;
+                                  result.hasMoreUnseenMessages = YES;
                               }
                           }];
 
             OWSAssert(interactionAfterUnreadIndicator);
 
-            if (hasMoreUnseenMessages) {
+            if (result.hasMoreUnseenMessages) {
                 NSMutableSet<NSData *> *missingUnseenSafetyNumberChanges = [NSMutableSet set];
                 for (TSInvalidIdentityKeyErrorMessage *safetyNumberChange in blockingSafetyNumberChanges) {
                     BOOL isUnseen = safetyNumberChange.timestampForSorting
@@ -403,7 +403,7 @@ NS_ASSUME_NONNULL_BEGIN
                 TSUnreadIndicatorInteraction *indicator =
                     [[TSUnreadIndicatorInteraction alloc] initWithTimestamp:indicatorTimestamp
                                                                      thread:thread
-                                                      hasMoreUnseenMessages:hasMoreUnseenMessages
+                                                      hasMoreUnseenMessages:result.hasMoreUnseenMessages
                                        missingUnseenSafetyNumberChangeCount:missingUnseenSafetyNumberChangeCount];
                 [indicator saveWithTransaction:transaction];
 

--- a/Signal/src/util/ThreadUtil.m
+++ b/Signal/src/util/ThreadUtil.m
@@ -18,6 +18,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface ThreadDynamicInteractions ()
+
+@property (nonatomic, nullable) NSNumber *unreadIndicatorPosition;
+
+@property (nonatomic, nullable) NSNumber *firstUnseenInteractionTimestamp;
+
+@property (nonatomic) BOOL hasMoreUnseenMessages;
+
+@end
+
+#pragma mark -
+
 @implementation ThreadDynamicInteractions
 
 - (void)clearUnreadIndicatorState


### PR DESCRIPTION
…unseen messages”.

Otherwise, tapping on "load more messages" autoscrolls you _downward_ which is completely wrong.

PTAL @michaelkirk 