### PR TITLE
cache local number

### DIFF
--- a/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
+++ b/Signal/src/Models/TSMessageAdapaters/TSVideoAttachmentAdapter.m
@@ -9,7 +9,6 @@
 #import "Signal-Swift.h"
 #import "TSAttachmentStream.h"
 #import "TSMessagesManager.h"
-#import "TSStorageManager+keyingMaterial.h"
 #import "UIColor+JSQMessages.h"
 #import "UIColor+OWS.h"
 #import "UIDevice+TSHardwareVersion.h"

--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -86,7 +86,6 @@
 #import <SignalServiceKit/TSSocketManager.h>
 #import <SignalServiceKit/TSStorageManager+Calling.h>
 #import <SignalServiceKit/TSStorageManager+SessionStore.h>
-#import <SignalServiceKit/TSStorageManager+keyingMaterial.h>
 #import <SignalServiceKit/TSThread.h>
 #import <WebRTC/RTCAudioSession.h>
 #import <WebRTC/RTCCameraPreviewView.h>

--- a/Signal/src/ViewControllers/CodeVerificationViewController.m
+++ b/Signal/src/ViewControllers/CodeVerificationViewController.m
@@ -13,7 +13,6 @@
 #import <SignalServiceKit/OWSError.h>
 #import <SignalServiceKit/TSAccountManager.h>
 #import <SignalServiceKit/TSNetworkManager.h>
-#import <SignalServiceKit/TSStorageManager+keyingMaterial.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Signal/src/ViewControllers/FingerprintViewController.m
+++ b/Signal/src/ViewControllers/FingerprintViewController.m
@@ -17,9 +17,9 @@
 #import <SignalServiceKit/OWSFingerprint.h>
 #import <SignalServiceKit/OWSFingerprintBuilder.h>
 #import <SignalServiceKit/OWSIdentityManager.h>
+#import <SignalServiceKit/TSAccountManager.h>
 #import <SignalServiceKit/TSInfoMessage.h>
 #import <SignalServiceKit/TSStorageManager+SessionStore.h>
-#import <SignalServiceKit/TSStorageManager+keyingMaterial.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -74,7 +74,7 @@ typedef void (^CustomLayoutBlock)();
 
 @property (nonatomic) NSString *recipientId;
 @property (nonatomic) NSData *identityKey;
-@property (nonatomic) TSStorageManager *storageManager;
+@property (nonatomic) TSAccountManager *accountManager;
 @property (nonatomic) OWSFingerprint *fingerprint;
 @property (nonatomic) NSString *contactName;
 
@@ -118,6 +118,8 @@ typedef void (^CustomLayoutBlock)();
         return self;
     }
 
+    _accountManager = [TSAccountManager sharedInstance];
+
     [self observeNotifications];
 
     return self;
@@ -142,8 +144,6 @@ typedef void (^CustomLayoutBlock)();
 
     self.recipientId = recipientId;
 
-    self.storageManager = [TSStorageManager sharedManager];
-
     OWSContactsManager *contactsManager = [Environment getCurrent].contactsManager;
     self.contactName = [contactsManager displayNameForPhoneIdentifier:recipientId];
 
@@ -155,7 +155,7 @@ typedef void (^CustomLayoutBlock)();
     self.identityKey = recipientIdentity.identityKey;
 
     OWSFingerprintBuilder *builder =
-        [[OWSFingerprintBuilder alloc] initWithStorageManager:self.storageManager contactsManager:contactsManager];
+        [[OWSFingerprintBuilder alloc] initWithAccountManager:self.accountManager contactsManager:contactsManager];
     self.fingerprint =
         [builder fingerprintWithTheirSignalId:recipientId theirIdentityKey:recipientIdentity.identityKey];
 }

--- a/Signal/src/ViewControllers/FingerprintViewScanController.m
+++ b/Signal/src/ViewControllers/FingerprintViewScanController.m
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FingerprintViewScanController () <OWSQRScannerDelegate>
 
-@property (nonatomic) TSStorageManager *storageManager;
+@property (nonatomic) TSAccountManager *accountManager;
 @property (nonatomic) NSString *recipientId;
 @property (nonatomic) NSData *identityKey;
 @property (nonatomic) OWSFingerprint *fingerprint;
@@ -39,8 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert(recipientId.length > 0);
 
     self.recipientId = recipientId;
-
-    self.storageManager = [TSStorageManager sharedManager];
+    self.accountManager = [TSAccountManager sharedInstance];
 
     OWSContactsManager *contactsManager = [Environment getCurrent].contactsManager;
     self.contactName = [contactsManager displayNameForPhoneIdentifier:recipientId];
@@ -53,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.identityKey = recipientIdentity.identityKey;
 
     OWSFingerprintBuilder *builder =
-        [[OWSFingerprintBuilder alloc] initWithStorageManager:self.storageManager contactsManager:contactsManager];
+        [[OWSFingerprintBuilder alloc] initWithAccountManager:self.accountManager contactsManager:contactsManager];
     self.fingerprint =
         [builder fingerprintWithTheirSignalId:recipientId theirIdentityKey:recipientIdentity.identityKey];
 }

--- a/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
+++ b/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSArray<NSNumber *> *disappearingMessagesDurations;
 @property (nonatomic) OWSDisappearingMessagesConfiguration *disappearingMessagesConfiguration;
 
-@property (nonatomic, readonly) TSStorageManager *storageManager;
+@property (nonatomic, readonly) TSAccountManager *accountManager;
 @property (nonatomic, readonly) OWSContactsManager *contactsManager;
 @property (nonatomic, readonly) OWSMessageSender *messageSender;
 @property (nonatomic, readonly) OWSBlockingManager *blockingManager;
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)commonInit
 {
-    _storageManager = [TSStorageManager sharedManager];
+    _accountManager = [TSAccountManager sharedInstance];
     _contactsManager = [Environment getCurrent].contactsManager;
     _messageSender = [Environment getCurrent].messageSender;
     _blockingManager = [OWSBlockingManager sharedManager];
@@ -925,7 +925,7 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 
     NSMutableArray *newGroupMemberIds = [NSMutableArray arrayWithArray:gThread.groupModel.groupMemberIds];
-    [newGroupMemberIds removeObject:[self.storageManager localNumber]];
+    [newGroupMemberIds removeObject:[self.accountManager localNumber]];
     gThread.groupModel.groupMemberIds = newGroupMemberIds;
     [gThread save];
 

--- a/Signal/src/ViewControllers/OWSLinkDeviceViewController.m
+++ b/Signal/src/ViewControllers/OWSLinkDeviceViewController.m
@@ -8,7 +8,7 @@
 #import <SignalServiceKit/ECKeyPair+OWSPrivateKey.h>
 #import <SignalServiceKit/OWSDeviceProvisioner.h>
 #import <SignalServiceKit/OWSIdentityManager.h>
-#import <SignalServiceKit/TSStorageManager+keyingMaterial.h>
+#import <SignalServiceKit/TSAccountManager.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -131,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert(identityKeyPair);
     NSData *myPublicKey = identityKeyPair.publicKey;
     NSData *myPrivateKey = identityKeyPair.ows_privateKey;
-    NSString *accountIdentifier = [TSStorageManager localNumber];
+    NSString *accountIdentifier = [TSAccountManager localNumber];
 
     OWSDeviceProvisioner *provisioner = [[OWSDeviceProvisioner alloc] initWithMyPublicKey:myPublicKey
                                                                              myPrivateKey:myPrivateKey

--- a/SignalServiceKit/Example/TSKitiOSTestApp/Podfile.lock
+++ b/SignalServiceKit/Example/TSKitiOSTestApp/Podfile.lock
@@ -113,7 +113,7 @@ EXTERNAL SOURCES:
   AxolotlKit:
     :git: https://github.com/WhisperSystems/SignalProtocolKit.git
   SignalServiceKit:
-    :path: "../../../SignalServiceKit.podspec"
+    :path: ../../../SignalServiceKit.podspec
   SocketRocket:
     :git: https://github.com/facebook/SocketRocket.git
 

--- a/SignalServiceKit/src/Account/TSAccountManager.h
+++ b/SignalServiceKit/src/Account/TSAccountManager.h
@@ -22,7 +22,7 @@ extern NSString *const kNSNotificationName_LocalNumberDidChange;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
-                        storageManager:(TSStorageManager *)storageManager;
+                        storageManager:(TSStorageManager *)storageManager NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)sharedInstance;
 
@@ -43,6 +43,7 @@ extern NSString *const kNSNotificationName_LocalNumberDidChange;
  *  @return E164 formatted phone number
  */
 + (nullable NSString *)localNumber;
+- (nullable NSString *)localNumber;
 
 /**
  *  The registration ID is unique to an installation of TextSecure, it allows to know if the app was reinstalled

--- a/SignalServiceKit/src/Account/TSAccountManager.m
+++ b/SignalServiceKit/src/Account/TSAccountManager.m
@@ -20,43 +20,23 @@ NSString *const TSRegistrationErrorUserInfoHTTPStatus = @"TSHTTPStatus";
 NSString *const kNSNotificationName_RegistrationStateDidChange = @"kNSNotificationName_RegistrationStateDidChange";
 NSString *const kNSNotificationName_LocalNumberDidChange = @"kNSNotificationName_LocalNumberDidChange";
 
+NSString *const TSAccountManager_RegisteredNumberKey = @"TSStorageRegisteredNumberKey";
+NSString *const TSAccountManager_LocalRegistrationIdKey = @"TSStorageLocalRegistrationId";
+
 @interface TSAccountManager ()
 
+@property (nonatomic, readonly) BOOL isRegistered;
 @property (nonatomic, nullable) NSString *phoneNumberAwaitingVerification;
 @property (nonatomic, nullable) NSString *cachedLocalNumber;
-@property (nonatomic, readonly) TSStorageManager *storageManager;
+@property (nonatomic, readonly) YapDatabaseConnection *dbConnection;
 
 @end
 
 #pragma mark -
 
-@interface TSStorageManager (TSAccountManagerStorage)
-
-/**
- *  Stored registered phone number
- *
- *  @return E164 string of the registered phone number
- */
-+ (nullable NSString *)localNumber;
-- (nullable NSString *)localNumber;
-
-@end
-
-@implementation TSStorageManager (TSAccountManagerStorage)
-
-+ (nullable NSString *)localNumber
-{
-    return [[self sharedManager] localNumber];
-}
-
-- (nullable NSString *)localNumber
-{
-    return [self stringForKey:TSStorageRegisteredNumberKey inCollection:TSStorageUserAccountCollection];
-}
-
-@end
-
 @implementation TSAccountManager
+
+@synthesize isRegistered = _isRegistered;
 
 - (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
                         storageManager:(TSStorageManager *)storageManager
@@ -67,7 +47,7 @@ NSString *const kNSNotificationName_LocalNumberDidChange = @"kNSNotificationName
     }
 
     _networkManager = networkManager;
-    _storageManager = storageManager;
+    _dbConnection = [storageManager newDatabaseConnection];
 
     OWSSingletonAssert();
 
@@ -95,13 +75,42 @@ NSString *const kNSNotificationName_LocalNumberDidChange = @"kNSNotificationName
                                                       userInfo:nil];
 }
 
-+ (BOOL)isRegistered {
-    return [TSStorageManager localNumber] ? YES : NO;
++ (BOOL)isRegistered
+{
+    return [[self sharedInstance] isRegistered];
 }
 
-- (void)ifRegistered:(BOOL)isRegistered runAsync:(void (^)())block
+- (BOOL)isRegistered
 {
-    [self.storageManager ifLocalNumberPresent:isRegistered runAsync:block];
+    if (_isRegistered) {
+        return YES;
+    } else {
+        @synchronized (self) {
+            // Cache this once it's true since it's called alot, involves a dbLookup, and once set - it doesn't change.
+            _isRegistered = [self storedLocalNumber] != nil;
+        }
+    }
+    return _isRegistered;
+}
+
+- (void)ifRegistered:(BOOL)runIfRegistered runAsync:(void (^)())block
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        if ([self isRegistered] == runIfRegistered) {
+            if (runIfRegistered) {
+                DDLogDebug(@"%@ Running existing-user block", self.tag);
+            } else {
+                DDLogDebug(@"%@ Running new-user block", self.tag);
+            }
+            block();
+        } else {
+            if (runIfRegistered) {
+                DDLogDebug(@"%@ Skipping existing-user block for new-user", self.tag);
+            } else {
+                DDLogDebug(@"%@ Skipping new-user block for existing-user", self.tag);
+            }
+        }
+    });
 }
 
 - (void)didRegister
@@ -113,7 +122,7 @@ NSString *const kNSNotificationName_LocalNumberDidChange = @"kNSNotificationName
         @throw [NSException exceptionWithName:@"RegistrationFail" reason:@"Internal Corrupted State" userInfo:nil];
     }
 
-    [self.storageManager storePhoneNumber:phoneNumber];
+    [self storeLocalNumber:phoneNumber];
 
     [[NSNotificationCenter defaultCenter] postNotificationName:kNSNotificationName_RegistrationStateDidChange
                                                         object:nil
@@ -136,30 +145,47 @@ NSString *const kNSNotificationName_LocalNumberDidChange = @"kNSNotificationName
     @synchronized(self)
     {
         if (self.cachedLocalNumber == nil) {
-            self.cachedLocalNumber = [TSStorageManager localNumber];
+            self.cachedLocalNumber = self.storedLocalNumber;
         }
     }
 
     return self.cachedLocalNumber;
 }
 
-+ (uint32_t)getOrGenerateRegistrationId {
-    YapDatabaseConnection *dbConn   = [[TSStorageManager sharedManager] newDatabaseConnection];
-    __block uint32_t registrationID = 0;
+- (nullable NSString *)storedLocalNumber
+{
+    @synchronized (self) {
+        return [self.dbConnection stringForKey:TSAccountManager_RegisteredNumberKey
+                                  inCollection:TSStorageUserAccountCollection];
+    }
+}
 
-    [dbConn readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-      registrationID = [[transaction objectForKey:TSStorageLocalRegistrationId
-                                     inCollection:TSStorageUserAccountCollection] unsignedIntValue];
-    }];
+- (void)storeLocalNumber:(NSString *)localNumber
+{
+    @synchronized (self) {
+        [self.dbConnection setObject:localNumber
+                              forKey:TSAccountManager_RegisteredNumberKey
+                        inCollection:TSStorageUserAccountCollection];
+    }
+}
+
++ (uint32_t)getOrGenerateRegistrationId
+{
+    return [[self sharedInstance] getOrGenerateRegistrationId];
+}
+
+- (uint32_t)getOrGenerateRegistrationId
+{
+    uint32_t registrationID = [[self.dbConnection objectForKey:TSAccountManager_LocalRegistrationIdKey
+                                                  inCollection:TSStorageUserAccountCollection] unsignedIntValue];
 
     if (registrationID == 0) {
         registrationID = (uint32_t)arc4random_uniform(16380) + 1;
+        DDLogWarn(@"%@ Generated a new registrationID: %u", self.tag, registrationID);
 
-        [dbConn readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-          [transaction setObject:[NSNumber numberWithUnsignedInteger:registrationID]
-                          forKey:TSStorageLocalRegistrationId
-                    inCollection:TSStorageUserAccountCollection];
-        }];
+        [self.dbConnection setObject:[NSNumber numberWithUnsignedInteger:registrationID]
+                              forKey:TSAccountManager_LocalRegistrationIdKey
+                        inCollection:TSStorageUserAccountCollection];
     }
 
     return registrationID;

--- a/SignalServiceKit/src/Account/TSAttributes.m
+++ b/SignalServiceKit/src/Account/TSAttributes.m
@@ -3,9 +3,8 @@
 //
 
 #import "TSAttributes.h"
-
 #import "TSAccountManager.h"
-#import "TSStorageHeaders.h"
+#import "TSStorageManager+keyingMaterial.h"
 
 @implementation TSAttributes
 

--- a/SignalServiceKit/src/Contacts/SignalRecipient.m
+++ b/SignalServiceKit/src/Contacts/SignalRecipient.m
@@ -4,7 +4,8 @@
 
 #import "SignalRecipient.h"
 #import "OWSIdentityManager.h"
-#import "TSStorageHeaders.h"
+#import "TSAccountManager.h"
+#import <YapDatabase/YapDatabaseConnection.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -45,10 +46,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)selfRecipient
 {
-    SignalRecipient *myself = [self recipientWithTextSecureIdentifier:[TSStorageManager localNumber]];
+    SignalRecipient *myself = [self recipientWithTextSecureIdentifier:[TSAccountManager localNumber]];
     if (!myself) {
-        myself = [[self alloc] initWithTextSecureIdentifier:[TSStorageManager localNumber]
-                                                      relay:nil];
+        myself = [[self alloc] initWithTextSecureIdentifier:[TSAccountManager localNumber] relay:nil];
     }
     return myself;
 }

--- a/SignalServiceKit/src/Contacts/SignalRecipient.m
+++ b/SignalServiceKit/src/Contacts/SignalRecipient.m
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
     return recipient;
 }
 
+// TODO This method should probably live on the TSAccountManager rather than grabbing a global singleton.
 + (instancetype)selfRecipient
 {
     SignalRecipient *myself = [self recipientWithTextSecureIdentifier:[TSAccountManager localNumber]];

--- a/SignalServiceKit/src/Messages/OWSIdentityManager.m
+++ b/SignalServiceKit/src/Messages/OWSIdentityManager.m
@@ -15,7 +15,6 @@
 #import "TSContactThread.h"
 #import "TSErrorMessage.h"
 #import "TSGroupThread.h"
-#import "TSStorageManager+keyingMaterial.h"
 #import "TSStorageManager+sessionStore.h"
 #import "TSStorageManager.h"
 #import "TextSecureKitEnv.h"
@@ -326,7 +325,7 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
 
     @synchronized(self)
     {
-        if ([[self.storageManager localNumber] isEqualToString:recipientId]) {
+        if ([[TSAccountManager localNumber] isEqualToString:recipientId]) {
             if ([[self identityKeyPair].publicKey isEqualToData:identityKey]) {
                 return YES;
             } else {

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -30,7 +30,6 @@
 #import "TSPreKeyManager.h"
 #import "TSStorageManager+PreKeyStore.h"
 #import "TSStorageManager+SignedPreKeyStore.h"
-#import "TSStorageManager+keyingMaterial.h"
 #import "TSStorageManager+sessionStore.h"
 #import "TSStorageManager.h"
 #import "TSThread.h"
@@ -623,7 +622,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             || [message isKindOfClass:[OWSOutgoingSyncMessage class]]) {
 
             TSContactThread *contactThread = (TSContactThread *)thread;
-            if ([contactThread.contactIdentifier isEqualToString:self.storageManager.localNumber]
+            if ([contactThread.contactIdentifier isEqualToString:[TSAccountManager localNumber]]
                 && ![message isKindOfClass:[OWSOutgoingSyncMessage class]]) {
 
                 [self handleSendToMyself:message];
@@ -632,7 +631,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             }
 
             NSString *recipientContactId = [message isKindOfClass:[OWSOutgoingSyncMessage class]]
-                ? self.storageManager.localNumber
+                ? [TSAccountManager localNumber]
                 : contactThread.contactIdentifier;
 
             // If we block a user, don't send 1:1 messages to them. The UI
@@ -734,7 +733,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         NSString *recipientId = recipient.recipientId;
 
         // We don't need to send the message to ourselves...
-        if ([recipientId isEqualToString:[TSStorageManager localNumber]]) {
+        if ([recipientId isEqualToString:[TSAccountManager localNumber]]) {
             continue;
         }
         // We don't need to sent the message to all group members if

--- a/SignalServiceKit/src/Network/WebSockets/TSSocketManager.m
+++ b/SignalServiceKit/src/Network/WebSockets/TSSocketManager.m
@@ -476,10 +476,9 @@ NSString *const kNSNotification_SocketManagerStateDidChange = @"kNSNotification_
 }
 
 - (NSString *)webSocketAuthenticationString {
-    return [NSString
-        stringWithFormat:@"?login=%@&password=%@",
-                         [[TSStorageManager localNumber] stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"],
-                         [TSStorageManager serverAuthToken]];
+    return [NSString stringWithFormat:@"?login=%@&password=%@",
+                     [[TSAccountManager localNumber] stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"],
+                     [TSStorageManager serverAuthToken]];
 }
 
 #pragma mark - Socket LifeCycle

--- a/SignalServiceKit/src/Security/OWSFingerprintBuilder.h
+++ b/SignalServiceKit/src/Security/OWSFingerprintBuilder.h
@@ -4,14 +4,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class TSStorageManager;
+@class TSAccountManager;
 @class OWSFingerprint;
 @protocol ContactsManagerProtocol;
 
 @interface OWSFingerprintBuilder : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithStorageManager:(TSStorageManager *)storageManager
+- (instancetype)initWithAccountManager:(TSAccountManager *)accountManager
                        contactsManager:(id<ContactsManagerProtocol>)contactsManager NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/SignalServiceKit/src/Security/OWSFingerprintBuilder.m
+++ b/SignalServiceKit/src/Security/OWSFingerprintBuilder.m
@@ -6,21 +6,21 @@
 #import "ContactsManagerProtocol.h"
 #import "OWSFingerprint.h"
 #import "OWSIdentityManager.h"
-#import "TSStorageManager+keyingMaterial.h"
+#import "TSAccountManager.h"
 #import <25519/Curve25519.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OWSFingerprintBuilder ()
 
-@property (nonatomic, readonly) TSStorageManager *storageManager;
+@property (nonatomic, readonly) TSAccountManager *accountManager;
 @property (nonatomic, readonly) id<ContactsManagerProtocol> contactsManager;
 
 @end
 
 @implementation OWSFingerprintBuilder
 
-- (instancetype)initWithStorageManager:(TSStorageManager *)storageManager
+- (instancetype)initWithAccountManager:(TSAccountManager *)accountManager
                        contactsManager:(id<ContactsManagerProtocol>)contactsManager
 {
     self = [super init];
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
         return self;
     }
 
-    _storageManager = storageManager;
+    _accountManager = accountManager;
     _contactsManager = contactsManager;
 
     return self;
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSString *theirName = [self.contactsManager displayNameForPhoneIdentifier:theirSignalId];
 
-    NSString *mySignalId = [self.storageManager localNumber];
+    NSString *mySignalId = [self.accountManager localNumber];
     NSData *myIdentityKey = [[OWSIdentityManager sharedManager] identityKeyPair].publicKey;
 
     return [OWSFingerprint fingerprintWithMyStableId:mySignalId

--- a/SignalServiceKit/src/Storage/TSStorageHeaders.h
+++ b/SignalServiceKit/src/Storage/TSStorageHeaders.h
@@ -12,7 +12,6 @@
 #import "TSStorageManager+SessionStore.h"
 #import "TSStorageManager+SignedPreKeyStore.h"
 #import "TSStorageManager+keyFromIntLong.h"
-#import "TSStorageManager+keyingMaterial.h"
 #import "TSStorageManager+messageIDs.h"
 
 #endif

--- a/SignalServiceKit/src/Storage/TSStorageKeys.h
+++ b/SignalServiceKit/src/Storage/TSStorageKeys.h
@@ -1,9 +1,5 @@
 //
-//  TSStorageKeys.h
-//  TextSecureKit
-//
-//  Created by Frederic Jacobs on 28/10/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
 #ifndef TextSecureKit_TSStorageKeys_h
@@ -13,10 +9,8 @@
 
 #define TSStorageUserAccountCollection @"TSStorageUserAccountCollection"
 
-#define TSStorageRegisteredNumberKey @"TSStorageRegisteredNumberKey"
 #define TSStorageServerAuthToken @"TSStorageServerAuthToken"
 #define TSStorageServerSignalingKey @"TSStorageServerSignalingKey"
-#define TSStorageLocalRegistrationId @"TSStorageLocalRegistrationId"
 
 /**
  *  Preferences exposed to the user

--- a/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.h
+++ b/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.h
@@ -24,10 +24,6 @@
 
 + (NSString *)serverAuthToken;
 
-- (void)ifLocalNumberPresent:(BOOL)isPresent runAsync:(void (^)())block;
-
 + (void)storeServerToken:(NSString *)authToken signalingKey:(NSString *)signalingKey;
-
-- (void)storePhoneNumber:(NSString *)phoneNumber;
 
 @end

--- a/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.h
+++ b/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.h
@@ -1,9 +1,5 @@
 //
-//  TSStorageManager+keyingMaterial.h
-//  TextSecureKit
-//
-//  Created by Frederic Jacobs on 06/11/14.
-//  Copyright (c) 2014 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
 #import "TSStorageManager.h"
@@ -27,14 +23,6 @@
  */
 
 + (NSString *)serverAuthToken;
-
-/**
- *  Registered phone number
- *
- *  @return E164 string of the registered phone number
- */
-- (NSString *)localNumber;
-+ (NSString *)localNumber;
 
 - (void)ifLocalNumberPresent:(BOOL)isPresent runAsync:(void (^)())block;
 

--- a/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.m
+++ b/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.m
@@ -6,17 +6,6 @@
 
 @implementation TSStorageManager (keyingMaterial)
 
-+ (NSString *)localNumber
-{
-    return [[self sharedManager] localNumber];
-}
-
-- (NSString *)localNumber
-{
-    // TODO cache this? It only changes once, ever, and otherwise causes "surprising" transactions to occur.
-    return [self stringForKey:TSStorageRegisteredNumberKey inCollection:TSStorageUserAccountCollection];
-}
-
 - (void)ifLocalNumberPresent:(BOOL)runIfPresent runAsync:(void (^)())block;
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.m
+++ b/SignalServiceKit/src/Storage/TSStorageManager+keyingMaterial.m
@@ -4,33 +4,8 @@
 
 #import "TSStorageManager+keyingMaterial.h"
 
+// TODO merge this category extension's functionality into TSAccountManager
 @implementation TSStorageManager (keyingMaterial)
-
-- (void)ifLocalNumberPresent:(BOOL)runIfPresent runAsync:(void (^)())block;
-{
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        __block BOOL isPresent;
-        [self.newDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
-            isPresent = [[transaction objectForKey:TSStorageRegisteredNumberKey
-                                      inCollection:TSStorageUserAccountCollection] boolValue];
-        }];
-
-        if (isPresent == runIfPresent) {
-            if (runIfPresent) {
-                DDLogDebug(@"%@ Running existing-user block", self.logTag);
-            } else {
-                DDLogDebug(@"%@ Running new-user block", self.logTag);
-            }
-            block();
-        } else {
-            if (runIfPresent) {
-                DDLogDebug(@"%@ Skipping existing-user block for new-user", self.logTag);
-            } else {
-                DDLogDebug(@"%@ Skipping new-user block for existing-user", self.logTag);
-            }
-        }
-    });
-}
 
 + (NSString *)signalingKey {
     return [[self sharedManager] stringForKey:TSStorageServerSignalingKey inCollection:TSStorageUserAccountCollection];
@@ -38,15 +13,6 @@
 
 + (NSString *)serverAuthToken {
     return [[self sharedManager] stringForKey:TSStorageServerAuthToken inCollection:TSStorageUserAccountCollection];
-}
-
-- (void)storePhoneNumber:(NSString *)phoneNumber
-{
-    [self.dbReadWriteConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-        [transaction setObject:phoneNumber
-                        forKey:TSStorageRegisteredNumberKey
-                  inCollection:TSStorageUserAccountCollection];
-    }];
 }
 
 + (void)storeServerToken:(NSString *)authToken signalingKey:(NSString *)signalingKey {

--- a/SignalServiceKit/tests/Contacts/SignalRecipientTest.m
+++ b/SignalServiceKit/tests/Contacts/SignalRecipientTest.m
@@ -3,9 +3,15 @@
 //
 
 #import "SignalRecipient.h"
+#import "TSAccountManager.h"
 #import "TSStorageManager+keyingMaterial.h"
-#import "TSStorageManager.h"
 #import <XCTest/XCTest.h>
+
+@interface TSAccountManager (Testing)
+
+- (void)storeLocalNumber:(NSString *)localNumber;
+
+@end
 
 @interface SignalRecipientTest : XCTestCase
 
@@ -19,7 +25,7 @@
 {
     [super setUp];
     self.localNumber = @"+13231231234";
-    [[TSStorageManager sharedManager] storePhoneNumber:self.localNumber];
+    [[TSAccountManager sharedInstance] storeLocalNumber:self.localNumber];
 }
 
 - (void)testSelfRecipientWithExistingRecord

--- a/SignalServiceKit/tests/Messages/OWSMessageSenderTest.m
+++ b/SignalServiceKit/tests/Messages/OWSMessageSenderTest.m
@@ -10,13 +10,13 @@
 #import "OWSFakeNetworkManager.h"
 #import "OWSMessageSender.h"
 #import "OWSUploadingService.h"
+#import "TSAccountManager.h"
 #import "TSContactThread.h"
 #import "TSGroupModel.h"
 #import "TSGroupThread.h"
 #import "TSMessagesManager.h"
 #import "TSNetworkManager.h"
 #import "TSOutgoingMessage.h"
-#import "TSStorageManager+keyingMaterial.h"
 #import "TSStorageManager.h"
 #import <AxolotlKit/AxolotlExceptions.h>
 #import <AxolotlKit/SessionBuilder.h>
@@ -174,6 +174,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface TSAccountManager (Testing)
+
+- (void)storeLocalNumber:(NSString *)localNumber;
+
+@end
+
 @interface OWSMessageSenderTest : XCTestCase
 
 @property (nonatomic) TSThread *thread;
@@ -192,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
     [super setUp];
 
     // Hack to make sure we don't explode when sending sync message.
-    [[TSStorageManager sharedManager] storePhoneNumber:@"+13231231234"];
+    [[TSAccountManager sharedInstance] storeLocalNumber:@"+13231231234"];
 
     self.thread = [[TSContactThread alloc] initWithUniqueId:@"fake-thread-id"];
     [self.thread save];


### PR DESCRIPTION
The primary goal was to cache `localNumber` and `isRegistered`

In doing so I was compelled to gather some of the TSAccount concerns out of one of the myriad StorageManager extensions, which I think simplified things a bit.

note I updated all tests broken by these changes, but there are a couple failing SSK tests in master which remain broken in this branch.

PTAL @charlesmchen 
