### PR TITLE
Charlesmchen/pad empty profile name

### DIFF
--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -1178,11 +1178,6 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 
 - (nullable NSData *)encryptProfileNameWithUnpaddedName:(NSString *)name
 {
-    // TODO: Should this be nil or a padded-out empty string?
-    //    if (name.length == 0) {
-    //        return nil;
-    //    }
-
     NSData *nameData = [name dataUsingEncoding:NSUTF8StringEncoding];
     if (nameData.length > kOWSProfileManager_NameDataLength) {
         OWSFail(@"%@ name data is too long with length:%lu", self.tag, (unsigned long)nameData.length);


### PR DESCRIPTION
Per our conversation on Friday, we completely pad empty profile names so that they are indistinguishable from non-empty profile names.

// FREEBIE