### PR TITLE
Fix one-time crash when opening thread without having a local profile

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -473,6 +473,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
                 // Clean up any messages that expired since last launch immediately
                 // and continue cleaning in the background.
                 [[OWSDisappearingMessagesJob sharedJob] startIfNecessary];
+                [[OWSProfileManager sharedManager] ensureLocalProfileCached];
 
                 // Mark all "attempting out" messages as "unsent", i.e. any messages that were not successfully
                 // sent before the app exited should be marked as failures.

--- a/Signal/src/Profiles/OWSProfileManager.h
+++ b/Signal/src/Profiles/OWSProfileManager.h
@@ -36,6 +36,7 @@ extern const NSUInteger kOWSProfileManager_MaxAvatarDiameter;
 - (BOOL)hasLocalProfile;
 - (nullable NSString *)localProfileName;
 - (nullable UIImage *)localProfileAvatarImage;
+- (void)ensureLocalProfileCached;
 
 // This method is used to update the "local profile" state on the client
 // and the service.  Client state is only updated if service state is

--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -270,6 +270,13 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
     }
 }
 
+- (void)ensureLocalProfileCached
+{
+    // Since localUserProfile can create a transaction, we want to make sure it's not called for the first
+    // time unexpectedly (e.g. in a nested transaction.)
+    __unused UserProfile *profile = [self localUserProfile];
+}
+
 #pragma mark - Local Profile
 
 - (UserProfile *)localUserProfile
@@ -652,7 +659,6 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
     });
 }
 
-// TODO: The exact API & encryption scheme for profiles is not yet settled.
 - (void)updateServiceWithProfileName:(nullable NSString *)localProfileName
                              success:(void (^)())successBlock
                              failure:(void (^)())failureBlock

--- a/Signal/src/ViewControllers/SignalsViewController.m
+++ b/Signal/src/ViewControllers/SignalsViewController.m
@@ -11,6 +11,7 @@
 #import "NSDate+millisecondTimeStamp.h"
 #import "OWSContactsManager.h"
 #import "OWSNavigationController.h"
+#import "OWSProfileManager.h"
 #import "ProfileViewController.h"
 #import "PropertyListPreferences.h"
 #import "PushManager.h"
@@ -491,6 +492,7 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
         // Start running the disappearing messages job in case the newly registered user
         // enables this feature
         [[OWSDisappearingMessagesJob sharedJob] startIfNecessary];
+        [[OWSProfileManager sharedManager] ensureLocalProfileCached];
     } else if (!self.viewHasEverAppeared) {
         [self displayAnyUnseenUpgradeExperience];
     }


### PR DESCRIPTION
I saw this crash locally, but am not able to reproduce it from a fresh install.

[symbolicated-incoming_call .txt](https://github.com/WhisperSystems/Signal-iOS/files/1285266/symbolicated-incoming_call.txt)

ProfileManager creates a transaction while saving the localProfile (which must not exist yet) during an existing transaction from `ensureDynamicInteractions`.

"Normally" we create the local profile when the profile view is displayed so this shouldn't an issue.
However, I think it's probably better to be explicit about this creation to catch whatever edge case exists.

PTAL @charlesmchen 