### PR TITLE
ensure blocking keychange message has identityKey before proceeding

### DIFF
--- a/Signal/src/util/ThreadUtil.m
+++ b/Signal/src/util/ThreadUtil.m
@@ -287,7 +287,14 @@ NS_ASSUME_NONNULL_BEGIN
                     if (!isMissing) {
                         continue;
                     }
-                    [missingUnseenSafetyNumberChanges addObject:safetyNumberChange.newIdentityKey];
+
+                    NSData *_Nullable newIdentityKey = safetyNumberChange.newIdentityKey;
+                    if (newIdentityKey == nil) {
+                        OWSFail(@"Safety number change was missing it's new identity key.");
+                        continue;
+                    }
+
+                    [missingUnseenSafetyNumberChanges addObject:newIdentityKey];
                 }
 
                 // Count the de-duplicated "blocking" safety number changes and all

--- a/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.h
+++ b/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.h
@@ -1,9 +1,5 @@
 //
-//  TSInvalidIdentityKeyErrorMessage.h
-//  Signal
-//
-//  Created by Frederic Jacobs on 15/02/15.
-//  Copyright (c) 2015 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
 #import "TSErrorMessage.h"
@@ -15,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TSInvalidIdentityKeyErrorMessage : TSErrorMessage
 
 - (void)acceptNewIdentityKey;
-- (NSData *)newIdentityKey;
+- (nullable NSData *)newIdentityKey;
 - (NSString *)theirSignalId;
 
 @end

--- a/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.m
+++ b/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyErrorMessage.m
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSAssert(NO, @"Method needs to be implemented in subclasses of TSInvalidIdentityKeyErrorMessage.");
 }
 
-- (NSString *)newIdentityKey
+- (nullable NSData *)newIdentityKey
 {
     NSAssert(NO, @"Method needs to be implemented in subclasses of TSInvalidIdentityKeyErrorMessage.");
     return nil;

--- a/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyReceivingErrorMessage.m
+++ b/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeyReceivingErrorMessage.m
@@ -74,9 +74,9 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    NSData *newKey = [self newIdentityKey];
+    NSData *_Nullable newKey = [self newIdentityKey];
     if (!newKey) {
-        DDLogError(@"Couldn't extract identity key to accept");
+        OWSFail(@"Couldn't extract identity key to accept");
         return;
     }
 
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
     });
 }
 
-- (NSData *)newIdentityKey
+- (nullable NSData *)newIdentityKey
 {
     if (!self.envelope) {
         DDLogError(@"Error message had no envelope data to extract key from");

--- a/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
+++ b/SignalServiceKit/src/Messages/InvalidKeyMessages/TSInvalidIdentityKeySendingErrorMessage.m
@@ -50,12 +50,18 @@ NSString *TSInvalidRecipientKey = @"TSInvalidRecipientKey";
     OWSFail(@"accepting new identity key is deprecated.");
 
     // Saving a new identity mutates the session store so it must happen on the sessionStoreQueue
+    NSData *_Nullable newIdentityKey = self.newIdentityKey;
+    if (!newIdentityKey) {
+        OWSFail(@"newIdentityKey is unexpectedly nil. Bad Prekey bundle?: %@", self.preKeyBundle);
+        return;
+    }
+
     dispatch_async([OWSDispatch sessionStoreQueue], ^{
-        [[OWSIdentityManager sharedManager] saveRemoteIdentity:self.newIdentityKey recipientId:self.recipientId];
+        [[OWSIdentityManager sharedManager] saveRemoteIdentity:newIdentityKey recipientId:self.recipientId];
     });
 }
 
-- (NSData *)newIdentityKey
+- (nullable NSData *)newIdentityKey
 {
     return [self.preKeyBundle.identityKey removeKeyType];
 }


### PR DESCRIPTION
This is increasingly irrelevant due to changes around safety number handling, but older clients with legacy messages can still run into this.

FIXES: https://github.com/WhisperSystems/Signal-iOS/issues/2346

PTAL @charlesmchen 