### PR TITLE
Always reload home view table when changing grouping.

### DIFF
--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -843,6 +843,7 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
 
     [self updateShouldObserveDBModifications];
 
+    [[self tableView] reloadData];
     [self checkIfEmptyView];
     [self updateReminderViews];
 }


### PR DESCRIPTION
Might be redundant in some cases but `reloadData` should be cheap. Might help with the "empty home view" issue and also future-proofs us when refactoring home view in the future.

PTAL @michaelkirk 