### PR TITLE
audio route cleanup

### DIFF
--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -89,7 +89,7 @@ class CallViewController: UIViewController, CallObserver, CallServiceObserver, R
     // MARK: Audio Source
 
     var hasAlternateAudioSources: Bool {
-        Logger.info("\(TAG) available audio routes count: \(allAudioSources.count)")
+        Logger.info("\(TAG) available audio sources: \(allAudioSources)")
         // internal mic and speakerphone will be the first two, any more than one indicates e.g. an attached bluetooth device.
 
         // TODO is this sufficient? Are their devices w/ bluetooth but no external speaker? e.g. ipod?

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -13,10 +13,10 @@ struct AudioSource: Hashable {
     let localizedName: String
     let portDescription: AVAudioSessionPortDescription?
 
-    // The built in loud speaker / aka speakerphone
+    // The built-in loud speaker / aka speakerphone
     let isBuiltInSpeaker: Bool
 
-    // The build in quiet speaker, aka the normal phone handset receiver earpiece
+    // The built-in quiet speaker, aka the normal phone handset receiver earpiece
     let isBuiltInEarPiece: Bool
 
     init(localizedName: String, image: UIImage, isBuiltInSpeaker: Bool, isBuiltInEarPiece: Bool, portDescription: AVAudioSessionPortDescription? = nil) {
@@ -176,11 +176,12 @@ struct AudioSource: Hashable {
             return
         }
 
-        // Disallow bluetooth when user has explicitly chosen the built in receiver.
-        // I'm actually not sure why this is required - it seems like we should just be able
+        // Disallow bluetooth while (and only while) the user has explicitly chosen the built in receiver.
+        //
+        // NOTE: I'm actually not sure why this is required - it seems like we should just be able
         // to setPreferredInput to call.audioSource.portDescription in this case,
         // but in practice I'm seeing the call revert to the bluetooth headset.
-        // Presumably something else (in WebRTC?) is touching our shared AudioSession.
+        // Presumably something else (in WebRTC?) is touching our shared AudioSession. - mjk
         let options: AVAudioSessionCategoryOptions = call.audioSource?.isBuiltInEarPiece == true ? [] : [.allowBluetooth]
 
         if call.state == .localRinging {
@@ -207,7 +208,7 @@ struct AudioSource: Hashable {
 
         let session = AVAudioSession.sharedInstance()
         do {
-            // It's importent to set preferred input *after* ensuring properAudioSession
+            // It's important to set preferred input *after* ensuring properAudioSession
             // because some sources are only valid for certain category/option combinations.
             let existingPreferredInput = session.preferredInput
             if  existingPreferredInput != call.audioSource?.portDescription {

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -22,7 +22,15 @@ struct AudioSource: Hashable {
     }
 
     init(portDescription: AVAudioSessionPortDescription) {
-        self.init(localizedName: portDescription.portName,
+
+        // portDescription.portName works well for BT linked devices, but if we are using
+        // the built in mic, we have "iPhone Microphone" which is a little awkward.
+        // In that case, instead we prefer just the model name e.g. "iPhone" or "iPad"
+        let localizedName = portDescription.portType == AVAudioSessionPortBuiltInMic ?
+            UIDevice.current.localizedModel :
+            portDescription.portName
+
+        self.init(localizedName: localizedName,
                   image:#imageLiteral(resourceName: "button_phone_white"), // TODO
                   isBuiltInSpeaker: false,
                   portDescription: portDescription)

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -182,13 +182,18 @@ struct AudioSource: Hashable {
             setAudioSession(category: AVAudioSessionCategorySoloAmbient,
                             mode: AVAudioSessionModeDefault)
         } else if call.hasLocalVideo {
-            // Don't allow bluetooth for local video if speakerphone has been explicitly chosen by the user.
-            let options: AVAudioSessionCategoryOptions = call.isSpeakerphoneEnabled ? [.defaultToSpeaker] : [.defaultToSpeaker, .allowBluetooth]
-
+            // Apple Docs say that setting mode to AVAudioSessionModeVideoChat has the
+            // side effect of setting options: .allowBluetooth, when I remove the (seemingly unnecessary)
+            // option, and inspect AVAudioSession.sharedInstance.categoryOptions == 0. And availableInputs
+            // does not include my linked bluetooth device
             setAudioSession(category: AVAudioSessionCategoryPlayAndRecord,
                             mode: AVAudioSessionModeVideoChat,
-                            options: options)
+                            options: [.allowBluetooth])
         } else {
+            // Apple Docs say that setting mode to AVAudioSessionModeVoiceChat has the
+            // side effect of setting options: .allowBluetooth, when I remove the (seemingly unnecessary)
+            // option, and inspect AVAudioSession.sharedInstance.categoryOptions == 0. And availableInputs
+            // does not include my linked bluetooth device
             setAudioSession(category: AVAudioSessionCategoryPlayAndRecord,
                             mode: AVAudioSessionModeVoiceChat,
                             options: [.allowBluetooth])

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -140,7 +140,7 @@
 "ATTACHMENT_TYPE_VOICE_MESSAGE" = "Voice Message";
 
 /* action sheet button title to enable built in speaker during a call */
-"AUDIO_ROUTE_BUILT_IN_SPEAKER" = "Built in Speaker";
+"AUDIO_ROUTE_BUILT_IN_SPEAKER" = "Speaker";
 
 /* An explanation of the consequences of blocking another user. */
 "BLOCK_BEHAVIOR_EXPLANATION" = "Blocked users will not be able to call you or send you messages.";


### PR DESCRIPTION
- Nicer labels for devices in route picker
- Fix issue with audio not being routed to receiver if picked too early

PTAL @charlesmchen 