### PR TITLE
Fix: tapping input obscures last messages

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -3946,7 +3946,7 @@ typedef enum : NSUInteger {
     [self presentViewController:controller animated:YES completion:nil];
 }
 
-- (void)textViewDidChangeSize
+- (void)textViewDidChangePosition
 {
     OWSAssert([NSThread isMainThread]);
 

--- a/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.h
+++ b/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didPasteAttachment:(SignalAttachment *_Nullable)attachment;
 
-- (void)textViewDidChangeSize;
+- (void)textViewDidChangePosition;
 
 @end
 

--- a/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.m
+++ b/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.m
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL becameFirstResponder = [super becomeFirstResponder];
     if (becameFirstResponder) {
         // Intercept to scroll to bottom when text view is tapped.
-        [self.textViewPasteDelegate textViewDidChangeSize];
+        [self.textViewPasteDelegate textViewDidChangePosition];
     }
     return becameFirstResponder;
 }
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
     [super setFrame:frame];
 
     if (didChangeSize && isNonEmpty) {
-        [self.textViewPasteDelegate textViewDidChangeSize];
+        [self.textViewPasteDelegate textViewDidChangePosition];
     }
 }
 
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
     [super setBounds:bounds];
 
     if (didChangeSize && isNonEmpty) {
-        [self.textViewPasteDelegate textViewDidChangeSize];
+        [self.textViewPasteDelegate textViewDidChangePosition];
     }
 }
 

--- a/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.m
+++ b/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.m
@@ -11,6 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)canBecomeFirstResponder
 {
+    // Intercept to scroll to bottom when text view is tapped.
+    [self.textViewPasteDelegate textViewDidChangeSize];
+
     return YES;
 }
 

--- a/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.m
+++ b/Signal/src/ViewControllers/ConversationView/OWSMessagesComposerTextView.m
@@ -11,10 +11,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)canBecomeFirstResponder
 {
-    // Intercept to scroll to bottom when text view is tapped.
-    [self.textViewPasteDelegate textViewDidChangeSize];
-
     return YES;
+}
+
+- (BOOL)becomeFirstResponder
+{
+    BOOL becameFirstResponder = [super becomeFirstResponder];
+    if (becameFirstResponder) {
+        // Intercept to scroll to bottom when text view is tapped.
+        [self.textViewPasteDelegate textViewDidChangeSize];
+    }
+    return becameFirstResponder;
 }
 
 - (BOOL)pasteboardHasPossibleAttachment


### PR DESCRIPTION
Previously tapping the input would pop the keyboard, which would hide the last couple messages, until you tapped a key, which would scroll to bottom.

Instead we should scroll to bottom when the keyboard is popped.

PTAL @charlesmchen 