### PR TITLE
Charlesmchen/refine call service

### DIFF
--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -304,8 +304,6 @@ protocol CallServiceObserver: class {
             Logger.debug("\(self.TAG) setting peerConnectionClient in \(#function) for call: \(call.identifiersForLogs)")
             self.peerConnectionClient = peerConnectionClient
             self.fulfillPeerConnectionClientPromise?()
-            self.fulfillPeerConnectionClientPromise = nil
-            self.rejectPeerConnectionClientPromise = nil
 
             return peerConnectionClient.createOffer()
         }.then { (sessionDescription: HardenedRTCSessionDescription) -> Promise<Void> in
@@ -378,8 +376,6 @@ protocol CallServiceObserver: class {
         }
 
         fulfillReadyToSendIceUpdatesPromise()
-        self.fulfillReadyToSendIceUpdatesPromise = nil
-        self.rejectReadyToSendIceUpdatesPromise = nil
     }
 
     /**
@@ -599,8 +595,6 @@ protocol CallServiceObserver: class {
             let peerConnectionClient = PeerConnectionClient(iceServers: iceServers, delegate: self, callDirection: .incoming, useTurnOnly: useTurnOnly)
             self.peerConnectionClient = peerConnectionClient
             self.fulfillPeerConnectionClientPromise?()
-            self.fulfillPeerConnectionClientPromise = nil
-            self.rejectPeerConnectionClientPromise = nil
 
             let offerSessionDescription = RTCSessionDescription(type: .offer, sdp: callerSessionDescription)
             let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
@@ -892,8 +886,6 @@ protocol CallServiceObserver: class {
         assert(self.fulfillCallConnectedPromise != nil)
         // cancel connection timeout
         self.fulfillCallConnectedPromise?()
-        self.fulfillCallConnectedPromise = nil
-        self.rejectCallConnectedPromise = nil
 
         call.state = .connected
 

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -304,6 +304,8 @@ protocol CallServiceObserver: class {
             Logger.debug("\(self.TAG) setting peerConnectionClient in \(#function) for call: \(call.identifiersForLogs)")
             self.peerConnectionClient = peerConnectionClient
             self.fulfillPeerConnectionClientPromise?()
+            self.fulfillPeerConnectionClientPromise = nil
+            self.rejectPeerConnectionClientPromise = nil
 
             return peerConnectionClient.createOffer()
         }.then { (sessionDescription: HardenedRTCSessionDescription) -> Promise<Void> in
@@ -376,6 +378,8 @@ protocol CallServiceObserver: class {
         }
 
         fulfillReadyToSendIceUpdatesPromise()
+        self.fulfillReadyToSendIceUpdatesPromise = nil
+        self.rejectReadyToSendIceUpdatesPromise = nil
     }
 
     /**
@@ -595,6 +599,8 @@ protocol CallServiceObserver: class {
             let peerConnectionClient = PeerConnectionClient(iceServers: iceServers, delegate: self, callDirection: .incoming, useTurnOnly: useTurnOnly)
             self.peerConnectionClient = peerConnectionClient
             self.fulfillPeerConnectionClientPromise?()
+            self.fulfillPeerConnectionClientPromise = nil
+            self.rejectPeerConnectionClientPromise = nil
 
             let offerSessionDescription = RTCSessionDescription(type: .offer, sdp: callerSessionDescription)
             let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
@@ -886,6 +892,8 @@ protocol CallServiceObserver: class {
         assert(self.fulfillCallConnectedPromise != nil)
         // cancel connection timeout
         self.fulfillCallConnectedPromise?()
+        self.fulfillCallConnectedPromise = nil
+        self.rejectCallConnectedPromise = nil
 
         call.state = .connected
 

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -34,10 +34,7 @@ extension CallUIAdaptee {
     internal func showCall(_ call: SignalCall) {
         AssertIsOnMainThread()
 
-        let callViewController = CallViewController()
-        let thread = TSContactThread.getOrCreateThread(contactId: call.remotePhoneNumber)
-        callViewController.call = call
-        callViewController.thread = thread
+        let callViewController = CallViewController(call:call)
         callViewController.modalTransitionStyle = .crossDissolve
 
         guard let presentingViewController = Environment.getCurrent().signalsViewController else {


### PR DESCRIPTION
* Converted `call` and `thread` properties of `CallViewController` from var to let.
* Cleared fulfill/reject properties in `CallService` as they are fulfilled or rejected.

PTAL @michaelkirk 