### PR TITLE
Clear own avatar on service if necessary when updating local profile.…

### DIFF
--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -478,6 +478,7 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
     return data;
 }
 
+// If avatarData is nil, we are clearing the avatar.
 - (void)uploadAvatarToService:(NSData *_Nullable)avatarData
                       success:(void (^)(NSString *_Nullable avatarUrlPath))successBlock
                       failure:(void (^)())failureBlock


### PR DESCRIPTION
… Clear others' avatar when appropriate.

* Clear own avatar on service if necessary when updating local profile.
  * We request the upload form (but not submit that form) to clear the profile avatar.
* Clear others' avatar when appropriate.
  * We need to immediately clear other users' profile avatar when their avatar changes or is cleared.

PTAL @michaelkirk 
