### PR TITLE
Add group members individual to profile whitelist when adding group.

### DIFF
--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -868,6 +868,13 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
         TSGroupThread *groupThread = (TSGroupThread *)thread;
         NSData *groupId = groupThread.groupModel.groupId;
         [self addGroupIdToProfileWhitelist:groupId];
+
+        // When we add a group to the profile whitelist,
+        // also add all current members to the profile
+        // whitelist individually as well.
+        for (NSString *recipientId in groupThread.recipientIdentifiers) {
+            [self addUserToProfileWhitelist:recipientId];
+        }
     } else {
         NSString *recipientId = thread.contactIdentifier;
         [self addUserToProfileWhitelist:recipientId];

--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -869,9 +869,10 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
         NSData *groupId = groupThread.groupModel.groupId;
         [self addGroupIdToProfileWhitelist:groupId];
 
-        // When we add a group to the profile whitelist,
-        // also add all current members to the profile
-        // whitelist individually as well.
+        // When we add a group to the profile whitelist, we might as well
+        // also add all current members to the profile whitelist
+        // individually as well just in case delivery of the profile key
+        // fails.
         for (NSString *recipientId in groupThread.recipientIdentifiers) {
             [self addUserToProfileWhitelist:recipientId];
         }


### PR DESCRIPTION
This shouldn't matter in most cases, but it can only help profiles sync faster in case of delivery problems or unreliable networks.

PTAL @michaelkirk 