### PR TITLE
Don't consider registration complete until user registers their push notification tokens.

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -466,10 +466,10 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
                     RTCInitializeSSL();
 
-                    [OWSSyncPushTokensJob runWithPushManager:[PushManager sharedManager]
-                                              accountManager:[Environment getCurrent].accountManager
-                                                 preferences:[Environment preferences]
-                                                  showAlerts:NO];
+                    __unused AnyPromise *promise =
+                        [OWSSyncPushTokensJob runWithPushManager:[PushManager sharedManager]
+                                                  accountManager:[Environment getCurrent].accountManager
+                                                     preferences:[Environment preferences]];
 
                     // Clean up any messages that expired since last launch immediately
                     // and continue cleaning in the background.

--- a/Signal/src/ViewControllers/AdvancedSettingsTableViewController.m
+++ b/Signal/src/ViewControllers/AdvancedSettingsTableViewController.m
@@ -12,6 +12,7 @@
 #import "PushManager.h"
 #import "Signal-Swift.h"
 #import "TSAccountManager.h"
+#import <PromiseKit/AnyPromise.h>
 #import <Reachability/Reachability.h>
 #import <SignalServiceKit/OWSSignalService.h>
 
@@ -242,10 +243,17 @@ NS_ASSUME_NONNULL_BEGIN
     OWSSyncPushTokensJob *job =
         [[OWSSyncPushTokensJob alloc] initWithPushManager:[PushManager sharedManager]
                                            accountManager:[Environment getCurrent].accountManager
-                                              preferences:[Environment preferences]
-                                               showAlerts:YES];
+                                              preferences:[Environment preferences]];
     job.uploadOnlyIfStale = NO;
-    [job run];
+    [job run]
+        .then(^{
+            [OWSAlerts showAlertWithTitle:NSLocalizedString(@"PUSH_REGISTER_SUCCESS",
+                                              @"Title of alert shown when push tokens sync job succeeds.")];
+        })
+        .catch(^(NSError *error) {
+            [OWSAlerts showAlertWithTitle:NSLocalizedString(@"REGISTRATION_BODY",
+                                              @"Title of alert shown when push tokens sync job fails.")];
+        });
 }
 
 - (void)didToggleEnableLogSwitch:(UISwitch *)sender {

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -484,8 +484,6 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
         [self.editingDbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction * _Nonnull transaction) {
             [self.experienceUpgradeFinder markAllAsSeenWithTransaction:transaction];
         }];
-        [self ensureNotificationsUpToDate];
-
         // Start running the disappearing messages job in case the newly registered user
         // enables this feature
         [[OWSDisappearingMessagesJob sharedJob] startIfNecessary];
@@ -530,14 +528,6 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
                              [self markAllUpgradeExperiencesAsSeen];
                          }];
     }
-}
-
-- (void)ensureNotificationsUpToDate
-{
-    [OWSSyncPushTokensJob runWithPushManager:[PushManager sharedManager]
-                              accountManager:self.accountManager
-                                 preferences:[Environment preferences]
-                                  showAlerts:NO];
 }
 
 - (void)tableViewSetUp {

--- a/Signal/src/environment/Environment.m
+++ b/Signal/src/environment/Environment.m
@@ -61,8 +61,8 @@ static Environment *environment = nil;
 {
     @synchronized (self) {
         if (!_accountManager) {
-            _accountManager =
-                [[AccountManager alloc] initWithTextSecureAccountManager:[TSAccountManager sharedInstance]];
+            _accountManager = [[AccountManager alloc] initWithTextSecureAccountManager:[TSAccountManager sharedInstance]
+                                                                           preferences:self.preferences];
         }
     }
 


### PR DESCRIPTION
Previously we let registration complete and then immediately uploaded push tokens. But in the event of a failure-to-upload for whatever reason, this would mean the user can send, but not receive, messages.

PTAL @charlesmchen 
