### PR TITLE
Fix sending images taken on iOS11 camera.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/MessagesViewController.m
@@ -3311,6 +3311,8 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     } else {
         // Non-Video image picked from library
 
+        // To avoid re-encoding GIF and PNG's as JPEG we have to get the raw data of
+        // the selected item vs. using the UIImagePickerControllerOriginalImage
         NSURL *assetURL = info[UIImagePickerControllerReferenceURL];
         PHAsset *asset = [[PHAsset fetchAssetsWithALAssetURLs:@[ assetURL ] options:nil] lastObject];
         if (!asset) {

--- a/Signal/src/ViewControllers/SignalAttachment.swift
+++ b/Signal/src/ViewControllers/SignalAttachment.swift
@@ -251,7 +251,12 @@ class SignalAttachment: NSObject {
     // Image attachments may be converted to another image format before 
     // being uploaded.
     private class var inputImageUTISet: Set<String> {
-        return MIMETypeUtil.supportedImageUTITypes().union(animatedImageUTISet)
+         // HEIC is valid input, but not valid output. Non-iOS11 clients do not support it.
+        let heicSet: Set<String> = Set(["public.heic"])
+
+        return MIMETypeUtil.supportedImageUTITypes()
+            .union(animatedImageUTISet)
+            .union(heicSet)
     }
 
     // Returns the set of UTIs that correspond to valid _output_ image formats
@@ -441,7 +446,7 @@ class SignalAttachment: NSObject {
         }
 
         guard imageData.count > 0 else {
-            assert(imageData.count > 0)
+            owsFail("\(self.TAG) in \(#function) imageData was empty")
             attachment.error = .invalidData
             return attachment
         }


### PR DESCRIPTION
fixes https://github.com/WhisperSystems/Signal-iOS/issues/2202

Convert .heic to .jpg upon sending

I punted on displaying HEIC natively in Signal, not so much for technical reasons, but moreso that I'm not sure what the right move is here. iOS seems to want to treat HEIC as an internal optimization that's invisible to the user.  e.g. sharing out an HEIC image from Photos converts it to JPG. 

So at this point, you'd have to be trying pretty hard to actually get an HEIC image into Signal. If you do - maybe you intend for it to *stay* an HEIC? But we couldn't do that if a user e.g. copy/pasted an HEIC image to another thread, since we can't assume the other client understand what HEIC's are. FWIW this is inline with what whatsapp does.

PTAL @charlesmchen 
