### PR TITLE
Make sure we're requesting access for contacts before checking access

### DIFF
--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -185,9 +185,6 @@
     self.missingContactsPermissionView.tapAction = ^{
         [[UIApplication sharedApplication] openSystemSettings];
     };
-    // Should only have to do this once per load (e.g. vs did appear) since app restarts when permissions change.
-    self.hideMissingContactsPermissionViewConstraint.active = !self.shouldShowMissingContactsPermissionView;
-
 
     if ([self.traitCollection respondsToSelector:@selector(forceTouchCapability)] &&
         (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable)) {
@@ -291,8 +288,13 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     if ([TSThread numberOfKeysInCollection] > 0) {
-        [self.contactsManager requestSystemContactsOnce];
+        [self.contactsManager requestSystemContactsOnceWithCompletion:^(NSError *_Nullable error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                self.hideMissingContactsPermissionViewConstraint.active = !self.shouldShowMissingContactsPermissionView;
+            });
+        }];
     }
+
     [self updateInboxCountLabel];
 
     self.isViewVisible = YES;


### PR DESCRIPTION
I'm actually not sure how I got my simulator wedged into this state -
but my contacts access was "undetermined" and I had several messages.

Maybe they appeared while the app was closed?

I verified that the banner appears as expected when access is denied.

PTAL @charlesmchen 