### PR TITLE
infer when group has been whitelisted on linked device

### DIFF
--- a/SignalServiceKit/src/Messages/TSMessagesManager.m
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.m
@@ -715,13 +715,14 @@ NS_ASSUME_NONNULL_BEGIN
         OWSSignalServiceProtosDataMessage *dataMessage = syncMessage.sent.message;
         OWSAssert(dataMessage);
         NSString *destination = syncMessage.sent.destination;
-        if (dataMessage && destination.length > 0 && [dataMessage hasProfileKey]) {
+        if (dataMessage && destination.length > 0 && dataMessage.hasProfileKey) {
             // If we observe a linked device sending our profile key to another
             // user, we can infer that that user belongs in our profile whitelist.
-            [self.profileManager addUserToProfileWhitelist:destination];
-
-            // TODO: Can we also infer when groups are added to the whitelist
-            //       from sent messages to groups?
+            if (dataMessage.hasGroup) {
+                [self.profileManager addGroupIdToProfileWhitelist:dataMessage.group.id];
+            } else {
+                [self.profileManager addUserToProfileWhitelist:destination];
+            }
         }
 
         if ([self isDataMessageGroupAvatarUpdate:syncMessage.sent.message]) {

--- a/SignalServiceKit/src/Protocols/ProfileManagerProtocol.h
+++ b/SignalServiceKit/src/Protocols/ProfileManagerProtocol.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isThreadInProfileWhitelist:(TSThread *)thread;
 
 - (void)addUserToProfileWhitelist:(NSString *)recipientId;
+- (void)addGroupIdToProfileWhitelist:(NSData *)groupId;
 
 @end
 


### PR DESCRIPTION
Since clients only include the `profileKey` for synced group messages when that group is whitelisted, it's presence is sufficient to deduce the group is whitelisted.

PTAL @charlesmchen 