### PR TITLE
Log/Code Cleanup

### DIFF
--- a/Signal/src/Models/AccountManager.swift
+++ b/Signal/src/Models/AccountManager.swift
@@ -80,21 +80,20 @@ class AccountManager: NSObject {
     func getTurnServerInfo() -> Promise<TurnServerInfo> {
         return Promise { fulfill, reject in
             self.networkManager.makeRequest(TurnServerInfoRequest(),
-                                            success: { (task: URLSessionDataTask, responseObject: Any?) in
+                                            success: { (_: URLSessionDataTask, responseObject: Any?) in
                                                 guard responseObject != nil else {
                                                     return reject(OWSErrorMakeUnableToProcessServerResponseError())
                                                 }
 
                                                 if let responseDictionary = responseObject as? [String: AnyObject] {
                                                     if let turnServerInfo = TurnServerInfo(attributes:responseDictionary) {
-                                                        Logger.debug("\(self.TAG) got valid turnserver info")
                                                         return fulfill(turnServerInfo)
                                                     }
                                                     Logger.error("\(self.TAG) unexpected server response:\(responseDictionary)")
                                                 }
                                                 return reject(OWSErrorMakeUnableToProcessServerResponseError())
             },
-                                            failure: { (task: URLSessionDataTask, error: Error) in
+                                            failure: { (_: URLSessionDataTask, error: Error) in
                                                     return reject(error)
             })
         }

--- a/Signal/src/ProfileFetcherJob.swift
+++ b/Signal/src/ProfileFetcherJob.swift
@@ -87,8 +87,6 @@ class ProfileFetcherJob: NSObject {
     }
 
     private func processResponse(signalServiceProfile: SignalServiceProfile) {
-        Logger.debug("\(TAG) in \(#function) for \(signalServiceProfile)")
-
         verifyIdentityUpToDateAsync(recipientId: signalServiceProfile.recipientId, latestIdentityKey: signalServiceProfile.identityKey)
 
         // Eventually we'll want to do more things with new SignalServiceProfile fields here.

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -321,8 +321,7 @@ import AVFoundation
                 let oldMode = session.mode
                 let oldOptions = session.categoryOptions
 
-                if oldCategory == category, oldMode == mode, oldOptions == options {
-                    Logger.debug("\(self.TAG) in \(#function) doing nothing, since audio session is unchanged.")
+                guard oldCategory != category || oldMode != mode || oldOptions != options else {
                     return
                 }
 
@@ -333,17 +332,15 @@ import AVFoundation
                     Logger.debug("\(self.TAG) audio session changed mode: \(oldMode) -> \(mode) ")
                 }
                 if oldOptions != options {
-                    Logger.debug("\(self.TAG) audio session changed category: \(oldOptions) -> \(options) ")
+                    Logger.debug("\(self.TAG) audio session changed options: \(oldOptions) -> \(options) ")
                 }
-
-                Logger.debug("\(self.TAG) setting new category: \(category) mode: \(mode) options: \(options)")
                 try session.setCategory(category, mode: mode, options: options)
 
             } else {
                 let oldCategory = session.category
                 let oldOptions = session.categoryOptions
-                if session.category == category, session.categoryOptions == options {
-                    Logger.debug("\(self.TAG) in \(#function) doing nothing, since audio session is unchanged.")
+
+                guard session.category != category || session.categoryOptions != options else {
                     return
                 }
 
@@ -351,10 +348,8 @@ import AVFoundation
                     Logger.debug("\(self.TAG) audio session changed category: \(oldCategory) -> \(category) ")
                 }
                 if oldOptions != options {
-                    Logger.debug("\(self.TAG) audio session changed category: \(oldOptions) -> \(options) ")
+                    Logger.debug("\(self.TAG) audio session changed options: \(oldOptions) -> \(options) ")
                 }
-
-                Logger.debug("\(self.TAG) setting new category: \(category) options: \(options)")
                 try session.setCategory(category, with: options)
 
             }

--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -444,13 +444,13 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         }
     }
 
-    public func addIceCandidate(_ candidate: RTCIceCandidate) {
+    public func addRemoteIceCandidate(_ candidate: RTCIceCandidate) {
         PeerConnectionClient.signalingQueue.async {
             guard self.peerConnection != nil else {
                 Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
                 return
             }
-            Logger.debug("\(self.TAG) adding candidate")
+            Logger.info("\(self.TAG) adding remote ICE candidate: \(candidate.sdp)")
             self.peerConnection.add(candidate)
         }
     }
@@ -672,7 +672,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
                 Logger.debug("\(self.TAG) \(#function) Ignoring obsolete event in terminated client")
                 return
             }
-            Logger.debug("\(self.TAG) didGenerate IceCandidate:\(candidate.sdp)")
+            Logger.info("\(self.TAG) adding local ICE candidate:\(candidate.sdp)")
             if let delegate = self.delegate {
                 DispatchQueue.main.async { [weak self] in
                     guard let strongSelf = self else { return }

--- a/Signal/src/call/WebRTCCallMessageHandler.swift
+++ b/Signal/src/call/WebRTCCallMessageHandler.swift
@@ -29,7 +29,6 @@ class WebRTCCallMessageHandler: NSObject, OWSCallMessageHandler {
 
     public func receivedOffer(_ offer: OWSSignalServiceProtosCallMessageOffer, from callerId: String) {
         AssertIsOnMainThread()
-        Logger.verbose("\(TAG) handling offer from caller:\(callerId)")
 
         let thread = TSContactThread.getOrCreateThread(contactId: callerId)
         self.callService.handleReceivedOffer(thread: thread, callId: offer.id, sessionDescription: offer.sessionDescription)
@@ -37,7 +36,6 @@ class WebRTCCallMessageHandler: NSObject, OWSCallMessageHandler {
 
     public func receivedAnswer(_ answer: OWSSignalServiceProtosCallMessageAnswer, from callerId: String) {
         AssertIsOnMainThread()
-        Logger.verbose("\(TAG) handling answer from caller:\(callerId)")
 
         let thread = TSContactThread.getOrCreateThread(contactId: callerId)
         self.callService.handleReceivedAnswer(thread: thread, callId: answer.id, sessionDescription: answer.sessionDescription)
@@ -45,7 +43,6 @@ class WebRTCCallMessageHandler: NSObject, OWSCallMessageHandler {
 
     public func receivedIceUpdate(_ iceUpdate: OWSSignalServiceProtosCallMessageIceUpdate, from callerId: String) {
         AssertIsOnMainThread()
-        Logger.verbose("\(TAG) handling iceUpdates from caller:\(callerId)")
 
         let thread = TSContactThread.getOrCreateThread(contactId: callerId)
 
@@ -58,7 +55,6 @@ class WebRTCCallMessageHandler: NSObject, OWSCallMessageHandler {
 
     public func receivedHangup(_ hangup: OWSSignalServiceProtosCallMessageHangup, from callerId: String) {
         AssertIsOnMainThread()
-        Logger.verbose("\(TAG) handling 'hangup' from caller:\(callerId)")
 
         let thread = TSContactThread.getOrCreateThread(contactId: callerId)
 
@@ -67,7 +63,6 @@ class WebRTCCallMessageHandler: NSObject, OWSCallMessageHandler {
 
     public func receivedBusy(_ busy: OWSSignalServiceProtosCallMessageBusy, from callerId: String) {
         AssertIsOnMainThread()
-        Logger.verbose("\(TAG) handling 'busy' from caller:\(callerId)")
 
         let thread = TSContactThread.getOrCreateThread(contactId: callerId)
 

--- a/Signal/src/contact/SystemContactsFetcher.swift
+++ b/Signal/src/contact/SystemContactsFetcher.swift
@@ -471,8 +471,6 @@ class SystemContactsFetcher: NSObject {
                     return
                 }
 
-                Logger.debug("\(self.TAG) Notifying delegate that system contacts did change. hash:\(contactsHash)")
-
                 self.lastDelegateNotificationDate = Date()
                 self.lastContactUpdateHash = contactsHash
 

--- a/Signal/src/util/DeviceSleepManager.swift
+++ b/Signal/src/util/DeviceSleepManager.swift
@@ -49,20 +49,26 @@ import Foundation
     }
 
     public func addBlock(blockObject: NSObject) {
+        AssertIsOnMainThread()
+
         blocks.append(SleepBlock(blockObject: blockObject))
 
         ensureSleepBlocking()
     }
 
     public func removeBlock(blockObject: NSObject) {
+        AssertIsOnMainThread()
+
         blocks = blocks.filter {
-         $0.blockObject != nil && $0.blockObject != blockObject
+            $0.blockObject != nil && $0.blockObject != blockObject
         }
 
         ensureSleepBlocking()
     }
 
     private func ensureSleepBlocking() {
+        AssertIsOnMainThread()
+
         // Cull expired blocks.
         blocks = blocks.filter {
             $0.blockObject != nil
@@ -71,7 +77,11 @@ import Foundation
 
         if UIApplication.shared.isIdleTimerDisabled != shouldBlock {
             if shouldBlock {
-                Logger.info("\(self.TAG) \(#function): Blocking sleep")
+                var logString = "\(self.TAG) \(#function): Blocking sleep because of: \(String(describing: blocks.first?.blockObject))"
+                if blocks.count > 1 {
+                    logString += " and \(blocks.count - 1) others."
+                }
+                Logger.info(logString)
             } else {
                 Logger.info("\(self.TAG) \(#function): Unblocking sleep")
             }

--- a/Signal/src/views/OWSExpirationTimerView.m
+++ b/Signal/src/views/OWSExpirationTimerView.m
@@ -175,7 +175,6 @@ double const OWSExpirationTimerViewBlinkingSeconds = 2;
 
 - (void)stopTimer
 {
-    DDLogVerbose(@"%@ Stopping Timer.", self.logTag);
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:OWSMessagesViewControllerDidAppearNotification
                                                   object:nil];


### PR DESCRIPTION
- make some logging clearer
- remove noisy unhelpful logging
- clearer method names

While debugging some call connectivity issues, I tried to clean up some of our logging and code. I wanted to separate this from the actual connectivity changes so that PR can be more focused.

The log statements I removed were kind of arbitrary - don't hesitate to veto any that you'd like to keep in. Comments in line...

PTAL @charlesmchen 