### PR TITLE
Charlesmchen/leak call view

### DIFF
--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -147,9 +147,10 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
 
         contactNameLabel.text = contactsManager.displayName(forPhoneIdentifier: thread.contactIdentifier())
         updateAvatarImage()
-        NotificationCenter.default.addObserver(forName: .OWSContactsManagerSignalAccountsDidChange, object: nil, queue: nil) { _ in
-            Logger.info("\(self.TAG) updating avatar image")
-            self.updateAvatarImage()
+        NotificationCenter.default.addObserver(forName: .OWSContactsManagerSignalAccountsDidChange, object: nil, queue: nil) { [weak self] _ in
+            guard let strongSelf = self else { return }
+            Logger.info("\(strongSelf.TAG) updating avatar image")
+            strongSelf.updateAvatarImage()
         }
 
         assert(call != nil)


### PR DESCRIPTION
* We were leaking CallViewController.
* Therefore we were leaking SignalCall.
* This lead to lots of spurious events related to previous calls in our logs.
* We should also clean up SignalCall immediately (instead of waiting for it to time out) by rejecting the "connected" promise when clean up a call (e.g. hang up while in connecting).

// FREEBIE
