### PR TITLE
Play audible alert for missed call

### DIFF
--- a/Signal/src/environment/NotificationsManager.m
+++ b/Signal/src/environment/NotificationsManager.m
@@ -96,6 +96,9 @@
         PushManagerUserInfoKeysCallBackSignalRecipientId : call.remotePhoneNumber
     };
 
+    if ([self shouldPlaySoundForNotification]) {
+        notification.soundName = @"NewMessage.aifc";
+    }
 
     NSString *alertMessage;
     switch (self.notificationPreviewType) {
@@ -132,6 +135,9 @@
         PushManagerUserInfoKeysCallBackSignalRecipientId : call.remotePhoneNumber,
         Signal_Thread_UserInfo_Key : thread.uniqueId
     };
+    if ([self shouldPlaySoundForNotification]) {
+        notification.soundName = @"NewMessage.aifc";
+    }
 
     NSString *alertMessage;
     switch (self.notificationPreviewType) {
@@ -169,6 +175,9 @@
         PushManagerUserInfoKeysCallBackSignalRecipientId : call.remotePhoneNumber,
         Signal_Thread_UserInfo_Key : thread.uniqueId
     };
+    if ([self shouldPlaySoundForNotification]) {
+        notification.soundName = @"NewMessage.aifc";
+    }
 
     NSString *alertMessage;
     switch (self.notificationPreviewType) {

--- a/Signal/src/environment/NotificationsManager.m
+++ b/Signal/src/environment/NotificationsManager.m
@@ -16,6 +16,8 @@
 #import <SignalServiceKit/TextSecureKitEnv.h>
 #import <SignalServiceKit/Threading.h>
 
+NSString *const kNotificationsManagerNewMesssageSoundName = @"NewMessage.aifc";
+
 @interface NotificationsManager ()
 
 @property (nonatomic) SystemSoundID newMessageSound;
@@ -97,7 +99,7 @@
     };
 
     if ([self shouldPlaySoundForNotification]) {
-        notification.soundName = @"NewMessage.aifc";
+        notification.soundName = kNotificationsManagerNewMesssageSoundName;
     }
 
     NSString *alertMessage;
@@ -136,7 +138,7 @@
         Signal_Thread_UserInfo_Key : thread.uniqueId
     };
     if ([self shouldPlaySoundForNotification]) {
-        notification.soundName = @"NewMessage.aifc";
+        notification.soundName = kNotificationsManagerNewMesssageSoundName;
     }
 
     NSString *alertMessage;
@@ -176,7 +178,7 @@
         Signal_Thread_UserInfo_Key : thread.uniqueId
     };
     if ([self shouldPlaySoundForNotification]) {
-        notification.soundName = @"NewMessage.aifc";
+        notification.soundName = kNotificationsManagerNewMesssageSoundName;
     }
 
     NSString *alertMessage;
@@ -219,7 +221,7 @@
         UILocalNotification *notification = [[UILocalNotification alloc] init];
         notification.userInfo             = @{Signal_Thread_UserInfo_Key : thread.uniqueId};
         if (shouldPlaySound) {
-            notification.soundName = @"NewMessage.aifc";
+            notification.soundName = kNotificationsManagerNewMesssageSoundName;
         }
 
         NSString *alertBodyString = @"";
@@ -268,7 +270,7 @@
     if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive && messageDescription) {
         UILocalNotification *notification = [[UILocalNotification alloc] init];
         if (shouldPlaySound) {
-            notification.soundName = @"NewMessage.aifc";
+            notification.soundName = kNotificationsManagerNewMesssageSoundName;
         }
 
         switch (self.notificationPreviewType) {


### PR DESCRIPTION
Previously we weren't playing alert sounds for any of the following:

- missed call due to no longer verified
- missed call due to recent SN change
- regular ole' missed call

PTAL @charlesmchen 