### PR TITLE
Fix jolting animation after sending a message

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -1896,7 +1896,7 @@ typedef enum : NSUInteger {
 
             // Or when the next message is *not* an outgoing sent/delivered message.
             TSOutgoingMessage *nextMessage = [self nextOutgoingMessage:indexPath];
-            if (nextMessage && nextMessage.messageState != TSOutgoingMessageStateSentToService) {
+            if (nextMessage && nextMessage.messageState == TSOutgoingMessageStateUnsent) {
                 [self updateLastDeliveredMessage:message];
                 return result;
             }


### PR DESCRIPTION
Let me preface this by saying I'm not married to this solution, but that I think we need to do something about this. It doesn't prevent anyone from using our app and it's been around for a long time (forever), but it's something that all our users see all the time.

When we send the nth message, we retain the footer for the n-1th message until the nth message is successfully sent.

Rendering process looks roughly like this:

1. render the footer on the n-1th message ("delivered")
2. draw the nth message with the "..." footer
3. update the nth message with the "sent" footer (and then "delivered) and hide the footer for
   the n-1th message

In the normal case this all happens very quickly, which results in some unpleasant flicker every time you send a message due to the height of the footer "moving" from the n-1th item to the nth item.

The concession in this PR is that we'll only print the n-1th footer once the outgoing message *fails*. So until we implement a design more like Android's double-check for sent/delivery, the user will not be able to distinguish between a sent vs delivered message *while* their next message is currently outgoing.

In my opinion the lack of jank in the normal case supersedes this shortcoming - but again I'm open to suggestion.

Here's the problem I'm trying to fix (slowed down):
![send-render-glitch](https://user-images.githubusercontent.com/217057/29339155-f12b698c-81e6-11e7-8675-c807d68e8c71.gif)

PTAL @charlesmchen 