### PR TITLE
fix cold call from contacts

### DIFF
--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -22,7 +22,6 @@
 #import "PropertyListPreferences.h"
 #import "PushManager.h"
 #import "SettingsTableViewController.h"
-#import "SignalsViewController.h"
 #import "UIColor+OWS.h"
 #import "UIFont+OWS.h"
 #import "UIUtil.h"

--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -22,6 +22,7 @@
 #import "PropertyListPreferences.h"
 #import "PushManager.h"
 #import "SettingsTableViewController.h"
+#import "SignalsViewController.h"
 #import "UIColor+OWS.h"
 #import "UIFont+OWS.h"
 #import "UIUtil.h"

--- a/Signal/src/Storyboard/Main.storyboard
+++ b/Signal/src/Storyboard/Main.storyboard
@@ -95,7 +95,6 @@
                         <outlet property="hideMissingContactsPermissionViewConstraint" destination="b7U-Ma-c6S" id="bcT-sh-weS"/>
                         <outlet property="missingContactsPermissionView" destination="7iZ-hQ-Iik" id="aWf-NH-kn6"/>
                         <outlet property="tableView" destination="PaA-ol-uQT" id="nQU-tR-wbL"/>
-                        <segue destination="Tyf-mN-gzf" kind="modal" identifier="ShowIncomingCallSegue" id="G2B-Fr-Ezs"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dE8-zB-mtF" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -149,23 +148,6 @@
                 </view>
             </objects>
             <point key="canvasLocation" x="-2287" y="-1516"/>
-        </scene>
-        <!--New Call-->
-        <scene sceneID="Xck-Ph-UlV">
-            <objects>
-                <viewController storyboardIdentifier="OWSCallViewController" title="New Call" definesPresentationContext="YES" modalTransitionStyle="crossDissolve" modalPresentationStyle="currentContext" id="Tyf-mN-gzf" customClass="OWSCallViewController" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="0w2-kv-AfM"/>
-                        <viewControllerLayoutGuide type="bottom" id="d8M-LU-Hfa"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="fjB-Ns-OQs">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="5mi-rT-gg5" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1790" y="-2348"/>
         </scene>
         <!--Signals Navigation Controller-->
         <scene sceneID="miN-Ma-3eR">

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -146,7 +146,11 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
         createViews()
 
         contactNameLabel.text = contactsManager.displayName(forPhoneIdentifier: thread.contactIdentifier())
-        contactAvatarView.image = OWSAvatarBuilder.buildImage(for: thread, contactsManager: contactsManager, diameter:400)
+        updateAvatarImage()
+        NotificationCenter.default.addObserver(forName: .OWSContactsManagerSignalAccountsDidChange, object: nil, queue: nil) { _ in
+            Logger.info("\(self.TAG) updating avatar image")
+            self.updateAvatarImage()
+        }
 
         assert(call != nil)
         // Subscribe for future call updates
@@ -312,6 +316,10 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
         let image = UIImage(named:imageName)
         assert(image != nil)
         button.setImage(image, for:.selected)
+    }
+
+    func updateAvatarImage() {
+        contactAvatarView.image = OWSAvatarBuilder.buildImage(for: thread, contactsManager: contactsManager, diameter:400)
     }
 
     func createIncomingCallControls() {

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -8,7 +8,6 @@ import PromiseKit
 
 // TODO: Add category so that button handlers can be defined where button is created.
 // TODO: Ensure buttons enabled & disabled as necessary.
-@objc(OWSCallViewController)
 class CallViewController: UIViewController, CallObserver, CallServiceObserver, RTCEAGLVideoViewDelegate {
 
     let TAG = "[CallViewController]"

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -31,7 +31,7 @@
 #define CELL_HEIGHT 72.0f
 #define HEADER_HEIGHT 44.0f
 
-NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallSegue";
+// NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallSegue";
 
 @interface SignalsViewController ()
 
@@ -195,12 +195,12 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
         (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable)) {
         [self registerForPreviewingWithDelegate:self sourceView:self.tableView];
     }
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleActiveCallNotification:)
-                                                 name:[CallService callServiceActiveCallNotificationName]
-                                               object:nil];
-    
+
+    //    [[NSNotificationCenter defaultCenter] addObserver:self
+    //                                             selector:@selector(handleActiveCallNotification:)
+    //                                                 name:[CallService callServiceActiveCallNotificationName]
+    //                                               object:nil];
+    //
     [self updateBarButtonItems];
 }
 
@@ -260,29 +260,30 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
     }
 }
 
-- (void)handleActiveCallNotification:(NSNotification *)notification
-{
-    AssertIsOnMainThread();
-    
-    if (![notification.object isKindOfClass:[SignalCall class]]) {
-        DDLogError(@"%@ expected presentCall observer to be notified with a SignalCall, but found %@",
-                   self.tag,
-                   notification.object);
-        return;
-    }
-    
-    SignalCall *call = (SignalCall *)notification.object;
-    
-    // Dismiss any other modals so we can present call modal.
-    if (self.presentedViewController) {
-        [self dismissViewControllerAnimated:YES
-                                 completion:^{
-            [self performSegueWithIdentifier:SignalsViewControllerSegueShowIncomingCall sender:call];
-        }];
-    } else {
-        [self performSegueWithIdentifier:SignalsViewControllerSegueShowIncomingCall sender:call];
-    }
-}
+//- (void)handleActiveCallNotification:(NSNotification *)notification
+//{
+//    // TODO insteead at the callsite lets present as topmost VC
+//    AssertIsOnMainThread();
+//
+//    if (![notification.object isKindOfClass:[SignalCall class]]) {
+//        DDLogError(@"%@ expected presentCall observer to be notified with a SignalCall, but found %@",
+//                   self.tag,
+//                   notification.object);
+//        return;
+//    }
+//
+//    SignalCall *call = (SignalCall *)notification.object;
+//
+//    // Dismiss any other modals so we can present call modal.
+//    if (self.presentedViewController) {
+//        [self dismissViewControllerAnimated:YES
+//                                 completion:^{
+//            [self performSegueWithIdentifier:SignalsViewControllerSegueShowIncomingCall sender:call];
+//        }];
+//    } else {
+//        [self performSegueWithIdentifier:SignalsViewControllerSegueShowIncomingCall sender:call];
+//    }
+//}
 
 - (void)previewingContext:(id<UIViewControllerPreviewing>)previewingContext
      commitViewController:(UIViewController *)viewControllerToCommit {
@@ -727,25 +728,25 @@ NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallS
 
 #pragma mark - Navigation
 
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    if ([segue.identifier isEqualToString:SignalsViewControllerSegueShowIncomingCall]) {
-        DDLogDebug(@"%@ preparing for incoming call segue", self.tag);
-        if (![segue.destinationViewController isKindOfClass:[OWSCallViewController class]]) {
-            DDLogError(@"%@ Received unexpected destination view controller: %@", self.tag, segue.destinationViewController);
-            return;
-        }
-        OWSCallViewController *callViewController = (OWSCallViewController *)segue.destinationViewController;
-
-        if (![sender isKindOfClass:[SignalCall class]]) {
-            DDLogError(@"%@ expecting call segueu to be sent by a SignalCall, but found: %@", self.tag, sender);
-            return;
-        }
-        SignalCall *call = (SignalCall *)sender;
-        TSContactThread *thread = [TSContactThread getOrCreateThreadWithContactId:call.remotePhoneNumber];
-        callViewController.thread = thread;
-        callViewController.call = call;
-    }
-}
+//- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+//    if ([segue.identifier isEqualToString:SignalsViewControllerSegueShowIncomingCall]) {
+//        DDLogDebug(@"%@ preparing for incoming call segue", self.tag);
+//        if (![segue.destinationViewController isKindOfClass:[OWSCallViewController class]]) {
+//            DDLogError(@"%@ Received unexpected destination view controller: %@", self.tag,
+//            segue.destinationViewController); return;
+//        }
+//        OWSCallViewController *callViewController = (OWSCallViewController *)segue.destinationViewController;
+//
+//        if (![sender isKindOfClass:[SignalCall class]]) {
+//            DDLogError(@"%@ expecting call segueu to be sent by a SignalCall, but found: %@", self.tag, sender);
+//            return;
+//        }
+//        SignalCall *call = (SignalCall *)sender;
+//        TSContactThread *thread = [TSContactThread getOrCreateThreadWithContactId:call.remotePhoneNumber];
+//        callViewController.thread = thread;
+//        callViewController.call = call;
+//    }
+//}
 
 #pragma mark - IBAction
 

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -31,8 +31,6 @@
 #define CELL_HEIGHT 72.0f
 #define HEADER_HEIGHT 44.0f
 
-// NSString *const SignalsViewControllerSegueShowIncomingCall = @"ShowIncomingCallSegue";
-
 @interface SignalsViewController ()
 
 @property (nonatomic) YapDatabaseConnection *editingDbConnection;
@@ -196,11 +194,6 @@
         [self registerForPreviewingWithDelegate:self sourceView:self.tableView];
     }
 
-    //    [[NSNotificationCenter defaultCenter] addObserver:self
-    //                                             selector:@selector(handleActiveCallNotification:)
-    //                                                 name:[CallService callServiceActiveCallNotificationName]
-    //                                               object:nil];
-    //
     [self updateBarButtonItems];
 }
 
@@ -259,31 +252,6 @@
         return nil;
     }
 }
-
-//- (void)handleActiveCallNotification:(NSNotification *)notification
-//{
-//    // TODO insteead at the callsite lets present as topmost VC
-//    AssertIsOnMainThread();
-//
-//    if (![notification.object isKindOfClass:[SignalCall class]]) {
-//        DDLogError(@"%@ expected presentCall observer to be notified with a SignalCall, but found %@",
-//                   self.tag,
-//                   notification.object);
-//        return;
-//    }
-//
-//    SignalCall *call = (SignalCall *)notification.object;
-//
-//    // Dismiss any other modals so we can present call modal.
-//    if (self.presentedViewController) {
-//        [self dismissViewControllerAnimated:YES
-//                                 completion:^{
-//            [self performSegueWithIdentifier:SignalsViewControllerSegueShowIncomingCall sender:call];
-//        }];
-//    } else {
-//        [self performSegueWithIdentifier:SignalsViewControllerSegueShowIncomingCall sender:call];
-//    }
-//}
 
 - (void)previewingContext:(id<UIViewControllerPreviewing>)previewingContext
      commitViewController:(UIViewController *)viewControllerToCommit {
@@ -725,28 +693,6 @@
         dismissNavigationBlock();
     }
 }
-
-#pragma mark - Navigation
-
-//- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-//    if ([segue.identifier isEqualToString:SignalsViewControllerSegueShowIncomingCall]) {
-//        DDLogDebug(@"%@ preparing for incoming call segue", self.tag);
-//        if (![segue.destinationViewController isKindOfClass:[OWSCallViewController class]]) {
-//            DDLogError(@"%@ Received unexpected destination view controller: %@", self.tag,
-//            segue.destinationViewController); return;
-//        }
-//        OWSCallViewController *callViewController = (OWSCallViewController *)segue.destinationViewController;
-//
-//        if (![sender isKindOfClass:[SignalCall class]]) {
-//            DDLogError(@"%@ expecting call segueu to be sent by a SignalCall, but found: %@", self.tag, sender);
-//            return;
-//        }
-//        SignalCall *call = (SignalCall *)sender;
-//        TSContactThread *thread = [TSContactThread getOrCreateThreadWithContactId:call.remotePhoneNumber];
-//        callViewController.thread = thread;
-//        callViewController.call = call;
-//    }
-//}
 
 #pragma mark - IBAction
 

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -248,15 +248,6 @@ protocol CallServiceObserver: class {
         self.callUIAdapter = CallUIAdapter(callService: self, contactsManager: self.contactsManager, notificationsAdapter: self.notificationsAdapter)
     }
 
-    // MARK: - Class Methods
-
-    // MARK: Notifications
-
-    // Wrapping these class constants in a method to make it accessible to objc
-//    class func callServiceActiveCallNotificationName() -> String {
-//        return  "CallServiceActiveCallNotification"
-//    }
-
     // MARK: - Service Actions
 
     /**

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -253,9 +253,9 @@ protocol CallServiceObserver: class {
     // MARK: Notifications
 
     // Wrapping these class constants in a method to make it accessible to objc
-    class func callServiceActiveCallNotificationName() -> String {
-        return  "CallServiceActiveCallNotification"
-    }
+//    class func callServiceActiveCallNotificationName() -> String {
+//        return  "CallServiceActiveCallNotification"
+//    }
 
     // MARK: - Service Actions
 

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -42,8 +42,9 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
         Logger.debug("\(TAG) \(#function)")
 
         // present Call View controller
-        let callNotificationName = CallService.callServiceActiveCallNotificationName()
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: callNotificationName), object: call)
+//        let callNotificationName = CallService.callServiceActiveCallNotificationName()
+//        NotificationCenter.default.post(name: NSNotification.Name(rawValue: callNotificationName), object: call)
+        self.showCall(call)
 
         // present lock screen notification
         if UIApplication.shared.applicationState == .active {

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -41,9 +41,6 @@ class NonCallKitCallUIAdaptee: CallUIAdaptee {
 
         Logger.debug("\(TAG) \(#function)")
 
-        // present Call View controller
-//        let callNotificationName = CallService.callServiceActiveCallNotificationName()
-//        NotificationCenter.default.post(name: NSNotification.Name(rawValue: callNotificationName), object: call)
         self.showCall(call)
 
         // present lock screen notification

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -34,23 +34,15 @@ extension CallUIAdaptee {
     internal func showCall(_ call: SignalCall) {
         AssertIsOnMainThread()
 
-//        let callNotificationName = CallService.callServiceActiveCallNotificationName()
-//        NotificationCenter.default.post(name: NSNotification.Name(rawValue: callNotificationName), object: call)
-
         let callViewController = CallViewController()
         let thread = TSContactThread.getOrCreateThread(contactId: call.remotePhoneNumber)
         callViewController.call = call
         callViewController.thread = thread
         callViewController.modalTransitionStyle = .crossDissolve
 
-        //Environment.getCurrent().signalsViewController
-        // TODO dismiss any modal, can/should we present from frontmost?
-//        let presentingViewController = UIApplication.shared.frontmostViewController
-//        presentingViewController?.present(callViewController, animated: true)
-
-        guard let presentingViewController = Environment.getCurrent().signalsViewController else {
-            Logger.error("in \(#function) signals view controller unexpectedly nil")
-            assertionFailure("in \(#function) signals view controller unexpectedly nil")
+        guard let presentingViewController = UIApplication.shared.frontmostViewController else {
+            Logger.error("in \(#function) frontmost view controller unexpectedly nil")
+            assertionFailure("in \(#function) frontmost view controller unexpectedly nil")
             return
         }
 

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -40,9 +40,9 @@ extension CallUIAdaptee {
         callViewController.thread = thread
         callViewController.modalTransitionStyle = .crossDissolve
 
-        guard let presentingViewController = UIApplication.shared.frontmostViewController else {
-            Logger.error("in \(#function) frontmost view controller unexpectedly nil")
-            assertionFailure("in \(#function) frontmost view controller unexpectedly nil")
+        guard let presentingViewController = Environment.getCurrent().signalsViewController else {
+            Logger.error("in \(#function) view controller unexpectedly nil")
+            assertionFailure("in \(#function) view controller unexpectedly nil")
             return
         }
 

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -34,8 +34,30 @@ extension CallUIAdaptee {
     internal func showCall(_ call: SignalCall) {
         AssertIsOnMainThread()
 
-        let callNotificationName = CallService.callServiceActiveCallNotificationName()
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: callNotificationName), object: call)
+//        let callNotificationName = CallService.callServiceActiveCallNotificationName()
+//        NotificationCenter.default.post(name: NSNotification.Name(rawValue: callNotificationName), object: call)
+
+        let callViewController = CallViewController()
+        let thread = TSContactThread.getOrCreateThread(contactId: call.remotePhoneNumber)
+        callViewController.call = call
+        callViewController.thread = thread
+        callViewController.modalTransitionStyle = .crossDissolve
+
+        //Environment.getCurrent().signalsViewController
+        // TODO dismiss any modal, can/should we present from frontmost?
+//        let presentingViewController = UIApplication.shared.frontmostViewController
+//        presentingViewController?.present(callViewController, animated: true)
+
+        guard let presentingViewController = Environment.getCurrent().signalsViewController else {
+            Logger.error("in \(#function) signals view controller unexpectedly nil")
+            assertionFailure("in \(#function) signals view controller unexpectedly nil")
+            return
+        }
+
+        if let presentedViewController = presentingViewController.presentedViewController {
+            presentedViewController.dismiss(animated: false)
+        }
+        presentingViewController.present(callViewController, animated: true)
     }
 
     internal func reportMissedCall(_ call: SignalCall, callerName: String) {


### PR DESCRIPTION
Problem Motivation:

tap-swipe-kill Signal
go to contacts app
choose to signal-call a signal contact Alice.

expected: 
see a call started with Alice
hear a call started with Alice

actual:
do *not* see a call started with Alice.
but worse yet, hear a call started with Alice.


The problem was we were triggering the call presentation logic with a notification, but when the app is being started cold. the observer hasn't started observing by the time we processed the activity.

Now that we're all gungho on programmatic VC's, I think we're better off avoiding the notification passing paradigm all together in favor of explicit presentation.

PTAL @charlesmchen