### PR TITLE
Charlesmchen/conversation back button hot area

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -170,7 +170,7 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     // We need to manually resize and position the title views;
     // iOS AutoLayout doesn't work inside navigation bar items.
     const int kTitleVSpacing = 0.f;
-    const int kTitleHMargin = 5.f;
+    const int kTitleHMargin = 0.f;
     CGFloat titleHeight = ceil([self.titleLabel sizeThatFits:CGSizeZero].height);
     CGFloat subtitleHeight = ceil([self.subtitleLabel sizeThatFits:CGSizeZero].height);
     CGFloat contentHeight = titleHeight + kTitleVSpacing + subtitleHeight;

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -1354,10 +1354,17 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     }
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
     CGFloat screenWidth = MIN(screenSize.width, screenSize.height);
-    // Request "full width" title; the navigation bar will truncate this
-    // to fit between the left and right buttons.
-    self.navigationBarTitleView.frame = CGRectMake(0, 0, screenWidth, 44);
-    self.navigationItem.titleView = self.navigationBarTitleView;
+    if (self.navigationItem.titleView != self.navigationBarTitleView) {
+        // Request "full width" title; the navigation bar will truncate this
+        // to fit between the left and right buttons.
+        self.navigationBarTitleView.frame = CGRectMake(0, 0, screenWidth, 44);
+        self.navigationItem.titleView = self.navigationBarTitleView;
+    } else {
+        // Don't reset the frame of the navigationBarTitleView every time
+        // this method is called or we'll gave bad frames where it will appear
+        // in the wrong position.
+        [self.navigationBarTitleView layoutSubviews];
+    }
 
     if (self.userLeftGroup) {
         self.navigationItem.rightBarButtonItems = @[];

--- a/Signal/src/util/UIViewController+OWS.m
+++ b/Signal/src/util/UIViewController+OWS.m
@@ -49,9 +49,12 @@ NS_ASSUME_NONNULL_BEGIN
     const CGFloat kTopInsetPadding = 1.5;
     backButton.imageEdgeInsets = UIEdgeInsetsMake(kTopInsetPadding, kExtraLeftPadding, 0, 0);
 
-    backButton.frame = CGRectMake(0, 0, backImage.size.width + kExtraRightPadding, backImage.size.height + kExtraHeightPadding);
+    CGRect buttonFrame
+        = CGRectMake(0, 0, backImage.size.width + kExtraRightPadding, backImage.size.height + kExtraHeightPadding);
+    backButton.frame = buttonFrame;
 
     UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithCustomView:backButton];
+    backItem.width = buttonFrame.size.width;
 
     return backItem;
 }


### PR DESCRIPTION
* Moves the conversation view's title header from being a "left bar button item" to the `titleView`.
* Increases the hot area for the back button which has been hard to hit.
* Takes full advantage of the navigation bar width, which ensures that the "tap for settings" interaction works anywhere in the title area.
* Future-proofs the app against changes in iOS since we're no longer "cutting against the grain" of how navigation bar contents are supposed to work.
* Simplifies this logic.
* Simplifies RTL.

### 1:1 Conversation with disappearing messages (Worst Case)

![screen shot 2017-09-07 at 10 46 45 am](https://user-images.githubusercontent.com/625803/30169477-7eb71a3c-93ba-11e7-8a00-f1cce6c237a9.png)

### 1:1 Conversation 

![screen shot 2017-09-07 at 10 46 38 am](https://user-images.githubusercontent.com/625803/30169476-7eb0df46-93ba-11e7-8271-6653923103be.png)

### Group Conversation with disappearing messages (Worst Case)

![screen shot 2017-09-07 at 10 44 50 am](https://user-images.githubusercontent.com/625803/30169475-7eb01886-93ba-11e7-9c21-71c30d2f4681.png)

### Group Conversation

![screen shot 2017-09-07 at 10 44 43 am](https://user-images.githubusercontent.com/625803/30169474-7eae6d1a-93ba-11e7-92d6-81d1a2bf1250.png)

PTAL @michaelkirk 
