### PR TITLE
fix production crash on addObject, presumably it's nil.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -3876,20 +3876,30 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
 
     TSThread *thread = self.thread;
     uint64_t lastVisibleTimestamp = self.lastVisibleTimestamp;
+
     [self.editingDatabaseConnection asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
         NSMutableArray<id<OWSReadTracking>> *interactions = [NSMutableArray new];
+        
         [[TSDatabaseView unseenDatabaseViewExtension:transaction]
             enumerateRowsInGroup:thread.uniqueId
                       usingBlock:^(
                           NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop) {
 
-                          TSInteraction *interaction = object;
-                          if (interaction.timestampForSorting > lastVisibleTimestamp) {
+                          if (![object conformsToProtocol:@protocol(OWSReadTracking)]) {
+                              OWSFail(@"Expected to conform to OWSReadTracking: object with class: %@ collection: %@ "
+                                      @"key: %@",
+                                  [object class],
+                                  collection,
+                                  key);
+                              return;
+                          }
+                          id<OWSReadTracking> possiblyRead = (id<OWSReadTracking>)object;
+
+                          if (possiblyRead.timestampForSorting > lastVisibleTimestamp) {
                               *stop = YES;
                               return;
                           }
 
-                          id<OWSReadTracking> possiblyRead = (id<OWSReadTracking>)object;
                           OWSAssert(!possiblyRead.read);
                           if (!possiblyRead.read) {
                               [interactions addObject:possiblyRead];

--- a/SignalServiceKit/src/Contacts/TSThread.m
+++ b/SignalServiceKit/src/Contacts/TSThread.m
@@ -221,7 +221,8 @@ NS_ASSUME_NONNULL_BEGIN
                       NSString *collection, NSString *key, id object, id metadata, NSUInteger index, BOOL *stop) {
 
                       if (![object conformsToProtocol:@protocol(OWSReadTracking)]) {
-                          DDLogError(@"%@ Unexpected object in unread messages: %@", self.tag, object);
+                          OWSFail(@"%@ Unexpected object in unread messages: %@", self.tag, object);
+                          return;
                       }
                       [messages addObject:(id<OWSReadTracking>)object];
                   }];

--- a/SignalServiceKit/src/Messages/OWSReadTracking.h
+++ b/SignalServiceKit/src/Messages/OWSReadTracking.h
@@ -15,6 +15,7 @@
  */
 @property (nonatomic, readonly, getter=wasRead) BOOL read;
 
+@property (nonatomic, readonly) uint64_t timestampForSorting;
 @property (nonatomic, readonly) NSString *uniqueThreadId;
 
 - (BOOL)shouldAffectUnreadCounts;


### PR DESCRIPTION
The root cause of this crash is still unclear, but this will prevent the proximate cause, and give us additional diagnostic data in the cases where it was happening. 

IMO, as a rule we should not be writing code which blindly casts.

PTAL @charlesmchen 
