### PR TITLE
Always present settings from OWSNavigationController

### DIFF
--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -20,6 +20,7 @@
 #import "OWSDatabaseMigration.h"
 #import "OWSLogger.h"
 #import "OWSMessageEditing.h"
+#import "OWSNavigationController.h"
 #import "OWSProfileManager.h"
 #import "OWSProgressView.h"
 #import "OWSViewController.h"

--- a/Signal/src/ViewControllers/AppSettingsViewController.h
+++ b/Signal/src/ViewControllers/AppSettingsViewController.h
@@ -4,6 +4,15 @@
 
 #import "OWSTableViewController.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSNavigationController;
+
 @interface AppSettingsViewController : OWSTableViewController
 
++ (OWSNavigationController *)inModalNavigationController;
+- (instancetype)init NS_UNAVAILABLE;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/src/ViewControllers/AppSettingsViewController.m
+++ b/Signal/src/ViewControllers/AppSettingsViewController.m
@@ -10,6 +10,7 @@
 #import "NotificationSettingsViewController.h"
 #import "OWSContactsManager.h"
 #import "OWSLinkedDevicesTableViewController.h"
+#import "OWSNavigationController.h"
 #import "PrivacySettingsTableViewController.h"
 #import "ProfileViewController.h"
 #import "PropertyListPreferences.h"
@@ -28,6 +29,18 @@
 #pragma mark -
 
 @implementation AppSettingsViewController
+
+/**
+ * We always present the settings controller modally, from within an OWSNavigationController
+ */
++ (OWSNavigationController *)inModalNavigationController
+{
+    AppSettingsViewController *viewController = [AppSettingsViewController new];
+    OWSNavigationController *navController =
+        [[OWSNavigationController alloc] initWithRootViewController:viewController];
+
+    return navController;
+}
 
 - (instancetype)init
 {
@@ -63,6 +76,8 @@
 {
     [super viewDidLoad];
     [self.navigationItem setHidesBackButton:YES];
+
+    OWSAssert([self.navigationController isKindOfClass:[OWSNavigationController class]]);
 
     [self.navigationController.navigationBar setTranslucent:NO];
     self.navigationItem.leftBarButtonItem =

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -905,7 +905,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
             assert(fromViewController != nil)
 
             // Construct the "settings" view & push the "privacy settings" view.
-            let navigationController = UINavigationController(rootViewController:AppSettingsViewController())
+            let navigationController = AppSettingsViewController.inModalNavigationController()
             navigationController.pushViewController(PrivacySettingsTableViewController(), animated:false)
 
             fromViewController?.present(navigationController, animated: true, completion: nil)

--- a/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
+++ b/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
@@ -126,7 +126,7 @@ private class CallKitExperienceUpgradeViewController: ExperienceUpgradeViewContr
             assert(fromViewController != nil)
 
             // Construct the "settings" view & push the "privacy settings" view.
-            let navigationController = UINavigationController(rootViewController:AppSettingsViewController())
+            let navigationController = AppSettingsViewController.inModalNavigationController()
             navigationController.pushViewController(PrivacySettingsTableViewController(), animated:false)
 
             fromViewController?.present(navigationController, animated: true, completion: nil)

--- a/Signal/src/ViewControllers/ShowGroupMembersViewController.m
+++ b/Signal/src/ViewControllers/ShowGroupMembersViewController.m
@@ -95,6 +95,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    OWSAssert([self.navigationController isKindOfClass:[OWSNavigationController class]]);
+
     // HACK otherwise CNContactViewController Navbar is shown as black.
     // RADAR rdar://28433898 http://www.openradar.me/28433898
     // CNContactViewController incompatible with opaque navigation bar

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -310,8 +310,7 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
 }
 
 - (void)settingsButtonPressed:(id)sender {
-    AppSettingsViewController *vc = [AppSettingsViewController new];
-    OWSNavigationController *navigationController = [[OWSNavigationController alloc] initWithRootViewController:vc];
+    OWSNavigationController *navigationController = [AppSettingsViewController inModalNavigationController];
     [self presentViewController:navigationController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
For 2.16

We were using UINavigationController in a couple of places.

PTAL @charlesmchen 