### PR TITLE
Simplify code / pre-cache localNumber

### DIFF
--- a/Signal/src/util/OWSContactsSyncing.m
+++ b/Signal/src/util/OWSContactsSyncing.m
@@ -139,12 +139,9 @@ NSString *const kTSStorageManagerOWSContactsSyncingLastMessageKey =
         return;
     }
 
-    [[TSAccountManager sharedInstance] ifRegistered:YES
-                                           runAsync:^{
-                                               dispatch_async(dispatch_get_main_queue(), ^{
-                                                   [self sendSyncContactsMessageIfNecessary];
-                                               });
-                                           }];
+    if ([TSAccountManager sharedInstance]) {
+        [self sendSyncContactsMessageIfNecessary];
+    }
 }
 
 #pragma mark - Logging

--- a/SignalServiceKit/src/Account/TSAccountManager.h
+++ b/SignalServiceKit/src/Account/TSAccountManager.h
@@ -35,8 +35,6 @@ extern NSString *const kNSNotificationName_LocalNumberDidChange;
  */
 + (BOOL)isRegistered;
 
-- (void)ifRegistered:(BOOL)isRegistered runAsync:(void (^)())block;
-
 /**
  *  Returns current phone number for this device, which may not yet have been registered.
  *

--- a/SignalServiceKit/src/Account/TSAccountManager.m
+++ b/SignalServiceKit/src/Account/TSAccountManager.m
@@ -93,26 +93,6 @@ NSString *const TSAccountManager_LocalRegistrationIdKey = @"TSStorageLocalRegist
     return _isRegistered;
 }
 
-- (void)ifRegistered:(BOOL)runIfRegistered runAsync:(void (^)())block
-{
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        if ([self isRegistered] == runIfRegistered) {
-            if (runIfRegistered) {
-                DDLogDebug(@"%@ Running existing-user block", self.tag);
-            } else {
-                DDLogDebug(@"%@ Running new-user block", self.tag);
-            }
-            block();
-        } else {
-            if (runIfRegistered) {
-                DDLogDebug(@"%@ Skipping existing-user block for new-user", self.tag);
-            } else {
-                DDLogDebug(@"%@ Skipping new-user block for existing-user", self.tag);
-            }
-        }
-    });
-}
-
 - (void)didRegister
 {
     DDLogInfo(@"%@ didRegister", self.tag);

--- a/SignalServiceKit/src/Account/TSPreKeyManager.m
+++ b/SignalServiceKit/src/Account/TSPreKeyManager.m
@@ -109,10 +109,11 @@ static const NSTimeInterval kSignedPreKeyUpdateFailureMaxFailureDuration = 10 * 
             //       condition.
             lastPreKeyCheckTimestamp = [NSDate date];
 
-            [[TSAccountManager sharedInstance] ifRegistered:YES
-                                                   runAsync:^{
-                                                       [TSPreKeyManager checkPreKeys];
-                                                   }];
+            if ([TSAccountManager isRegistered]) {
+                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                    [TSPreKeyManager checkPreKeys];
+                });
+            }
         }
     });
 }


### PR DESCRIPTION
Now that `localNumber` is read from a dedicated dbConnection we don't have to worry about it blocking launch.

This has the side effect of making sure we pre-populate the cache for other uses of localNumber.

PTAL @charlesmchen 