### PR TITLE
Normalize conversation presentation logic.

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -442,9 +442,9 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     viewController.attachment = attachment;
     UINavigationController *navigationController =
         [[UINavigationController alloc] initWithRootViewController:viewController];
-    [[[Environment getCurrent] signalsViewController] presentTopLevelModalViewController:navigationController
-                                                                        animateDismissal:NO
-                                                                     animatePresentation:YES];
+    [[[Environment getCurrent] homeViewController] presentTopLevelModalViewController:navigationController
+                                                                     animateDismissal:NO
+                                                                  animatePresentation:YES];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
@@ -529,7 +529,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
                     // If app has not re-entered active, show screen protection if necessary.
                     [self showScreenProtection];
                 }
-                [[[Environment getCurrent] signalsViewController] updateInboxCountLabel];
+                [[[Environment getCurrent] homeViewController] updateInboxCountLabel];
                 [application endBackgroundTask:bgTask];
             });
         }
@@ -542,7 +542,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler {
     if ([TSAccountManager isRegistered]) {
-        [[Environment getCurrent].signalsViewController showNewConversationView];
+        [[Environment getCurrent].homeViewController showNewConversationView];
         completionHandler(YES);
     } else {
         UIAlertController *controller =
@@ -555,12 +555,11 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
                                                      handler:^(UIAlertAction *_Nonnull action){
 
                                                      }]];
-        [[Environment getCurrent]
-                .signalsViewController.presentedViewController presentViewController:controller
-                                                                            animated:YES
-                                                                          completion:^{
-                                                                            completionHandler(NO);
-                                                                          }];
+        [[Environment getCurrent].homeViewController.presentedViewController presentViewController:controller
+                                                                                          animated:YES
+                                                                                        completion:^{
+                                                                                            completionHandler(NO);
+                                                                                        }];
     }
 }
 

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -555,11 +555,12 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
                                                      handler:^(UIAlertAction *_Nonnull action){
 
                                                      }]];
-        [[Environment getCurrent].homeViewController.presentedViewController presentViewController:controller
-                                                                                          animated:YES
-                                                                                        completion:^{
-                                                                                            completionHandler(NO);
-                                                                                        }];
+        UIViewController *fromViewController = [[UIApplication sharedApplication] frontmostViewController];
+        [fromViewController presentViewController:controller
+                                         animated:YES
+                                       completion:^{
+                                           completionHandler(NO);
+                                       }];
     }
 }
 

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -544,6 +544,9 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     keyboardOnViewAppearing:(BOOL)keyboardOnViewAppearing
         callOnViewAppearing:(BOOL)callOnViewAppearing
 {
+    // At most one.
+    OWSAssert(!keyboardOnViewAppearing || !callOnViewAppearing);
+
     if (callOnViewAppearing) {
         keyboardOnViewAppearing = NO;
     }

--- a/Signal/src/ViewControllers/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeViewController.m
@@ -743,6 +743,9 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
     keyboardOnViewAppearing:(BOOL)keyboardOnViewAppearing
         callOnViewAppearing:(BOOL)callOnViewAppearing
 {
+    // At most one.
+    OWSAssert(!keyboardOnViewAppearing || !callOnViewAppearing);
+
     if (thread == nil) {
         OWSFail(@"Thread unexpectedly nil");
         return;

--- a/Signal/src/ViewControllers/NewContactThreadViewController.m
+++ b/Signal/src/ViewControllers/NewContactThreadViewController.m
@@ -625,7 +625,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self dismissViewControllerAnimated:YES
                              completion:^() {
-                                 [Environment messageIdentifier:recipientId withCompose:YES];
+                                 [Environment presentConversationForRecipientId:recipientId withCompose:YES];
                              }];
 }
 

--- a/Signal/src/ViewControllers/NewGroupViewController.m
+++ b/Signal/src/ViewControllers/NewGroupViewController.m
@@ -459,7 +459,7 @@ const NSUInteger kNewGroupViewControllerAvatarWidth = 68;
             [self dismissViewControllerAnimated:YES
                                      completion:^{
                                          // Pop to new group thread.
-                                         [Environment messageGroup:thread];
+                                         [Environment presentConversationForThread:thread];
                                      }];
 
         });
@@ -478,7 +478,7 @@ const NSUInteger kNewGroupViewControllerAvatarWidth = 68;
                                                                   failedMessageType:TSErrorMessageGroupCreationFailed]
                                              save];
 
-                                         [Environment messageGroup:thread];
+                                         [Environment presentConversationForThread:thread];
                                      }];
         });
     };

--- a/Signal/src/ViewControllers/SendExternalFileViewController.m
+++ b/Signal/src/ViewControllers/SendExternalFileViewController.m
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
     [ThreadUtil addThreadToProfileWhitelistIfEmptyContactThread:thread];
     [ThreadUtil sendMessageWithAttachment:self.attachment inThread:thread messageSender:self.messageSender];
 
-    [Environment messageThreadId:thread.uniqueId];
+    [Environment presentConversationForRecipientId:thread.uniqueId];
 }
 
 - (BOOL)canSelectBlockedContact

--- a/Signal/src/ViewControllers/ShowGroupMembersViewController.m
+++ b/Signal/src/ViewControllers/ShowGroupMembersViewController.m
@@ -408,12 +408,12 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssert(recipientId.length > 0);
 
-    [Environment messageIdentifier:recipientId withCompose:YES];
+    [Environment presentConversationForRecipientId:recipientId withCompose:YES];
 }
 
 - (void)callMember:(NSString *)recipientId
 {
-    [Environment callUserWithIdentifier:recipientId];
+    [Environment callRecipientId:recipientId];
 }
 
 - (void)showSafetyNumberView:(NSString *)recipientId

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -37,7 +37,7 @@ extension CallUIAdaptee {
         let callViewController = CallViewController(call: call)
         callViewController.modalTransitionStyle = .crossDissolve
 
-        guard let presentingViewController = Environment.getCurrent().signalsViewController else {
+        guard let presentingViewController = Environment.getCurrent().homeViewController else {
             owsFail("in \(#function) view controller unexpectedly nil")
             return
         }

--- a/Signal/src/environment/Environment.h
+++ b/Signal/src/environment/Environment.h
@@ -49,7 +49,7 @@
 @property (nonatomic, readonly) PropertyListPreferences *preferences;
 
 
-@property (nonatomic, readonly) HomeViewController *signalsViewController;
+@property (nonatomic, readonly) HomeViewController *homeViewController;
 @property (nonatomic, readonly, weak) UINavigationController *signUpFlowNavigationController;
 
 + (Environment *)getCurrent;
@@ -59,12 +59,12 @@
 
 + (void)resetAppData;
 
-- (void)setHomeViewController:(HomeViewController *)signalsViewController;
+- (void)setHomeViewController:(HomeViewController *)homeViewController;
 - (void)setSignUpFlowNavigationController:(UINavigationController *)signUpFlowNavigationController;
 
-+ (void)messageThreadId:(NSString *)threadId;
-+ (void)messageIdentifier:(NSString *)identifier withCompose:(BOOL)compose;
-+ (void)callUserWithIdentifier:(NSString *)identifier;
-+ (void)messageGroup:(TSGroupThread *)groupThread;
++ (void)presentConversationForRecipientId:(NSString *)recipientId;
++ (void)presentConversationForRecipientId:(NSString *)recipientId withCompose:(BOOL)compose;
++ (void)callRecipientId:(NSString *)recipientId;
++ (void)presentConversationForThread:(TSGroupThread *)groupThread;
 
 @end

--- a/Signal/src/environment/Environment.m
+++ b/Signal/src/environment/Environment.m
@@ -200,15 +200,16 @@ static Environment *environment = nil;
                   keyboardOnViewAppearing:(BOOL)keyboardOnViewAppearing
                       callOnViewAppearing:(BOOL)callOnViewAppearing
 {
-    [[TSStorageManager sharedManager].dbReadWriteConnection
-        asyncReadWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
-            TSThread *thread = [TSContactThread getOrCreateThreadWithContactId:recipientId transaction:transaction];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [self presentConversationForThread:thread
-                           keyboardOnViewAppearing:keyboardOnViewAppearing
-                               callOnViewAppearing:callOnViewAppearing];
-            });
-        }];
+    DispatchMainThreadSafe(^{
+        __block TSThread *thread = nil;
+        [[TSStorageManager sharedManager].dbReadWriteConnection
+            readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
+                thread = [TSContactThread getOrCreateThreadWithContactId:recipientId transaction:transaction];
+            }];
+        [self presentConversationForThread:thread
+                   keyboardOnViewAppearing:keyboardOnViewAppearing
+                       callOnViewAppearing:callOnViewAppearing];
+    });
 }
 
 + (void)presentConversationForThread:(TSThread *)thread

--- a/Signal/src/environment/Environment.m
+++ b/Signal/src/environment/Environment.m
@@ -200,6 +200,9 @@ static Environment *environment = nil;
                   keyboardOnViewAppearing:(BOOL)keyboardOnViewAppearing
                       callOnViewAppearing:(BOOL)callOnViewAppearing
 {
+    // At most one.
+    OWSAssert(!keyboardOnViewAppearing || !callOnViewAppearing);
+
     DispatchMainThreadSafe(^{
         __block TSThread *thread = nil;
         [[TSStorageManager sharedManager].dbReadWriteConnection
@@ -221,6 +224,9 @@ static Environment *environment = nil;
              keyboardOnViewAppearing:(BOOL)keyboardOnViewAppearing
                  callOnViewAppearing:(BOOL)callOnViewAppearing
 {
+    // At most one.
+    OWSAssert(!keyboardOnViewAppearing || !callOnViewAppearing);
+
     if (!thread) {
         OWSFail(@"%@ Can't present nil thread.", self.tag);
         return;

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -118,7 +118,7 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
 
     NSString *threadId = notification.userInfo[Signal_Thread_UserInfo_Key];
     if (threadId && [TSThread fetchObjectWithUniqueID:threadId]) {
-        [Environment messageThreadId:threadId];
+        [Environment presentConversationForRecipientId:threadId];
     }
 }
 
@@ -213,12 +213,12 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
         completionHandler();
     } else if ([identifier isEqualToString:PushManagerActionsShowThread]) {
         NSString *threadId = notification.userInfo[Signal_Thread_UserInfo_Key];
-        [Environment messageThreadId:threadId];
+        [Environment presentConversationForRecipientId:threadId];
         completionHandler();
     } else {
         OWSFail(@"%@ Unhandled action with identifier: %@", self.tag, identifier);
         NSString *threadId = notification.userInfo[Signal_Thread_UserInfo_Key];
-        [Environment messageThreadId:threadId];
+        [Environment presentConversationForRecipientId:threadId];
         completionHandler();
     }
 }
@@ -234,7 +234,7 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
             [thread markAllAsReadWithTransaction:transaction];
         }
         completionBlock:^{
-            [[[Environment getCurrent] signalsViewController] updateInboxCountLabel];
+            [[[Environment getCurrent] homeViewController] updateInboxCountLabel];
             [self cancelNotificationsWithThreadId:threadId];
 
             completionHandler();


### PR DESCRIPTION
Goal: ensure we never navigate to a conversation that we're already in.

Along the way I cleaned up the code significantly.

Bug Repro:
* On phone A, Navigate to group B, lock phone.
* Send message to group B from member.
* On phone A, swipe on notification to open Signal.

Expected: App is already in conversation view for group B.
Observed: App leaves and re-enters group B.

PTAL @michaelkirk 

