### PR TITLE
profile key message

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		45464DBC1DFA041F001D3FD6 /* DataChannelMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45464DBB1DFA041F001D3FD6 /* DataChannelMessage.swift */; };
 		454EBAB31F2BC08800ACE0BB /* OWSSwiftUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D99C921F2937CC00D284D6 /* OWSSwiftUtils.swift */; };
 		454EBAB41F2BE14C00ACE0BB /* OWSAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D99C911F2937CC00D284D6 /* OWSAnalytics.swift */; };
+		4556FA681F54AA9500AF40DD /* DebugUIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4556FA671F54AA9500AF40DD /* DebugUIProfile.swift */; };
+		4556FA691F54AA9500AF40DD /* DebugUIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4556FA671F54AA9500AF40DD /* DebugUIProfile.swift */; };
 		455A16DD1F1FEA0000F86704 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 455A16DB1F1FEA0000F86704 /* Metal.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		455A16DE1F1FEA0000F86704 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 455A16DC1F1FEA0000F86704 /* MetalKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		455AC69B1F4F79E500134004 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455AC69A1F4F79E500134004 /* ImageCache.swift */; };
@@ -608,6 +610,7 @@
 		4542F0951EBB9E9A00C7EE92 /* Promise+retainUntilComplete.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+retainUntilComplete.swift"; sourceTree = "<group>"; };
 		45464DBB1DFA041F001D3FD6 /* DataChannelMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataChannelMessage.swift; sourceTree = "<group>"; };
 		454B35071D08EED80026D658 /* mk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mk; path = translations/mk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4556FA671F54AA9500AF40DD /* DebugUIProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugUIProfile.swift; sourceTree = "<group>"; };
 		455A16DB1F1FEA0000F86704 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		455A16DC1F1FEA0000F86704 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		455AC69A1F4F79E500134004 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
@@ -1136,6 +1139,7 @@
 				34D8C0251ED3673300188D7C /* DebugUITableViewController.h */,
 				34D8C0261ED3673300188D7C /* DebugUITableViewController.m */,
 				45638BDB1F3DD0D400128435 /* DebugUICalling.swift */,
+				4556FA671F54AA9500AF40DD /* DebugUIProfile.swift */,
 			);
 			path = DebugUI;
 			sourceTree = "<group>";
@@ -2289,6 +2293,7 @@
 				34F3089F1ECA580B00BB7697 /* OWSUnreadIndicatorCell.m in Sources */,
 				34B3F8861E8DF1700035BE1A /* NotificationSettingsOptionsViewController.m in Sources */,
 				452ECA4D1E087E7200E2F016 /* MessageFetcherJob.swift in Sources */,
+				4556FA681F54AA9500AF40DD /* DebugUIProfile.swift in Sources */,
 				452EA0971EA662330078744B /* AttachmentPointerAdapter.swift in Sources */,
 				34DFCB851E8E04B500053165 /* AddToBlockListViewController.m in Sources */,
 				45855F371D9498A40084F340 /* OWSContactAvatarBuilder.m in Sources */,
@@ -2452,6 +2457,7 @@
 				954AEE6A1DF33E01002E5410 /* ContactsPickerTest.swift in Sources */,
 				B660F77B1C29988E00687D6E /* Queue.m in Sources */,
 				455AC69C1F4F79E500134004 /* ImageCache.swift in Sources */,
+				4556FA691F54AA9500AF40DD /* DebugUIProfile.swift in Sources */,
 				45666F581D9B2880008FE134 /* OWSScrubbingLogFormatterTest.m in Sources */,
 				B660F77F1C29988E00687D6E /* DateUtil.m in Sources */,
 				B660F7811C29988E00687D6E /* FunctionalUtil.m in Sources */,

--- a/Signal/src/Profiles/OWSProfileManager.h
+++ b/Signal/src/Profiles/OWSProfileManager.h
@@ -17,6 +17,7 @@ extern const NSUInteger kOWSProfileManager_MaxAvatarDiameter;
 
 @class TSThread;
 @class OWSAES256Key;
+@class OWSMessageSender;
 
 // This class can be safely accessed and used from any thread.
 @interface OWSProfileManager : NSObject <ProfileManagerProtocol>
@@ -77,6 +78,13 @@ extern const NSUInteger kOWSProfileManager_MaxAvatarDiameter;
 - (void)updateProfileForRecipientId:(NSString *)recipientId
                profileNameEncrypted:(nullable NSData *)profileNameEncrypted
                       avatarUrlPath:(nullable NSString *)avatarUrlPath;
+
+#pragma mark - User Interface
+
+- (void)presentAddThreadToProfileWhitelist:(TSThread *)thread
+                        fromViewController:(UIViewController *)fromViewController
+                             messageSender:(OWSMessageSender *)messageSender
+                                   success:(void (^)())successHandler;
 
 @end
 

--- a/Signal/src/Profiles/OWSProfileManager.h
+++ b/Signal/src/Profiles/OWSProfileManager.h
@@ -83,7 +83,6 @@ extern const NSUInteger kOWSProfileManager_MaxAvatarDiameter;
 
 - (void)presentAddThreadToProfileWhitelist:(TSThread *)thread
                         fromViewController:(UIViewController *)fromViewController
-                             messageSender:(OWSMessageSender *)messageSender
                                    success:(void (^)())successHandler;
 
 @end

--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -1339,7 +1339,6 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 
 - (void)presentAddThreadToProfileWhitelist:(TSThread *)thread
                         fromViewController:(UIViewController *)fromViewController
-                             messageSender:(OWSMessageSender *)messageSender
                                    success:(void (^)())successHandler
 {
     AssertIsOnMainThread();
@@ -1353,7 +1352,6 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
                                                         style:UIAlertActionStyleDefault
                                                       handler:^(UIAlertAction *_Nonnull action) {
                                                           [self userAddedThreadToProfileWhitelist:thread
-                                                                                    messageSender:messageSender
                                                                                           success:successHandler];
                                                       }]];
     [alertController addAction:[OWSAlerts cancelAction]];
@@ -1362,7 +1360,6 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 }
 
 - (void)userAddedThreadToProfileWhitelist:(TSThread *)thread
-                            messageSender:(OWSMessageSender *)messageSender
                                   success:(void (^)())successHandler
 {
     AssertIsOnMainThread();
@@ -1378,7 +1375,7 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
         return;
     }
 
-    [messageSender sendMessage:message
+    [self.messageSender sendMessage:message
         success:^{
             DDLogInfo(@"%@ Successfully sent profile key message to thread: %@", self.tag, thread);
             [OWSProfileManager.sharedManager addThreadToProfileWhitelist:thread];

--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -1352,20 +1352,18 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
     [alertController addAction:[UIAlertAction actionWithTitle:shareTitle
                                                         style:UIAlertActionStyleDefault
                                                       handler:^(UIAlertAction *_Nonnull action) {
-                                                          [self addThreadToProfileWhitelist:thread
-                                                                         fromViewController:fromViewController
-                                                                              messageSender:messageSender
-                                                                                    success:successHandler];
+                                                          [self userAddedThreadToProfileWhitelist:thread
+                                                                                    messageSender:messageSender
+                                                                                          success:successHandler];
                                                       }]];
     [alertController addAction:[OWSAlerts cancelAction]];
 
     [fromViewController presentViewController:alertController animated:YES completion:nil];
 }
 
-- (void)addThreadToProfileWhitelist:(TSThread *)thread
-                 fromViewController:(UIViewController *)fromViewController
-                      messageSender:(OWSMessageSender *)messageSender
-                            success:(void (^)())successHandler
+- (void)userAddedThreadToProfileWhitelist:(TSThread *)thread
+                            messageSender:(OWSMessageSender *)messageSender
+                                  success:(void (^)())successHandler
 {
     AssertIsOnMainThread();
 
@@ -1392,23 +1390,6 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
         failure:^(NSError *_Nonnull error) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 DDLogError(@"%@ Failed to send profile key message to thread: %@", self.tag, thread);
-                UIAlertController *retryAlertController = [UIAlertController
-                    alertControllerWithTitle:NSLocalizedString(@"SHARE_PROFILE_FAILED_TITLE", @"alert title")
-                                     message:error.localizedDescription
-                              preferredStyle:UIAlertControllerStyleAlert];
-                [retryAlertController
-                    addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"RETRY_BUTTON_TEXT", nil)
-                                                       style:UIAlertActionStyleDefault
-                                                     handler:^(UIAlertAction *_Nonnull retryAction) {
-                                                         [self addThreadToProfileWhitelist:thread
-                                                                        fromViewController:fromViewController
-                                                                             messageSender:messageSender
-                                                                                   success:successHandler];
-                                                     }]];
-
-                [retryAlertController addAction:[OWSAlerts cancelAction]];
-
-                [fromViewController presentViewController:retryAlertController animated:YES completion:nil];
             });
         }];
 }

--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -1367,9 +1367,19 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
                       messageSender:(OWSMessageSender *)messageSender
                             success:(void (^)())successHandler
 {
+    AssertIsOnMainThread();
 
     OWSProfileKeyMessage *message =
         [[OWSProfileKeyMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp] inThread:thread];
+
+    BOOL isFeatureEnabled = NO;
+    if (!isFeatureEnabled) {
+        DDLogWarn(@"%@ skipping sending profile-key message because the feature is not yet fully available.", self.tag);
+        [OWSProfileManager.sharedManager addThreadToProfileWhitelist:thread];
+        successHandler();
+        return;
+    }
+
     [messageSender sendMessage:message
         success:^{
             DDLogInfo(@"%@ Successfully sent profile key message to thread: %@", self.tag, thread);

--- a/Signal/src/Profiles/ProfileFetcherJob.swift
+++ b/Signal/src/Profiles/ProfileFetcherJob.swift
@@ -60,7 +60,7 @@ class ProfileFetcherJob: NSObject {
                 if remainingRetries > 0 {
                     self.updateProfile(recipientId: recipientId, remainingRetries: remainingRetries - 1)
                 } else {
-                    owsFail("\(self.TAG) in \(#function) failed to get profile with error: \(error)")
+                    Logger.error("\(self.TAG) in \(#function) failed to get profile with error: \(error)")
                 }
             }
         }.retainUntilComplete()

--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -70,6 +70,7 @@
 #import <SignalServiceKit/OWSMessageReceiver.h>
 #import <SignalServiceKit/OWSMessageSender.h>
 #import <SignalServiceKit/OWSOutgoingCallMessage.h>
+#import <SignalServiceKit/OWSProfileKeyMessage.h>
 #import <SignalServiceKit/OWSRecipientIdentity.h>
 #import <SignalServiceKit/OWSSignalService.h>
 #import <SignalServiceKit/OWSSyncContactsMessage.h>

--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -2791,7 +2791,6 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
 {
     [[OWSProfileManager sharedManager] presentAddThreadToProfileWhitelist:self.thread
                                                        fromViewController:self
-                                                            messageSender:self.messageSender
                                                                   success:successHandler];
 }
 

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
@@ -17,6 +17,7 @@
 #import <SignalServiceKit/TSCall.h>
 #import <SignalServiceKit/TSInvalidIdentityKeyReceivingErrorMessage.h>
 #import <SignalServiceKit/TSStorageManager+SessionStore.h>
+#import <SignalServiceKit/OWSProfileKeyMessage.h>
 #import <SignalServiceKit/TSThread.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -67,6 +68,18 @@ NS_ASSUME_NONNULL_BEGIN
                                          [[OWSProfileManager sharedManager] regenerateLocalProfile];
                                      }]];
 #endif
+    [items addObject:[OWSTableItem itemWithTitle:@"Send profile key message."
+                                     actionBlock:^{
+                                         OWSProfileKeyMessage *message = [[OWSProfileKeyMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp] inThread:thread];
+                                         
+                                         [[Environment getCurrent].messageSender sendMessage:message
+                                                                                     success:^{
+                                                                                         DDLogInfo(@"Successfully sent profile key message to thread: %@", thread);
+                                                                                     }
+                                                                                     failure:^(NSError * _Nonnull error) {
+                                                                                         OWSFail(@"Failed to send prifle key message to thread: %@", thread);
+                                                                                     }];
+                                     }]];
     [items addObject:[OWSTableItem itemWithTitle:@"Clear hasDismissedOffers"
                                      actionBlock:^{
                                          [DebugUIMisc clearHasDismissedOffers];

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
@@ -17,7 +17,6 @@
 #import <SignalServiceKit/TSCall.h>
 #import <SignalServiceKit/TSInvalidIdentityKeyReceivingErrorMessage.h>
 #import <SignalServiceKit/TSStorageManager+SessionStore.h>
-#import <SignalServiceKit/OWSProfileKeyMessage.h>
 #import <SignalServiceKit/TSThread.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
@@ -54,32 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
                                      actionBlock:^{
                                          [DebugUIMisc setManualCensorshipCircumventionEnabled:NO];
                                      }]];
-#ifdef DEBUG
-    [items addObject:[OWSTableItem itemWithTitle:@"Clear Profile Whitelist"
-                                     actionBlock:^{
-                                         [OWSProfileManager.sharedManager clearProfileWhitelist];
-                                     }]];
-    [items addObject:[OWSTableItem itemWithTitle:@"Log Profile Whitelist"
-                                     actionBlock:^{
-                                         [OWSProfileManager.sharedManager logProfileWhitelist];
-                                     }]];
-    [items addObject:[OWSTableItem itemWithTitle:@"Regenerate Profile/ProfileKey"
-                                     actionBlock:^{
-                                         [[OWSProfileManager sharedManager] regenerateLocalProfile];
-                                     }]];
-#endif
-    [items addObject:[OWSTableItem itemWithTitle:@"Send profile key message."
-                                     actionBlock:^{
-                                         OWSProfileKeyMessage *message = [[OWSProfileKeyMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp] inThread:thread];
-                                         
-                                         [[Environment getCurrent].messageSender sendMessage:message
-                                                                                     success:^{
-                                                                                         DDLogInfo(@"Successfully sent profile key message to thread: %@", thread);
-                                                                                     }
-                                                                                     failure:^(NSError * _Nonnull error) {
-                                                                                         OWSFail(@"Failed to send prifle key message to thread: %@", thread);
-                                                                                     }];
-                                     }]];
     [items addObject:[OWSTableItem itemWithTitle:@"Clear hasDismissedOffers"
                                      actionBlock:^{
                                          [DebugUIMisc clearHasDismissedOffers];

--- a/Signal/src/ViewControllers/DebugUI/DebugUIProfile.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIProfile.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+
+class DebugUIProfile: DebugUIPage {
+
+    let TAG = "[DebugUIProfile]"
+
+    // MARK: Dependencies
+
+    var messageSender: MessageSender {
+        return Environment.getCurrent().messageSender
+    }
+    var profileManager: OWSProfileManager {
+        return OWSProfileManager.shared()
+    }
+
+    // MARK: Overrides
+
+    override func name() -> String {
+        return "Profile"
+    }
+
+    override func section(thread aThread: TSThread?) -> OWSTableSection? {
+        let sectionItems = [
+            OWSTableItem(title: "Clear Profile Whitelist") {
+                self.profileManager.clearProfileWhitelist()
+            },
+            OWSTableItem(title: "Log Profile Whitelist") {
+                self.profileManager.logProfileWhitelist()
+            },
+            OWSTableItem(title: "Regenerate Profile/ProfileKey") {
+                self.profileManager.regenerateLocalProfile()
+            },
+            OWSTableItem(title: "Send profile key message.") {
+                let message = OWSProfileKeyMessage(timestamp: NSDate.ows_millisecondTimeStamp(), in: aThread)
+                self.messageSender.sendPromise(message: message).then {
+                    Logger.info("Successfully sent profile key message to thread: \(String(describing: aThread))")
+                }.catch { _ in
+                    owsFail("Failed to send profile key message to thread: \(String(describing: aThread))")
+                }
+            }
+        ]
+
+        return OWSTableSection(title: "Profile", items: sectionItems)
+    }
+
+}

--- a/Signal/src/ViewControllers/DebugUI/DebugUITableViewController.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUITableViewController.m
@@ -95,6 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
         [subsectionItems
             addObject:[self itemForSubsection:[DebugUICalling new] viewController:viewController thread:thread]];
     }
+    [subsectionItems addObject:[self itemForSubsection:[DebugUIProfile new] viewController:viewController thread:thread]];
     [subsectionItems addObject:[self itemForSubsection:[DebugUIMisc new] viewController:viewController thread:thread]];
 
     [contents addSection:[OWSTableSection sectionWithTitle:@"Sections" items:subsectionItems]];

--- a/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
+++ b/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
@@ -785,27 +785,12 @@ NS_ASSUME_NONNULL_BEGIN
 {
     [self.tableView deselectRowAtIndexPath:[self.tableView indexPathForSelectedRow] animated:YES];
 
-    UIAlertController *alertController =
-        [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
-
-    UIAlertAction *leaveAction = [UIAlertAction
-        actionWithTitle:NSLocalizedString(@"CONVERSATION_SETTINGS_VIEW_SHARE_PROFILE",
-                            @"Button to confirm that user wants to share their profile with a user or group.")
-                  style:UIAlertActionStyleDestructive
-                handler:^(UIAlertAction *_Nonnull action) {
-                    [self shareProfile];
-                }];
-    [alertController addAction:leaveAction];
-    [alertController addAction:[OWSAlerts cancelAction]];
-
-    [self presentViewController:alertController animated:YES completion:nil];
-}
-
-- (void)shareProfile
-{
-    [OWSProfileManager.sharedManager addThreadToProfileWhitelist:self.thread];
-
-    [self updateTableContents];
+    [OWSProfileManager.sharedManager presentAddThreadToProfileWhitelist:self.thread
+                                                     fromViewController:self
+                                                          messageSender:self.messageSender
+                                                                success:^{
+                                                                    [self updateTableContents];
+                                                                }];
 }
 
 - (void)showVerificationView

--- a/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
+++ b/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
@@ -787,7 +787,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     [OWSProfileManager.sharedManager presentAddThreadToProfileWhitelist:self.thread
                                                      fromViewController:self
-                                                          messageSender:self.messageSender
                                                                 success:^{
                                                                     [self updateTableContents];
                                                                 }];

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1417,6 +1417,9 @@
 /* action sheet item */
 "SHARE_ACTION_TWEET" = "Twitter";
 
+/* alert title */
+"SHARE_PROFILE_FAILED_TITLE" = "Failed to Share Your Profile";
+
 /* Action sheet item */
 "SHOW_SAFETY_NUMBER_ACTION" = "Show New Safety Number";
 

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1417,9 +1417,6 @@
 /* action sheet item */
 "SHARE_ACTION_TWEET" = "Twitter";
 
-/* alert title */
-"SHARE_PROFILE_FAILED_TITLE" = "Failed to Share Your Profile";
-
 /* Action sheet item */
 "SHOW_SAFETY_NUMBER_ACTION" = "Show New Safety Number";
 

--- a/SignalServiceKit/protobuf/OWSSignalServiceProtos.proto
+++ b/SignalServiceKit/protobuf/OWSSignalServiceProtos.proto
@@ -82,6 +82,7 @@ message DataMessage {
   enum Flags {
     END_SESSION = 1;
     EXPIRATION_TIMER_UPDATE = 2;
+    PROFILE_KEY = 4;
   }
 
   optional string             body        = 1;

--- a/SignalServiceKit/src/Messages/OWSProfileKeyMessage.h
+++ b/SignalServiceKit/src/Messages/OWSProfileKeyMessage.h
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "TSOutgoingMessage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OWSProfileKeyMessage : TSOutgoingMessage
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Messages/OWSProfileKeyMessage.m
+++ b/SignalServiceKit/src/Messages/OWSProfileKeyMessage.m
@@ -1,0 +1,50 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "OWSProfileKeyMessage.h"
+#import "OWSSignalServiceProtos.pb.h"
+#import "ProfileManagerProtocol.h"
+#import "ProtoBuf+OWS.h"
+#import "TextSecureKitEnv.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSProfileKeyMessage
+
+- (void)saveWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
+    // override superclass with no-op.
+    //
+    // There's no need to save this message, since it's not displayed to the user.
+}
+
+- (BOOL)shouldSyncTranscript
+{
+    return NO;
+}
+
+- (OWSSignalServiceProtosDataMessage *)buildDataMessage:(NSString *_Nullable)recipientId
+{
+    OWSAssert(self.thread);
+    
+    OWSSignalServiceProtosDataMessageBuilder *builder = [self dataMessageBuilder];
+    [builder addLocalProfileKey];
+    [builder setFlags:OWSSignalServiceProtosDataMessageFlagsProfileKey];
+    
+    if (recipientId.length > 0) {
+        // Once we've shared our profile key with a user (perhaps due to being
+        // a member of a whitelisted group), make sure they're whitelisted.
+        id<ProfileManagerProtocol> profileManager = [TextSecureKitEnv sharedEnv].profileManager;
+        // FIXME PERF avoid this dispatch. It's going to happen for *each* recipient in a group message.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [profileManager addUserToProfileWhitelist:recipientId];
+        });
+    }
+
+    return [builder build];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Messages/OWSSignalServiceProtos.pb.h
+++ b/SignalServiceKit/src/Messages/OWSSignalServiceProtos.pb.h
@@ -112,6 +112,7 @@ NSString *NSStringFromOWSSignalServiceProtosEnvelopeType(OWSSignalServiceProtosE
 typedef NS_ENUM(SInt32, OWSSignalServiceProtosDataMessageFlags) {
   OWSSignalServiceProtosDataMessageFlagsEndSession = 1,
   OWSSignalServiceProtosDataMessageFlagsExpirationTimerUpdate = 2,
+  OWSSignalServiceProtosDataMessageFlagsProfileKey = 4,
 };
 
 BOOL OWSSignalServiceProtosDataMessageFlagsIsValidValue(OWSSignalServiceProtosDataMessageFlags value);

--- a/SignalServiceKit/src/Messages/OWSSignalServiceProtos.pb.m
+++ b/SignalServiceKit/src/Messages/OWSSignalServiceProtos.pb.m
@@ -3103,6 +3103,7 @@ BOOL OWSSignalServiceProtosDataMessageFlagsIsValidValue(OWSSignalServiceProtosDa
   switch (value) {
     case OWSSignalServiceProtosDataMessageFlagsEndSession:
     case OWSSignalServiceProtosDataMessageFlagsExpirationTimerUpdate:
+    case OWSSignalServiceProtosDataMessageFlagsProfileKey:
       return YES;
     default:
       return NO;
@@ -3114,6 +3115,8 @@ NSString *NSStringFromOWSSignalServiceProtosDataMessageFlags(OWSSignalServicePro
       return @"OWSSignalServiceProtosDataMessageFlagsEndSession";
     case OWSSignalServiceProtosDataMessageFlagsExpirationTimerUpdate:
       return @"OWSSignalServiceProtosDataMessageFlagsExpirationTimerUpdate";
+    case OWSSignalServiceProtosDataMessageFlagsProfileKey:
+      return @"OWSSignalServiceProtosDataMessageFlagsProfileKey";
     default:
       return nil;
   }

--- a/SignalServiceKit/src/Protocols/ProtoBuf+OWS.h
+++ b/SignalServiceKit/src/Protocols/ProtoBuf+OWS.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OWSSignalServiceProtosDataMessageBuilder (OWS)
 
 - (void)addLocalProfileKeyIfNecessary:(TSThread *)thread recipientId:(NSString *_Nullable)recipientId;
+- (void)addLocalProfileKey;
 
 @end
 

--- a/SignalServiceKit/src/Protocols/ProtoBuf+OWS.m
+++ b/SignalServiceKit/src/Protocols/ProtoBuf+OWS.m
@@ -64,6 +64,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)addLocalProfileKey
+{
+    [self setProfileKey:self.localProfileKey.keyData];
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
1. Send an empty message upon whitelisting someone so they get our key right away.
2. Handle said messages.
3. Do not create a text message if there is no message body.

At present (1.) is implemented but disabled behind a feature flag so that we can let handling these messages roll out first.

(3.) exists so that we don't need to do this staged release dance in the future. 

PTAL @charlesmchen 