### PR TITLE
Partial revert of: Send ICE updates immediately - 2dcfb4e3b8b07bb2b54…

### DIFF
--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -160,6 +160,17 @@ protocol CallServiceObserver: class {
     // Used to coordinate promises across delegate methods
     private var fulfillCallConnectedPromise: (() -> Void)?
 
+    /**
+     * In the process of establishing a connection between the clients (ICE process) we must exchange ICE updates.
+     * Because this happens via Signal Service it's possible the callee user has not accepted any change in the caller's 
+     * identity. In which case *each* ICE update would cause an "identity change" warning on the callee's device. Since
+     * this could be several messages, the caller stores all ICE updates until receiving positive confirmation that the 
+     * callee has received a message from us. This positive confirmation comes in the form of the callees `CallAnswer` 
+     * message.
+     */
+    var sendIceUpdatesImmediately = true
+    var pendingIceUpdateMessages = [OWSCallIceUpdateMessage]()
+
     // Used by waitForPeerConnectionClient to make sure any received
     // ICE messages wait until the peer connection client is set up.
     private var fulfillPeerConnectionClientPromise: (() -> Void)?
@@ -260,6 +271,9 @@ protocol CallServiceObserver: class {
 
         self.call = call
 
+        sendIceUpdatesImmediately = false
+        pendingIceUpdateMessages = []
+
         let callRecord = TSCall(timestamp: NSDate.ows_millisecondTimeStamp(), withCallNumber: call.remotePhoneNumber, callType: RPRecentCallTypeOutgoingIncomplete, in: call.thread)
         callRecord.save()
         call.callRecord = callRecord
@@ -347,6 +361,19 @@ protocol CallServiceObserver: class {
         guard call.signalingId == callId else {
             Logger.warn("\(self.TAG) ignoring obsolete call: \(callId) in \(#function)")
             return
+        }
+
+        // Now that we know the recipient trusts our identity, we no longer need to enqueue ICE updates.
+        self.sendIceUpdatesImmediately = true
+
+        if pendingIceUpdateMessages.count > 0 {
+            Logger.error("\(self.TAG) Sending \(pendingIceUpdateMessages.count) pendingIceUpdateMessages")
+
+            let callMessage = OWSOutgoingCallMessage(thread: thread, iceUpdateMessages: pendingIceUpdateMessages)
+            let sendPromise = messageSender.sendCallMessage(callMessage).catch { error in
+                Logger.error("\(self.TAG) failed to send ice updates in \(#function) with error: \(error)")
+            }
+            sendPromise.retainUntilComplete()
         }
 
         guard let peerConnectionClient = self.peerConnectionClient else {
@@ -649,8 +676,19 @@ protocol CallServiceObserver: class {
 
         let iceUpdateMessage = OWSCallIceUpdateMessage(callId: call.signalingId, sdp: iceCandidate.sdp, sdpMLineIndex: iceCandidate.sdpMLineIndex, sdpMid: iceCandidate.sdpMid)
 
-        let callMessage = OWSOutgoingCallMessage(thread: call.thread, iceUpdateMessage: iceUpdateMessage)
-        self.messageSender.sendCallMessage(callMessage).retainUntilComplete()
+        if self.sendIceUpdatesImmediately {
+            Logger.info("\(TAG) in \(#function). Sending immediately.")
+            let callMessage = OWSOutgoingCallMessage(thread: call.thread, iceUpdateMessage: iceUpdateMessage)
+            let sendPromise = self.messageSender.sendCallMessage(callMessage)
+            sendPromise.retainUntilComplete()
+        } else {
+            // For outgoing messages, we wait to send ice updates until we're sure client received our call message.
+            // e.g. if the client has blocked our message due to an identity change, we'd otherwise
+            // bombard them with a bunch *more* undecipherable messages.
+            Logger.info("\(TAG) in \(#function). Enqueing for later.")
+            self.pendingIceUpdateMessages.append(iceUpdateMessage)
+            return
+        }
     }
 
     /**
@@ -1274,6 +1312,9 @@ protocol CallServiceObserver: class {
 
         self.call?.removeAllObservers()
         self.call = nil
+        self.sendIceUpdatesImmediately = true
+        Logger.info("\(TAG) clearing pendingIceUpdateMessages")
+        self.pendingIceUpdateMessages = []
         self.fulfillCallConnectedPromise = nil
 
         // In case we're still waiting on the peer connection setup somewhere, we need to reject it to avoid a memory leak.


### PR DESCRIPTION
Partial revert of: Send ICE updates immediately - 2dcfb4e3b8b07bb2b5419cad6fa324e5e585c3da

That commit made it more likely that the remote client will receive an
ICE update **before** the call offer. That commit also made clients robust to receiving them, but none of the clients in the wild have that robustness fix.

We want to ship the robustness fix (waitForPeerConnection in
handleRemoteAddedIceCandidate) before we have the caller start sending
ICE updates immediately. 

In a future release, when we're ready to have the caller ship ICE updates immediately, we can simply revert this commit.

PTAL @charlesmchen 
