### PR TITLE
Use profile name/image when available.

### DIFF
--- a/Signal/src/Models/OWSAvatarBuilder.m
+++ b/Signal/src/Models/OWSAvatarBuilder.m
@@ -20,7 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAvatarBuilder *avatarBuilder;
     if ([thread isKindOfClass:[TSContactThread class]]) {
-        avatarBuilder = [[OWSContactAvatarBuilder alloc] initWithThread:(TSContactThread *)thread contactsManager:contactsManager diameter:diameter];
+        TSContactThread *contactThread = (TSContactThread *)thread;
+        avatarBuilder = [[OWSContactAvatarBuilder alloc] initWithSignalId:contactThread.contactIdentifier diameter:diameter contactsManager:contactsManager];
     } else if ([thread isKindOfClass:[TSGroupThread class]]) {
         avatarBuilder = [[OWSGroupAvatarBuilder alloc] initWithThread:(TSGroupThread *)thread];
     } else {

--- a/Signal/src/Models/OWSContactAvatarBuilder.h
+++ b/Signal/src/Models/OWSContactAvatarBuilder.h
@@ -11,14 +11,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OWSContactAvatarBuilder : OWSAvatarBuilder
 
-- (instancetype)initWithContactId:(NSString *)contactId
-                             name:(NSString *)name
-                  contactsManager:(OWSContactsManager *)contactsManager
-                         diameter:(NSUInteger)diameter;
+/**
+ * Build an avatar for a Signal recipient
+ */
+- (instancetype)initWithSignalId:(NSString *)signalId
+                        diameter:(NSUInteger)diameter
+                 contactsManager:(OWSContactsManager *)contactsManager;
 
-- (instancetype)initWithThread:(TSContactThread *)thread
-               contactsManager:(OWSContactsManager *)contactsManager
-                      diameter:(NSUInteger)diameter;
+/**
+ * Build an avatar for a non-Signal recipient
+ */
+- (instancetype)initWithNonSignalName:(NSString *)nonSignalName
+                            colorSeed:(NSString *)colorSeed
+                             diameter:(NSUInteger)diameter
+                      contactsManager:(OWSContactsManager *)contactsManager;
+
 
 @end
 

--- a/Signal/src/Models/OWSContactAvatarBuilder.m
+++ b/Signal/src/Models/OWSContactAvatarBuilder.m
@@ -24,10 +24,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OWSContactAvatarBuilder
 
+#pragma mark - Initializers
+
 - (instancetype)initWithContactId:(NSString *)contactId
                              name:(NSString *)name
-                  contactsManager:(OWSContactsManager *)contactsManager
                          diameter:(NSUInteger)diameter
+                  contactsManager:(OWSContactsManager *)contactsManager
 {
     self = [super init];
     if (!self) {
@@ -36,18 +38,29 @@ NS_ASSUME_NONNULL_BEGIN
     
     _signalId = contactId;
     _contactName = name;
-    _contactsManager = contactsManager;
     _diameter = diameter;
+    _contactsManager = contactsManager;
     
     return self;
 }
 
-- (instancetype)initWithThread:(TSContactThread *)thread
-               contactsManager:(OWSContactsManager *)contactsManager
-                      diameter:(NSUInteger)diameter
+- (instancetype)initWithSignalId:(NSString *)signalId
+                        diameter:(NSUInteger)diameter
+                 contactsManager:(OWSContactsManager *)contactsManager
 {
-    return [self initWithContactId:thread.contactIdentifier name:thread.name contactsManager:contactsManager diameter:diameter];
+    NSString *name = [contactsManager displayNameForPhoneIdentifier:signalId];
+    return [self initWithContactId:signalId name:name diameter:diameter contactsManager:contactsManager];
 }
+
+- (instancetype)initWithNonSignalName:(NSString *)nonSignalName
+                            colorSeed:(NSString *)colorSeed
+                             diameter:(NSUInteger)diameter
+                      contactsManager:(OWSContactsManager *)contactsManager
+{
+    return [self initWithContactId:colorSeed name:nonSignalName diameter:diameter contactsManager:contactsManager];
+}
+
+#pragma mark - Instance methods
 
 - (nullable UIImage *)buildSavedImage
 {

--- a/Signal/src/views/ContactCell.swift
+++ b/Signal/src/views/ContactCell.swift
@@ -61,10 +61,11 @@ class ContactCell: UITableViewCell {
             }
 
             let kAvatarWidth: UInt = 40
-            let avatarBuilder = OWSContactAvatarBuilder(contactId:contactIdForDeterminingBackgroundColor,
-                                                        name:contact.fullName,
-                                                        contactsManager:contactsManager,
-                                                        diameter: kAvatarWidth)
+            let avatarBuilder = OWSContactAvatarBuilder(nonSignalName: contact.fullName,
+                                                        colorSeed: contactIdForDeterminingBackgroundColor,
+                                                        diameter: kAvatarWidth,
+                                                        contactsManager:contactsManager)
+
             self.contactImageView?.image = avatarBuilder.buildDefaultImage()
         } else {
             self.contactImageView?.image = contact.image

--- a/Signal/src/views/ContactTableViewCell.m
+++ b/Signal/src/views/ContactTableViewCell.m
@@ -81,26 +81,13 @@ const NSUInteger kContactTableViewCellAvatarSize = 40;
 - (void)configureWithSignalAccount:(SignalAccount *)signalAccount contactsManager:(OWSContactsManager *)contactsManager
 {
     [self configureWithRecipientId:signalAccount.recipientId
-                        avatarName:signalAccount.contact.fullName
-                       displayName:[contactsManager formattedDisplayNameForSignalAccount:signalAccount
-                                                                                    font:self.nameLabel.font]
                    contactsManager:contactsManager];
 }
 
-- (void)configureWithRecipientId:(NSString *)recipientId contactsManager:(OWSContactsManager *)contactsManager
-{
-    [self
-        configureWithRecipientId:recipientId
-                      avatarName:@""
-                     displayName:[contactsManager formattedFullNameForRecipientId:recipientId font:self.nameLabel.font]
-                 contactsManager:contactsManager];
-}
-
 - (void)configureWithRecipientId:(NSString *)recipientId
-                      avatarName:(NSString *)avatarName
-                     displayName:(NSAttributedString *)displayName
                  contactsManager:(OWSContactsManager *)contactsManager
 {
+    NSAttributedString *displayName = [contactsManager formattedFullNameForRecipientId:recipientId font:self.nameLabel.font];
     NSMutableAttributedString *attributedText = [displayName mutableCopy];
     if (self.accessoryMessage) {
         UILabel *blockedLabel = [[UILabel alloc] init];
@@ -113,10 +100,9 @@ const NSUInteger kContactTableViewCellAvatarSize = 40;
         self.accessoryView = blockedLabel;
     }
     self.nameLabel.attributedText = attributedText;
-    self.avatarView.image = [[[OWSContactAvatarBuilder alloc] initWithContactId:recipientId
-                                                                           name:avatarName
-                                                                contactsManager:contactsManager
-                                                                       diameter:kContactTableViewCellAvatarSize] build];
+    self.avatarView.image = [[[OWSContactAvatarBuilder alloc] initWithSignalId:recipientId
+                                                                      diameter:kContactTableViewCellAvatarSize
+                                                               contactsManager:contactsManager] build];
 
     // Force layout, since imageView isn't being initally rendered on App Store optimized build.
     [self layoutSubviews];


### PR DESCRIPTION
In the process, refactored the ContactAvatarBuilder to clarify intent of the two
methods. One is only used for non-signal contacts in the Invite flow.
The other should be used for any signal contacts so we have a single
consistent way of generating the avatar initials.

PTAL @charlesmchen 