### PR TITLE
copy tweaks

### DIFF
--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -56,10 +56,10 @@
 "APN_MESSAGE_IN_GROUP_DETAILED" = "%@ in group %@: %@";
 
 /* Message format for the 'new app version available' alert. Embeds: {{The latest app version number.}}. */
-"APP_UPDATE_NAG_ALERT_MESSAGE_FORMAT" = "Version %@ is available in the App Store.";
+"APP_UPDATE_NAG_ALERT_MESSAGE_FORMAT" = "Version %@ is now available in the App Store.";
 
 /* Title for the 'new app version available' alert. */
-"APP_UPDATE_NAG_ALERT_TITLE" = "New Version";
+"APP_UPDATE_NAG_ALERT_TITLE" = "A New Version of Signal is Available";
 
 /* Label for the 'update' button in the 'new app version available' alert. */
 "APP_UPDATE_NAG_ALERT_UPDATE_BUTTON" = "Update";


### PR DESCRIPTION
Just hit this for the first time using a debug build, and had a thought - because system alerts can sometimes pop up without providence, I think it's good to name the app in the alert to be clear what we're asking to update.

PTAL @charlesmchen

