### PR TITLE
Charlesmchen/new contact conversations vs profile whitelist

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -176,7 +176,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     // we need to bump this constant.
     //
     // We added a number of database views in v2.13.0.
-    NSString *kLastVersionWithDatabaseViewChange = @"2.13.0";
+    NSString *kLastVersionWithDatabaseViewChange = @"2.16.0";
     BOOL mayNeedUpgrade = ([TSAccountManager isRegistered] && lastLaunchedAppVersion
         && (!lastCompletedLaunchAppVersion ||
                [VersionMigrations isVersion:lastCompletedLaunchAppVersion

--- a/Signal/src/Profiles/OWSProfileManager.h
+++ b/Signal/src/Profiles/OWSProfileManager.h
@@ -43,6 +43,12 @@ extern const NSUInteger kOWSProfileManager_MaxAvatarDiameter;
 
 #pragma mark - Profile Whitelist
 
+#ifdef DEBUG
+// These methods are for debugging.
+- (void)clearProfileWhitelist;
+- (void)logProfileWhitelist;
+#endif
+
 - (void)addThreadToProfileWhitelist:(TSThread *)thread;
 
 - (BOOL)isThreadInProfileWhitelist:(TSThread *)thread;

--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -598,6 +598,8 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 #ifdef DEBUG
 - (void)clearProfileWhitelist
 {
+    DDLogWarn(@"%@ Clearing the profile whitelist.", self.tag);
+
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @synchronized(self)
         {
@@ -621,8 +623,20 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
             DDLogError(@"groupProfileWhitelistCache: %zd", self.groupProfileWhitelistCache.count);
             DDLogError(@"kOWSProfileManager_UserWhitelistCollection: %zd",
                 [self.dbConnection numberOfKeysInCollection:kOWSProfileManager_UserWhitelistCollection]);
+            [self.dbConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+                [transaction enumerateKeysInCollection:kOWSProfileManager_UserWhitelistCollection
+                                            usingBlock:^(NSString *_Nonnull key, BOOL *_Nonnull stop) {
+                                                DDLogError(@"\t profile whitelist user: %@", key);
+                                            }];
+            }];
             DDLogError(@"kOWSProfileManager_GroupWhitelistCollection: %zd",
                 [self.dbConnection numberOfKeysInCollection:kOWSProfileManager_GroupWhitelistCollection]);
+            [self.dbConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
+                [transaction enumerateKeysInCollection:kOWSProfileManager_GroupWhitelistCollection
+                                            usingBlock:^(NSString *_Nonnull key, BOOL *_Nonnull stop) {
+                                                DDLogError(@"\t profile whitelist group: %@", key);
+                                            }];
+            }];
         }
     });
 }

--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -595,6 +595,39 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 
 #pragma mark - Profile Whitelist
 
+#ifdef DEBUG
+- (void)clearProfileWhitelist
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        @synchronized(self)
+        {
+            [self.userProfileWhitelistCache removeAllObjects];
+            [self.groupProfileWhitelistCache removeAllObjects];
+
+            [self.dbConnection purgeCollection:kOWSProfileManager_UserWhitelistCollection];
+            [self.dbConnection purgeCollection:kOWSProfileManager_GroupWhitelistCollection];
+            OWSAssert(0 == [self.dbConnection numberOfKeysInCollection:kOWSProfileManager_UserWhitelistCollection]);
+            OWSAssert(0 == [self.dbConnection numberOfKeysInCollection:kOWSProfileManager_GroupWhitelistCollection]);
+        }
+    });
+}
+
+- (void)logProfileWhitelist
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        @synchronized(self)
+        {
+            DDLogError(@"userProfileWhitelistCache: %zd", self.userProfileWhitelistCache.count);
+            DDLogError(@"groupProfileWhitelistCache: %zd", self.groupProfileWhitelistCache.count);
+            DDLogError(@"kOWSProfileManager_UserWhitelistCollection: %zd",
+                [self.dbConnection numberOfKeysInCollection:kOWSProfileManager_UserWhitelistCollection]);
+            DDLogError(@"kOWSProfileManager_GroupWhitelistCollection: %zd",
+                [self.dbConnection numberOfKeysInCollection:kOWSProfileManager_GroupWhitelistCollection]);
+        }
+    });
+}
+#endif
+
 - (void)addUserToProfileWhitelist:(NSString *)recipientId
 {
     OWSAssert(recipientId.length > 0);

--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -166,6 +166,16 @@ typedef enum : NSUInteger {
 @property (nonatomic) TSThread *thread;
 @property (nonatomic) TSMessageAdapter *lastDeliveredMessage;
 @property (nonatomic) YapDatabaseConnection *editingDatabaseConnection;
+
+// These two properties must be updated in lockstep.
+//
+// * The first step is to update uiDatabaseConnection using beginLongLivedReadTransaction.
+// * The second step is to update messageMappings.
+// * We can't do the first step without doing the second step soon afterward.
+// * We can't do the second step without doing the first step first.
+// * We can't use messageMappings in between the first and second steps; e.g.
+//   we can't do any layout, since that uses numberOfItemsInSection: and
+//   interactionAtIndexPath: which use the messageMappings.
 @property (nonatomic) YapDatabaseConnection *uiDatabaseConnection;
 @property (nonatomic) YapDatabaseViewMappings *messageMappings;
 

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
@@ -53,6 +53,16 @@ NS_ASSUME_NONNULL_BEGIN
                                      actionBlock:^{
                                          [DebugUIMisc setManualCensorshipCircumventionEnabled:NO];
                                      }]];
+#ifdef DEBUG
+    [items addObject:[OWSTableItem itemWithTitle:@"Clear Profile Whitelist"
+                                     actionBlock:^{
+                                         [OWSProfileManager.sharedManager clearProfileWhitelist];
+                                     }]];
+    [items addObject:[OWSTableItem itemWithTitle:@"Log Profile Whitelist"
+                                     actionBlock:^{
+                                         [OWSProfileManager.sharedManager logProfileWhitelist];
+                                     }]];
+#endif
     return [OWSTableSection sectionWithTitle:self.name items:items];
 }
 

--- a/Signal/src/ViewControllers/SendExternalFileViewController.m
+++ b/Signal/src/ViewControllers/SendExternalFileViewController.m
@@ -64,6 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
+    [ThreadUtil addThreadToProfileWhitelistIfEmptyContactThread:thread];
     [ThreadUtil sendMessageWithAttachment:self.attachment inThread:thread messageSender:self.messageSender];
 
     [Environment messageThreadId:thread.uniqueId];

--- a/Signal/src/util/ThreadUtil.h
+++ b/Signal/src/util/ThreadUtil.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL hasMoreUnseenMessages;
 
+@property (nonatomic, readonly) BOOL didInsertDynamicInteractions;
+
 - (void)clearUnreadIndicatorState;
 
 @end
@@ -93,6 +95,13 @@ NS_ASSUME_NONNULL_BEGIN
                                       hideUnreadMessagesIndicator:(BOOL)hideUnreadMessagesIndicator
                                   firstUnseenInteractionTimestamp:(nullable NSNumber *)firstUnseenInteractionTimestamp
                                                      maxRangeSize:(int)maxRangeSize;
+
+// This method should be called right _before_ we send a message to a thread,
+// since we want to auto-add contact threads to the profile whitelist if the
+// conversation was initiated by the local user.
+//
+// Returns YES IFF the thread was just added to the profile whitelist.
++ (BOOL)addThreadToProfileWhitelistIfEmptyContactThread:(TSThread *)thread;
 
 @end
 

--- a/Signal/src/util/ThreadUtil.h
+++ b/Signal/src/util/ThreadUtil.h
@@ -38,8 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL hasMoreUnseenMessages;
 
-@property (nonatomic, readonly) BOOL didInsertDynamicInteractions;
-
 - (void)clearUnreadIndicatorState;
 
 @end

--- a/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
@@ -40,6 +40,10 @@ NSUInteger TSErrorMessageSchemaVersion = 1;
 
     _errorMessageSchemaVersion = TSErrorMessageSchemaVersion;
 
+    if (self.isDynamicInteraction) {
+        self.read = YES;
+    }
+
     return self;
 }
 
@@ -69,6 +73,10 @@ NSUInteger TSErrorMessageSchemaVersion = 1;
     _errorType = errorMessageType;
     _recipientId = recipientId;
     _errorMessageSchemaVersion = TSErrorMessageSchemaVersion;
+
+    if (self.isDynamicInteraction) {
+        self.read = YES;
+    }
 
     return self;
 }

--- a/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
@@ -35,6 +35,10 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
 
     _infoMessageSchemaVersion = TSInfoMessageSchemaVersion;
 
+    if (self.isDynamicInteraction) {
+        self.read = YES;
+    }
+
     return self;
 }
 
@@ -55,6 +59,10 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
 
     _messageType = infoMessage;
     _infoMessageSchemaVersion = TSInfoMessageSchemaVersion;
+
+    if (self.isDynamicInteraction) {
+        self.read = YES;
+    }
 
     return self;
 }

--- a/SignalServiceKit/src/Messages/TSMessagesManager.m
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.m
@@ -1141,9 +1141,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSUInteger)unreadMessagesCountExcept:(TSThread *)thread {
     __block NSUInteger numberOfItems;
     [self.dbConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-      numberOfItems = [[transaction ext:TSUnreadDatabaseViewExtensionName] numberOfItemsInAllGroups];
-      numberOfItems =
-          numberOfItems - [[transaction ext:TSUnreadDatabaseViewExtensionName] numberOfItemsInGroup:thread.uniqueId];
+        id databaseView = [transaction ext:TSUnreadDatabaseViewExtensionName];
+        OWSAssert(databaseView);
+        numberOfItems = ([databaseView numberOfItemsInAllGroups] - [databaseView numberOfItemsInGroup:thread.uniqueId]);
     }];
 
     return numberOfItems;

--- a/SignalServiceKit/src/Storage/TSDatabaseView.m
+++ b/SignalServiceKit/src/Storage/TSDatabaseView.m
@@ -125,7 +125,7 @@ NSString *const TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevic
 
     [self registerMessageDatabaseViewWithName:TSUnreadDatabaseViewExtensionName
                                  viewGrouping:viewGrouping
-                                      version:@"1"
+                                      version:@"2"
                                         async:NO];
 }
 
@@ -144,7 +144,7 @@ NSString *const TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevic
 
     [self registerMessageDatabaseViewWithName:TSUnseenDatabaseViewExtensionName
                                  viewGrouping:viewGrouping
-                                      version:@"1"
+                                      version:@"2"
                                         async:YES];
 }
 

--- a/SignalServiceKit/src/Storage/TSDatabaseView.m
+++ b/SignalServiceKit/src/Storage/TSDatabaseView.m
@@ -125,7 +125,7 @@ NSString *const TSSecondaryDevicesDatabaseViewExtensionName = @"TSSecondaryDevic
 
     [self registerMessageDatabaseViewWithName:TSUnreadDatabaseViewExtensionName
                                  viewGrouping:viewGrouping
-                                      version:@"2"
+                                      version:@"1"
                                         async:NO];
 }
 

--- a/SignalServiceKit/src/Storage/TSStorageManager.m
+++ b/SignalServiceKit/src/Storage/TSStorageManager.m
@@ -391,9 +391,7 @@ static NSString *keychainDBPassAccount    = @"TSDatabasePass";
 #pragma mark - convenience methods
 
 - (void)purgeCollection:(NSString *)collection {
-    [self.dbReadWriteConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-        [transaction removeAllObjectsInCollection:collection];
-    }];
+    [self.dbReadWriteConnection purgeCollection:collection];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key inCollection:(NSString *)collection {

--- a/SignalServiceKit/src/Storage/YapDatabaseConnection+OWS.h
+++ b/SignalServiceKit/src/Storage/YapDatabaseConnection+OWS.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable PreKeyRecord *)preKeyRecordForKey:(NSString *)key inCollection:(NSString *)collection;
 - (nullable SignedPreKeyRecord *)signedPreKeyRecordForKey:(NSString *)key inCollection:(NSString *)collection;
 
+- (NSUInteger)numberOfKeysInCollection:(NSString *)collection;
+
 #pragma mark -
 
 - (void)setObject:(id)object forKey:(NSString *)key inCollection:(NSString *)collection;
@@ -31,8 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeObjectForKey:(NSString *)string inCollection:(NSString *)collection;
 - (void)setInt:(int)integer forKey:(NSString *)key inCollection:(NSString *)collection;
 - (void)setDate:(NSDate *)value forKey:(NSString *)key inCollection:(NSString *)collection;
-- (void)purgeCollection:(NSString *)collection;
 - (int)incrementIntForKey:(NSString *)key inCollection:(NSString *)collection;
+
+- (void)purgeCollection:(NSString *)collection;
 
 @end
 

--- a/SignalServiceKit/src/Storage/YapDatabaseConnection+OWS.m
+++ b/SignalServiceKit/src/Storage/YapDatabaseConnection+OWS.m
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSUInteger)numberOfKeysInCollection:(NSString *)collection
 {
     __block NSUInteger result;
-    [self readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+    [self readWithBlock:^(YapDatabaseReadTransaction *transaction) {
         result = [transaction numberOfKeysInCollection:collection];
     }];
     return result;

--- a/SignalServiceKit/src/Storage/YapDatabaseConnection+OWS.m
+++ b/SignalServiceKit/src/Storage/YapDatabaseConnection+OWS.m
@@ -94,6 +94,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark -
 
+- (NSUInteger)numberOfKeysInCollection:(NSString *)collection
+{
+    __block NSUInteger result;
+    [self readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        result = [transaction numberOfKeysInCollection:collection];
+    }];
+    return result;
+}
+
 - (void)purgeCollection:(NSString *)collection
 {
     [self readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {


### PR DESCRIPTION
* Add debug UI tools for clearing and logging the profile whitelist.
* Auto-add new contact threads to profile whitelist when local user sends first message to that thread.
* Ensure dynamic interactions have a non-negative timestamp even if the conversation was empty.
* Only call updateMessageMappingRangeOptions _after_ beginLongLivedReadTransaction and updating messageMappings.
* Improve documentation around how to avoid corrupt mappings in conversation view.
* Fix edge cases around large initial range sizes.
* Always treat dynamic interactions as read.
* Rebuild the “unseen” database views to remove dynamic interactions (see above).

PTAL @michaelkirk 