### PR TITLE
delete system messages

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -2682,8 +2682,9 @@ typedef enum : NSUInteger {
     [systemMessageCell becomeFirstResponder];
 
     UIMenuController *theMenu = [UIMenuController sharedMenuController];
-
-    [theMenu setTargetRect:systemMessageCell.titleLabel.frame inView:systemMessageCell];
+    CGRect targetRect = [systemMessageCell.titleLabel.superview convertRect:systemMessageCell.titleLabel.frame
+                                                                     toView:systemMessageCell];
+    [theMenu setTargetRect:targetRect inView:systemMessageCell];
     [theMenu setMenuVisible:YES animated:YES];
 }
 

--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -1531,6 +1531,24 @@ typedef enum : NSUInteger {
     return YES;
 }
 
+- (BOOL)collectionView:(UICollectionView *)collectionView
+      canPerformAction:(SEL)action
+    forItemAtIndexPath:(NSIndexPath *)indexPath
+            withSender:(id)sender
+{
+    id<OWSMessageData> messageData = [self messageAtIndexPath:indexPath];
+    return [messageData canPerformEditingAction:action];
+}
+
+- (void)collectionView:(UICollectionView *)collectionView
+         performAction:(SEL)action
+    forItemAtIndexPath:(NSIndexPath *)indexPath
+            withSender:(id)sender
+{
+    id<OWSMessageData> messageData = [self messageAtIndexPath:indexPath];
+    [messageData performEditingAction:action];
+}
+
 - (void)collectionView:(UICollectionView *)collectionView
        willDisplayCell:(UICollectionViewCell *)cell
     forItemAtIndexPath:(NSIndexPath *)indexPath
@@ -3692,24 +3710,6 @@ typedef enum : NSUInteger {
             [possiblyRead markAsReadWithTransaction:transaction sendReadReceipt:YES updateExpiration:YES];
         }
     }];
-}
-
-- (BOOL)collectionView:(UICollectionView *)collectionView
-      canPerformAction:(SEL)action
-    forItemAtIndexPath:(NSIndexPath *)indexPath
-            withSender:(id)sender
-{
-    id<OWSMessageData> messageData = [self messageAtIndexPath:indexPath];
-    return [messageData canPerformEditingAction:action];
-}
-
-- (void)collectionView:(UICollectionView *)collectionView
-         performAction:(SEL)action
-    forItemAtIndexPath:(NSIndexPath *)indexPath
-            withSender:(id)sender
-{
-    id<OWSMessageData> messageData = [self messageAtIndexPath:indexPath];
-    [messageData performEditingAction:action];
 }
 
 - (void)updateGroupModelTo:(TSGroupModel *)newGroupModel successCompletion:(void (^_Nullable)())successCompletion

--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -2671,6 +2671,22 @@ typedef enum : NSUInteger {
     }
 }
 
+- (void)didLongPressSystemMessageCell:(OWSSystemMessageCell *)systemMessageCell;
+{
+    OWSAssert([NSThread isMainThread]);
+    OWSAssert(systemMessageCell);
+    OWSAssert(systemMessageCell.interaction);
+
+    DDLogDebug(@"%@ long pressed system message cell: %@", self.tag, systemMessageCell);
+
+    [systemMessageCell becomeFirstResponder];
+
+    UIMenuController *theMenu = [UIMenuController sharedMenuController];
+
+    [theMenu setTargetRect:systemMessageCell.titleLabel.frame inView:systemMessageCell];
+    [theMenu setMenuVisible:YES animated:YES];
+}
+
 #pragma mark - ContactEditingDelegate
 
 - (void)didFinishEditingContact

--- a/Signal/src/views/OWSSystemMessageCell.h
+++ b/Signal/src/views/OWSSystemMessageCell.h
@@ -8,10 +8,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class TSInteraction;
+@class OWSSystemMessageCell;
 
 @protocol OWSSystemMessageCellDelegate <NSObject>
 
 - (void)didTapSystemMessageWithInteraction:(TSInteraction *)interaction;
+- (void)didLongPressSystemMessageCell:(OWSSystemMessageCell *)systemMessageCell;
 
 @end
 
@@ -21,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<OWSSystemMessageCellDelegate> systemMessageCellDelegate;
 
+@property (nonatomic, readonly) UILabel *titleLabel;
 @property (nonatomic, nullable, readonly) TSInteraction *interaction;
 
 - (void)configureWithInteraction:(TSInteraction *)interaction;

--- a/Signal/src/views/OWSSystemMessageCell.m
+++ b/Signal/src/views/OWSSystemMessageCell.m
@@ -73,9 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
         [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
     [self addGestureRecognizer:tap];
 
-    UILongPressGestureRecognizer *longpress =
-        [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongpressGesture:)];
-    [self addGestureRecognizer:longpress];
+    UILongPressGestureRecognizer *longPress =
+        [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGesture:)];
+    [self addGestureRecognizer:longPress];
 }
 
 + (NSString *)cellReuseIdentifier
@@ -318,10 +318,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self.systemMessageCellDelegate didTapSystemMessageWithInteraction:self.interaction];
 }
 
-- (void)handleLongpressGesture:(UILongPressGestureRecognizer *)longpress
+- (void)handleLongPressGesture:(UILongPressGestureRecognizer *)longPress
 {
     OWSAssert(self.interaction);
-    if (longpress.state == UIGestureRecognizerStateBegan) {
+    if (longPress.state == UIGestureRecognizerStateBegan) {
         [self.systemMessageCellDelegate didLongPressSystemMessageCell:self];
     }
 }

--- a/Signal/src/views/OWSSystemMessageCell.m
+++ b/Signal/src/views/OWSSystemMessageCell.m
@@ -72,6 +72,10 @@ NS_ASSUME_NONNULL_BEGIN
     UITapGestureRecognizer *tap =
         [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
     [self addGestureRecognizer:tap];
+
+    UILongPressGestureRecognizer *longpress =
+        [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongpressGesture:)];
+    [self addGestureRecognizer:longpress];
 }
 
 + (NSString *)cellReuseIdentifier
@@ -290,6 +294,21 @@ NS_ASSUME_NONNULL_BEGIN
     self.interaction = nil;
 }
 
+#pragma mark - editing
+
+- (BOOL)canBecomeFirstResponder
+{
+    return YES;
+}
+
+- (void)delete:(nullable id)sender
+{
+    DDLogInfo(@"%@ chose delete", self.logTag);
+    OWSAssert(self.interaction);
+
+    [self.interaction remove];
+}
+
 #pragma mark - Gesture recognizers
 
 - (void)handleTapGesture:(UITapGestureRecognizer *)tap
@@ -297,6 +316,26 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert(self.interaction);
 
     [self.systemMessageCellDelegate didTapSystemMessageWithInteraction:self.interaction];
+}
+
+- (void)handleLongpressGesture:(UILongPressGestureRecognizer *)longpress
+{
+    OWSAssert(self.interaction);
+    if (longpress.state == UIGestureRecognizerStateBegan) {
+        [self.systemMessageCellDelegate didLongPressSystemMessageCell:self];
+    }
+}
+
+#pragma mark - Logging
+
++ (NSString *)logTag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)logTag
+{
+    return self.class.logTag;
 }
 
 @end


### PR DESCRIPTION
The reason this doesn't "just work" with our collection view, is JSQ does a hit test based on the "messageBubbleContainerView" which we don't use in the system message. 

I considered adding one, just to satisfy the hit test in a consistent way, but I think I actually prefer this approach.

Plus doing layout with a container view when we're not using autolayout is a bunch of lines of code I'd rather not mess up.

PTAL @charlesmchen 