### PR TITLE
Charlesmchen/rework profile view

### DIFF
--- a/Signal/src/ViewControllers/ProfileViewController.h
+++ b/Signal/src/ViewControllers/ProfileViewController.h
@@ -2,13 +2,11 @@
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
-#import "OWSTableViewController.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class SignalsViewController;
 
-@interface ProfileViewController : OWSTableViewController
+@interface ProfileViewController : UIViewController
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Signal/src/ViewControllers/ProfileViewController.m
+++ b/Signal/src/ViewControllers/ProfileViewController.m
@@ -135,6 +135,9 @@ NSString *const kProfileView_LastPresentedDate = @"kProfileView_LastPresentedDat
     // Avatar
 
     UIView *avatarRow = [UIView containerView];
+    avatarRow.userInteractionEnabled = YES;
+    [avatarRow
+        addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(avatarRowTapped:)]];
     [rows addObject:avatarRow];
 
     UILabel *avatarLabel = [UILabel new];
@@ -487,6 +490,13 @@ NSString *const kProfileView_LastPresentedDate = @"kProfileView_LastPresentedDat
 {
     if (sender.state == UIGestureRecognizerStateRecognized) {
         [self.nameTextField becomeFirstResponder];
+    }
+}
+
+- (void)avatarRowTapped:(UIGestureRecognizer *)sender
+{
+    if (sender.state == UIGestureRecognizerStateRecognized) {
+        [self avatarTapped];
     }
 }
 

--- a/Signal/src/ViewControllers/ProfileViewController.m
+++ b/Signal/src/ViewControllers/ProfileViewController.m
@@ -336,20 +336,24 @@ NSString *const kProfileView_LastPresentedDate = @"kProfileView_LastPresentedDat
                        action:@selector(backOrSkipButtonPressed)];
             break;
     }
-    if (self.hasUnsavedChanges) {
-        // If we have a unsaved changes, right item should be a "save" button.
-        self.navigationItem.rightBarButtonItem =
-            [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemSave
-                                                          target:self
-                                                          action:@selector(updatePressed)];
+
+    if (self.profileViewMode == ProfileViewMode_Registration) {
+        [self.skipOrSaveButton
+            setTitle:(self.hasUnsavedChanges
+                             ? NSLocalizedString(
+                                   @"PROFILE_VIEW_SAVE_BUTTON", @"Button to save the profile view in the profile view.")
+                             : NSLocalizedString(@"PROFILE_VIEW_SKIP_BUTTON",
+                                   @"Button to skip the profile view in the registration workflow."))forState
+                    :UIControlStateNormal];
+    } else {
+        if (self.hasUnsavedChanges) {
+            // If we have a unsaved changes, right item should be a "save" button.
+            self.navigationItem.rightBarButtonItem =
+                [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemSave
+                                                              target:self
+                                                              action:@selector(updatePressed)];
+        }
     }
-    [self.skipOrSaveButton
-        setTitle:(self.hasUnsavedChanges
-                         ? NSLocalizedString(
-                               @"PROFILE_VIEW_SAVE_BUTTON", @"Button to save the profile view in the profile view.")
-                         : NSLocalizedString(@"PROFILE_VIEW_SKIP_BUTTON",
-                               @"Button to skip the profile view in the registration workflow."))forState
-                :UIControlStateNormal];
 }
 
 - (void)updatePressed
@@ -496,11 +500,7 @@ NSString *const kProfileView_LastPresentedDate = @"kProfileView_LastPresentedDat
 
 - (void)skipOrSaveButtonPressed
 {
-    if (self.hasUnsavedChanges) {
-        [self updateProfile];
-    } else {
-        [self profileCompletedOrSkipped];
-    }
+    [self leaveViewCheckingForUnsavedChanges];
 }
 
 #pragma mark - AvatarViewHelperDelegate

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1084,12 +1084,6 @@
 /* Action Sheet title prompting the user for a profile avatar */
 "PROFILE_VIEW_AVATAR_ACTIONSHEET_TITLE" = "Set Profile Avatar";
 
-/* Instructions for how to change the profile avatar. */
-"PROFILE_VIEW_AVATAR_INSTRUCTIONS" = "Tap to Select Avatar";
-
-/* Header title for the profile avatar field of the profile view. */
-"PROFILE_VIEW_AVATAR_SECTION_HEADER" = "Avatar";
-
 /* Label for action that clear's the user's profile avatar */
 "PROFILE_VIEW_CLEAR_AVATAR" = "Clear Avatar";
 
@@ -1097,10 +1091,19 @@
 "PROFILE_VIEW_ERROR_UPDATE_FAILED" = "Profile update failed.";
 
 /* Default text for the profile name field of the profile view. */
-"PROFILE_VIEW_NAME_DEFAULT_TEXT" = "Enter your name.";
+"PROFILE_VIEW_NAME_DEFAULT_TEXT" = "Enter your name";
+
+/* Label for the profile avatar field of the profile view. */
+"PROFILE_VIEW_PROFILE_AVATAR_FIELD" = "Avatar";
+
+/* Description of the user profile. */
+"PROFILE_VIEW_PROFILE_DESCRIPTION" = "Your profile affects how you will appear to other users if you are not in their contacts.";
+
+/* Link to more information about the user profile. */
+"PROFILE_VIEW_PROFILE_DESCRIPTION_LINK" = "Click here to learn more.";
 
 /* Label for the profile name field of the profile view. */
-"PROFILE_VIEW_NAME_SECTION_HEADER" = "Profile Name";
+"PROFILE_VIEW_PROFILE_NAME_FIELD" = "Profile Name";
 
 /* Alert title that indicates the user's profile view is being saved. */
 "PROFILE_VIEW_SAVING" = "Saving...";

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1105,8 +1105,14 @@
 /* Label for the profile name field of the profile view. */
 "PROFILE_VIEW_PROFILE_NAME_FIELD" = "Profile Name";
 
+/* Button to save the profile view in the profile view. */
+"PROFILE_VIEW_SAVE_BUTTON" = "Save";
+
 /* Alert title that indicates the user's profile view is being saved. */
 "PROFILE_VIEW_SAVING" = "Saving...";
+
+/* Button to skip the profile view in the registration workflow. */
+"PROFILE_VIEW_SKIP_BUTTON" = "Skip";
 
 /* Title for the profile view. */
 "PROFILE_VIEW_TITLE" = "Profile";


### PR DESCRIPTION

![screen shot 2017-08-21 at 12 22 00 pm](https://user-images.githubusercontent.com/625803/29528861-85bd7e90-866b-11e7-8a4f-34b8520725a5.png)
![screen shot 2017-08-21 at 12 21 44 pm](https://user-images.githubusercontent.com/625803/29528862-85bf347e-866b-11e7-9350-895d1c5a2ae0.png)

* We prefer a layout that won't be hidden on small form factor devices.
* We could add a large "Save/Skip" button in the view when it is used in the onboarding workflow. 
* I added a first pass at the "profile info" copy and the link to more info.

PTAL @michaelkirk 