### PR TITLE
Save identity from profile fetch even if there's no pre-existing

### DIFF
--- a/Signal/src/ProfileFetcherJob.swift
+++ b/Signal/src/ProfileFetcherJob.swift
@@ -96,11 +96,6 @@ class ProfileFetcherJob: NSObject {
 
     private func verifyIdentityUpToDateAsync(recipientId: String, latestIdentityKey: Data) {
         OWSDispatch.sessionStoreQueue().async {
-            if OWSIdentityManager.shared().identityKey(forRecipientId: recipientId) == nil {
-                // first time use, do nothing, since there's no change.
-                return
-            }
-
             if OWSIdentityManager.shared().saveRemoteIdentity(latestIdentityKey, recipientId: recipientId) {
                 Logger.info("\(self.TAG) updated identity key with fetched profile for recipient: \(recipientId)")
                 self.storageManager.archiveAllSessions(forContact: recipientId)


### PR DESCRIPTION
identity.

This allows us to view someone's SN before messaging them.

PTAL @charlesmchen 