### PR TITLE
Use existing isViewLoaded var

### DIFF
--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -25,7 +25,6 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
 
     // MARK: Views
 
-    var isViewLoaded = false
     var hasConstraints = false
     var blurView: UIVisualEffectView!
     var dateFormatter: DateFormatter?
@@ -181,10 +180,13 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         updateCallUI(callState: call.state)
     }
 
+    override func loadView() {
+        self.view = UIView()
+        createViews()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        createViews()
 
         contactNameLabel.text = contactsManager.displayName(forPhoneIdentifier: thread.contactIdentifier())
         updateAvatarImage()
@@ -198,7 +200,6 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         call.addObserverAndSyncState(observer: self)
 
         Environment.getCurrent().callService.addObserverAndSyncState(observer: self)
-        self.isViewLoaded = true
     }
 
     // MARK: - Create Views


### PR DESCRIPTION
Using the existing `isViewLoaded` defined in UIKit will actually already do what we need without having to define a new var.

I could have made a new var with a name distinct from `isViewLoaded`, but this approach seems slightly more inline with UIKit - i.e. `loadView` is where the views are created.

PTAL @charlesmchen 