### PR TITLE
Charlesmchen/batch message processing

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -29,6 +29,7 @@
 #import <SignalServiceKit/OWSFailedAttachmentDownloadsJob.h>
 #import <SignalServiceKit/OWSFailedMessagesJob.h>
 #import <SignalServiceKit/OWSIncomingMessageReadObserver.h>
+#import <SignalServiceKit/OWSMessageDecrypter.h>
 #import <SignalServiceKit/OWSMessageSender.h>
 #import <SignalServiceKit/TSAccountManager.h>
 #import <SignalServiceKit/TSDatabaseView.h>
@@ -816,6 +817,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     // If there were any messages in our local queue which we hadn't yet processed.
     [[OWSMessageReceiver sharedInstance] handleAnyUnprocessedEnvelopesAsync];
+    //    [[OWSMessageDecrypter sharedInstance] handleAnyUnprocessedEnvelopesAsync];
 
     [OWSProfileManager.sharedManager fetchLocalUsersProfile];
 }

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -25,11 +25,11 @@
 #import "VersionMigrations.h"
 #import "ViewControllerUtils.h"
 #import <AxolotlKit/SessionCipher.h>
+#import <SignalServiceKit/OWSBatchMessageProcessor.h>
 #import <SignalServiceKit/OWSDisappearingMessagesJob.h>
 #import <SignalServiceKit/OWSFailedAttachmentDownloadsJob.h>
 #import <SignalServiceKit/OWSFailedMessagesJob.h>
 #import <SignalServiceKit/OWSIncomingMessageReadObserver.h>
-#import <SignalServiceKit/OWSMessageDecrypter.h>
 #import <SignalServiceKit/OWSMessageSender.h>
 #import <SignalServiceKit/TSAccountManager.h>
 #import <SignalServiceKit/TSDatabaseView.h>
@@ -817,7 +817,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     // If there were any messages in our local queue which we hadn't yet processed.
     [[OWSMessageReceiver sharedInstance] handleAnyUnprocessedEnvelopesAsync];
-    //    [[OWSMessageDecrypter sharedInstance] handleAnyUnprocessedEnvelopesAsync];
+    [[OWSBatchMessageProcessor sharedInstance] handleAnyUnprocessedEnvelopesAsync];
 
     [OWSProfileManager.sharedManager fetchLocalUsersProfile];
 }

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -2600,6 +2600,7 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
                         [[OWSAttachmentsProcessor alloc] initWithAttachmentPointer:attachmentPointer
                                                                     networkManager:self.networkManager];
                     [processor fetchAttachmentsForMessage:message
+                                           storageManager:self.storageManager
                         success:^(TSAttachmentStream *_Nonnull attachmentStream) {
                             DDLogInfo(
                                 @"%@ Successfully redownloaded attachment in thread: %@", self.tag, message.thread);

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -2598,7 +2598,8 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
                 handler:^(UIAlertAction *_Nonnull action) {
                     OWSAttachmentsProcessor *processor =
                         [[OWSAttachmentsProcessor alloc] initWithAttachmentPointer:attachmentPointer
-                                                                    networkManager:self.networkManager];
+                                                                    networkManager:self.networkManager
+                                                                    storageManager:self.storageManager];
                     [processor fetchAttachmentsForMessage:message
                                            storageManager:self.storageManager
                         success:^(TSAttachmentStream *_Nonnull attachmentStream) {

--- a/Signal/src/ViewControllers/OWSNavigationController.m
+++ b/Signal/src/ViewControllers/OWSNavigationController.m
@@ -51,8 +51,9 @@
     // If we're not going to cancel the pop/back, we need to call the super
     // implementation since it has important side effects.
     if (result) {
+        // NOTE: result might end up NO if the super implementation cancels the
+        //       the pop/back.
         result = [super navigationBar:navigationBar shouldPopItem:item];
-        OWSAssert(result);
     }
     return result;
 }

--- a/SignalServiceKit/src/Contacts/Threads/TSGroupThread.h
+++ b/SignalServiceKit/src/Contacts/Threads/TSGroupThread.h
@@ -8,6 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class TSAttachmentStream;
+@class YapDatabaseReadWriteTransaction;
 
 @interface TSGroupThread : TSThread
 
@@ -18,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
                                     transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 + (instancetype)getOrCreateThreadWithGroupIdData:(NSData *)groupId;
++ (instancetype)getOrCreateThreadWithGroupIdData:(NSData *)groupId
+                                     transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 + (instancetype)threadWithGroupModel:(TSGroupModel *)groupModel transaction:(YapDatabaseReadTransaction *)transaction;
 
@@ -27,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<TSGroupThread *> *)groupThreadsWithRecipientId:(NSString *)recipientId;
 
 - (void)updateAvatarWithAttachmentStream:(TSAttachmentStream *)attachmentStream;
+- (void)updateAvatarWithAttachmentStream:(TSAttachmentStream *)attachmentStream
+                             transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/SignalServiceKit/src/Devices/OWSReadReceiptsProcessor.h
+++ b/SignalServiceKit/src/Devices/OWSReadReceiptsProcessor.h
@@ -1,4 +1,6 @@
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -6,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class OWSReadReceipt;
 @class TSIncomingMessage;
 @class TSStorageManager;
+@class YapDatabaseReadWriteTransaction;
 
 extern NSString *const OWSReadReceiptsProcessorMarkedMessageAsReadNotification;
 
@@ -30,6 +33,7 @@ extern NSString *const OWSReadReceiptsProcessorMarkedMessageAsReadNotification;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (void)process;
+- (void)processWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/SignalServiceKit/src/Devices/OWSReadReceiptsProcessor.m
+++ b/SignalServiceKit/src/Devices/OWSReadReceiptsProcessor.m
@@ -59,8 +59,8 @@ NSString *const OWSReadReceiptsProcessorMarkedMessageAsReadNotification =
 
 - (instancetype)initWithIncomingMessage:(TSIncomingMessage *)message storageManager:(TSStorageManager *)storageManager
 {
-    // Only groupthread sets authorId, thus this crappy code.
-    // TODO ALL incoming messages should have an authorId.
+    // authorId isn't set on all legacy messages, so we take
+    // extra measures to ensure we obtain a valid value.
     NSString *messageAuthorId;
     if (message.authorId) { // Group Thread
         messageAuthorId = message.authorId;

--- a/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.h
+++ b/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.h
@@ -1,5 +1,6 @@
-//  Created by Michael Kirk on 9/23/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -7,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class OWSMessageSender;
 @class TSNetworkManager;
 @class TSAttachmentStream;
+@class YapDatabaseReadWriteTransaction;
 
 @interface OWSRecordTranscriptJob : NSObject
 
@@ -15,7 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
                                         messageSender:(OWSMessageSender *)messageSender
                                        networkManager:(TSNetworkManager *)networkManager NS_DESIGNATED_INITIALIZER;
 
-- (void)runWithAttachmentHandler:(void (^)(TSAttachmentStream *attachmentStream))attachmentHandler;
+- (void)runWithAttachmentHandler:(void (^)(TSAttachmentStream *attachmentStream))attachmentHandler
+                     transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
+++ b/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
@@ -41,16 +41,22 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)runWithAttachmentHandler:(void (^)(TSAttachmentStream *attachmentStream))attachmentHandler
+                     transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
+    OWSAssert(transaction);
+
     OWSIncomingSentMessageTranscript *transcript = self.incomingSentMessageTranscript;
     DDLogDebug(@"%@ Recording transcript: %@", self.tag, transcript);
 
     if (transcript.isEndSessionMessage) {
         DDLogInfo(@"%@ EndSession was sent to recipient: %@.", self.tag, transcript.recipientId);
-        [self.storageManager deleteAllSessionsForContact:transcript.recipientId];
+        // NOTE: We dispatch_sync() here.
+        dispatch_sync([OWSDispatch sessionStoreQueue], ^{
+            [self.storageManager deleteAllSessionsForContact:transcript.recipientId];
+        });
         [[[TSInfoMessage alloc] initWithTimestamp:transcript.timestamp
                                          inThread:transcript.thread
-                                      messageType:TSInfoMessageTypeSessionDidEnd] save];
+                                      messageType:TSInfoMessageTypeSessionDidEnd] saveWithTransaction:transaction];
 
         // Don't continue processing lest we print a bubble for the session reset.
         return;
@@ -62,7 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                         timestamp:transcript.timestamp
                                                             relay:transcript.relay
                                                            thread:thread
-                                                   networkManager:self.networkManager];
+                                                   networkManager:self.networkManager
+                                                      transaction:transaction];
 
     // TODO group updates. Currently desktop doesn't support group updates, so not a problem yet.
     TSOutgoingMessage *outgoingMessage =
@@ -79,10 +86,13 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    [self.messageSender handleMessageSentRemotely:outgoingMessage sentAt:transcript.expirationStartedAt];
+    [self.messageSender handleMessageSentRemotely:outgoingMessage
+                                           sentAt:transcript.expirationStartedAt
+                                      transaction:transaction];
 
     [attachmentsProcessor
         fetchAttachmentsForMessage:outgoingMessage
+                       transaction:transaction
                            success:attachmentHandler
                            failure:^(NSError *_Nonnull error) {
                                DDLogError(@"%@ failed to fetch transcripts attachments for message: %@",
@@ -101,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                      expiresInSeconds:transcript.expirationDuration
                                                                       expireStartedAt:transcript.expirationStartedAt];
         // Since textMessage is a new message, updateWithWasSentAndDelivered will save it.
-        [textMessage updateWithWasSentAndDelivered];
+        [textMessage updateWithWasSentFromLinkedDeviceWithTransaction:transaction];
     }
 }
 

--- a/SignalServiceKit/src/Devices/OWSSendReadReceiptsJob.m
+++ b/SignalServiceKit/src/Devices/OWSSendReadReceiptsJob.m
@@ -1,5 +1,6 @@
-//  Created by Michael Kirk on 9/24/16.
-//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
 
 #import "OWSSendReadReceiptsJob.h"
 #import "OWSMessageSender.h"
@@ -41,8 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)runWith:(TSIncomingMessage *)message
 {
-    // Only groupthread sets authorId, thus this crappy code.
-    // TODO Refactor so that ALL incoming messages have an authorId.
+    // authorId isn't set on all legacy messages, so we take
+    // extra measures to ensure we obtain a valid value.
     NSString *messageAuthorId;
     if (message.authorId) { // Group Thread
         messageAuthorId = message.authorId;

--- a/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.h
+++ b/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.h
@@ -34,13 +34,15 @@ extern NSString *const kAttachmentDownloadAttachmentIDKey;
                                    relay:(nullable NSString *)relay
                                   thread:(TSThread *)thread
                           networkManager:(TSNetworkManager *)networkManager
+                          storageManager:(TSStorageManager *)storageManager
                              transaction:(YapDatabaseReadWriteTransaction *)transaction NS_DESIGNATED_INITIALIZER;
 
 /*
  * Retry fetching failed attachment download
  */
 - (instancetype)initWithAttachmentPointer:(TSAttachmentPointer *)attachmentPointer
-                           networkManager:(TSNetworkManager *)networkManager NS_DESIGNATED_INITIALIZER;
+                           networkManager:(TSNetworkManager *)networkManager
+                           storageManager:(TSStorageManager *)storageManager NS_DESIGNATED_INITIALIZER;
 
 - (void)fetchAttachmentsForMessage:(nullable TSMessage *)message
                     storageManager:(TSStorageManager *)storageManager

--- a/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.h
+++ b/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.h
@@ -8,12 +8,14 @@ extern NSString *const kAttachmentDownloadProgressNotification;
 extern NSString *const kAttachmentDownloadProgressKey;
 extern NSString *const kAttachmentDownloadAttachmentIDKey;
 
-@class TSMessage;
-@class TSThread;
-@class TSNetworkManager;
-@class OWSSignalServiceProtosAttachmentPointer;
-@class TSAttachmentStream;
 @class TSAttachmentPointer;
+@class TSAttachmentStream;
+@class TSMessage;
+@class TSNetworkManager;
+@class TSStorageManager;
+@class TSThread;
+@class OWSSignalServiceProtosAttachmentPointer;
+@class YapDatabaseReadWriteTransaction;
 
 /**
  * Given incoming attachment protos, determines which we support.
@@ -31,7 +33,8 @@ extern NSString *const kAttachmentDownloadAttachmentIDKey;
                                timestamp:(uint64_t)timestamp
                                    relay:(nullable NSString *)relay
                                   thread:(TSThread *)thread
-                          networkManager:(TSNetworkManager *)networkManager NS_DESIGNATED_INITIALIZER;
+                          networkManager:(TSNetworkManager *)networkManager
+                             transaction:(YapDatabaseReadWriteTransaction *)transaction NS_DESIGNATED_INITIALIZER;
 
 /*
  * Retry fetching failed attachment download
@@ -40,6 +43,11 @@ extern NSString *const kAttachmentDownloadAttachmentIDKey;
                            networkManager:(TSNetworkManager *)networkManager NS_DESIGNATED_INITIALIZER;
 
 - (void)fetchAttachmentsForMessage:(nullable TSMessage *)message
+                    storageManager:(TSStorageManager *)storageManager
+                           success:(void (^)(TSAttachmentStream *attachmentStream))successHandler
+                           failure:(void (^)(NSError *error))failureHandler;
+- (void)fetchAttachmentsForMessage:(nullable TSMessage *)message
+                       transaction:(YapDatabaseReadWriteTransaction *)transaction
                            success:(void (^)(TSAttachmentStream *attachmentStream))successHandler
                            failure:(void (^)(NSError *error))failureHandler;
 @end

--- a/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.m
+++ b/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.m
@@ -32,6 +32,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
 @interface OWSAttachmentsProcessor ()
 
 @property (nonatomic, readonly) TSNetworkManager *networkManager;
+@property (nonatomic, readonly) TSStorageManager *storageManager;
 @property (nonatomic, readonly) NSArray<TSAttachmentPointer *> *supportedAttachmentPointers;
 
 @end
@@ -40,6 +41,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
 
 - (instancetype)initWithAttachmentPointer:(TSAttachmentPointer *)attachmentPointer
                            networkManager:(TSNetworkManager *)networkManager
+                           storageManager:(TSStorageManager *)storageManager
 {
     self = [super init];
     if (!self) {
@@ -47,6 +49,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
     }
 
     _networkManager = networkManager;
+    _storageManager = storageManager;
 
     _supportedAttachmentPointers = @[ attachmentPointer ];
     _supportedAttachmentIds = @[ attachmentPointer.uniqueId ];
@@ -59,6 +62,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
                                    relay:(nullable NSString *)relay
                                   thread:(TSThread *)thread
                           networkManager:(TSNetworkManager *)networkManager
+                          storageManager:(TSStorageManager *)storageManager
                              transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
     self = [super init];
@@ -67,6 +71,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
     }
 
     _networkManager = networkManager;
+    _storageManager = storageManager;
 
     NSMutableArray<NSString *> *attachmentIds = [NSMutableArray new];
     NSMutableArray<TSAttachmentPointer *> *supportedAttachmentPointers = [NSMutableArray new];

--- a/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.m
+++ b/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.m
@@ -15,6 +15,7 @@
 #import "TSInfoMessage.h"
 #import "TSMessage.h"
 #import "TSNetworkManager.h"
+#import "TSStorageManager.h"
 #import "TSThread.h"
 #import <YapDatabase/YapDatabaseConnection.h>
 
@@ -58,6 +59,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
                                    relay:(nullable NSString *)relay
                                   thread:(TSThread *)thread
                           networkManager:(TSNetworkManager *)networkManager
+                             transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
     self = [super init];
     if (!self) {
@@ -97,7 +99,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
 
         [attachmentIds addObject:pointer.uniqueId];
 
-        [pointer save];
+        [pointer saveWithTransaction:transaction];
         [supportedAttachmentPointers addObject:pointer];
         [supportedAttachmentIds addObject:pointer.uniqueId];
     }
@@ -110,31 +112,60 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
 }
 
 - (void)fetchAttachmentsForMessage:(nullable TSMessage *)message
+                    storageManager:(TSStorageManager *)storageManager
                            success:(void (^)(TSAttachmentStream *attachmentStream))successHandler
                            failure:(void (^)(NSError *error))failureHandler
 {
+    [[storageManager newDatabaseConnection] readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [self fetchAttachmentsForMessage:message
+                             transaction:transaction
+                                 success:successHandler
+                                 failure:failureHandler];
+    }];
+}
+
+- (void)fetchAttachmentsForMessage:(nullable TSMessage *)message
+                       transaction:(YapDatabaseReadWriteTransaction *)transaction
+                           success:(void (^)(TSAttachmentStream *attachmentStream))successHandler
+                           failure:(void (^)(NSError *error))failureHandler
+{
+    OWSAssert(transaction);
+
     for (TSAttachmentPointer *attachmentPointer in self.supportedAttachmentPointers) {
-        [self retrieveAttachment:attachmentPointer message:message success:successHandler failure:failureHandler];
+        [self retrieveAttachment:attachmentPointer
+                         message:message
+                     transaction:transaction
+                         success:successHandler
+                         failure:failureHandler];
     }
 }
 
 - (void)retrieveAttachment:(TSAttachmentPointer *)attachment
                    message:(nullable TSMessage *)message
+               transaction:(YapDatabaseReadWriteTransaction *)transaction
                    success:(void (^)(TSAttachmentStream *attachmentStream))successHandler
                    failure:(void (^)(NSError *error))failureHandler
 {
-    [self setAttachment:attachment isDownloadingInMessage:message];
+    OWSAssert(transaction);
+
+    [self setAttachment:attachment isDownloadingInMessage:message transaction:transaction];
 
     void (^markAndHandleFailure)(NSError *) = ^(NSError *error) {
-        [self setAttachment:attachment didFailInMessage:message];
-        return failureHandler(error);
+        // Ensure enclosing transaction is complete.
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [self setAttachment:attachment didFailInMessage:message];
+            failureHandler(error);
+        });
     };
 
     void (^markAndHandleSuccess)(TSAttachmentStream *attachmentStream) = ^(TSAttachmentStream *attachmentStream) {
-        successHandler(attachmentStream);
-        if (message) {
-            [message touch];
-        }
+        // Ensure enclosing transaction is complete.
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            successHandler(attachmentStream);
+            if (message) {
+                [message touch];
+            }
+        });
     };
 
     if (attachment.serverId < 100) {
@@ -352,12 +383,16 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
     });
 }
 
-- (void)setAttachment:(TSAttachmentPointer *)pointer isDownloadingInMessage:(nullable TSMessage *)message
+- (void)setAttachment:(TSAttachmentPointer *)pointer
+    isDownloadingInMessage:(nullable TSMessage *)message
+               transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
+    OWSAssert(transaction);
+
     pointer.state = TSAttachmentPointerStateDownloading;
-    [pointer save];
+    [pointer saveWithTransaction:transaction];
     if (message) {
-        [message touch];
+        [message touchWithTransaction:transaction];
     }
 }
 

--- a/SignalServiceKit/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.h
+++ b/SignalServiceKit/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class OWSSignalServiceProtosDataMessage;
 @class OWSSignalServiceProtosAttachmentPointer;
 @class TSThread;
+@class YapDatabaseReadWriteTransaction;
 
 /**
  * Represents notification of a message sent on our behalf from another device.
@@ -23,13 +24,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) uint64_t timestamp;
 @property (nonatomic, readonly) uint64_t expirationStartedAt;
 @property (nonatomic, readonly) uint32_t expirationDuration;
-@property (nonatomic, readonly) TSThread *thread;
 @property (nonatomic, readonly) BOOL isGroupUpdate;
 @property (nonatomic, readonly) BOOL isExpirationTimerUpdate;
 @property (nonatomic, readonly) BOOL isEndSessionMessage;
 @property (nullable, nonatomic, readonly) NSData *groupId;
 @property (nonatomic, readonly) NSString *body;
 @property (nonatomic, readonly) NSArray<OWSSignalServiceProtosAttachmentPointer *> *attachmentPointerProtos;
+
+- (TSThread *)threadWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/SignalServiceKit/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.m
+++ b/SignalServiceKit/src/Messages/DeviceSyncing/OWSIncomingSentMessageTranscript.m
@@ -3,16 +3,14 @@
 //
 
 #import "OWSIncomingSentMessageTranscript.h"
-#import "OWSAttachmentsProcessor.h"
 #import "OWSSignalServiceProtos.pb.h"
-#import "TSMessagesManager.h"
-#import "TSOutgoingMessage.h"
-#import "TSThread.h"
-
-// Thread finding imports
 #import "TSContactThread.h"
 #import "TSGroupModel.h"
 #import "TSGroupThread.h"
+#import "TSMessagesManager.h"
+#import "TSOutgoingMessage.h"
+#import "TSStorageManager.h"
+#import "TSThread.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -49,12 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (TSThread *)thread
+- (TSThread *)threadWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
 {
     if (self.dataMessage.hasGroup) {
-        return [TSGroupThread getOrCreateThreadWithGroupIdData:self.dataMessage.group.id];
+        return [TSGroupThread getOrCreateThreadWithGroupIdData:self.dataMessage.group.id transaction:transaction];
     } else {
-        return [TSContactThread getOrCreateThreadWithContactId:self.recipientId];
+        return [TSContactThread getOrCreateThreadWithContactId:self.recipientId transaction:transaction];
     }
 }
 

--- a/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.h
@@ -101,7 +101,9 @@ extern NSString *const TSIncomingMessageWasReadOnThisDeviceNotification;
  *   When the message was created in milliseconds since epoch
  *
  */
-+ (nullable instancetype)findMessageWithAuthorId:(NSString *)authorId timestamp:(uint64_t)timestamp;
++ (nullable instancetype)findMessageWithAuthorId:(NSString *)authorId
+                                       timestamp:(uint64_t)timestamp
+                                     transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @property (nonatomic, readonly) NSString *authorId;
 

--- a/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.m
@@ -92,8 +92,8 @@ NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingM
                                  if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
                                      TSIncomingMessage *message = (TSIncomingMessage *)interaction;
 
-                                     // Only groupthread sets authorId, thus this crappy code.
-                                     // TODO ALL incoming messages should have an authorId.
+                                     // authorId isn't set on all legacy messages, so we take
+                                     // extra measures to ensure we obtain a valid value.
                                      NSString *messageAuthorId;
                                      if (message.authorId) { // Group Thread
                                          messageAuthorId = message.authorId;

--- a/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.m
@@ -75,37 +75,39 @@ NSString *const TSIncomingMessageWasReadOnThisDeviceNotification = @"TSIncomingM
     return self;
 }
 
-+ (nullable instancetype)findMessageWithAuthorId:(NSString *)authorId timestamp:(uint64_t)timestamp
++ (nullable instancetype)findMessageWithAuthorId:(NSString *)authorId
+                                       timestamp:(uint64_t)timestamp
+                                     transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
+    OWSAssert(transaction);
+
     __block TSIncomingMessage *foundMessage;
-    [self.dbReadWriteConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-        // In theory we could build a new secondaryIndex for (authorId,timestamp), but in practice there should
-        // be *very* few (millisecond) timestamps with multiple authors.
-        [TSDatabaseSecondaryIndexes
-            enumerateMessagesWithTimestamp:timestamp
-                                 withBlock:^(NSString *collection, NSString *key, BOOL *stop) {
-                                     TSInteraction *interaction =
-                                         [TSInteraction fetchObjectWithUniqueID:key transaction:transaction];
-                                     if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
-                                         TSIncomingMessage *message = (TSIncomingMessage *)interaction;
+    // In theory we could build a new secondaryIndex for (authorId,timestamp), but in practice there should
+    // be *very* few (millisecond) timestamps with multiple authors.
+    [TSDatabaseSecondaryIndexes
+        enumerateMessagesWithTimestamp:timestamp
+                             withBlock:^(NSString *collection, NSString *key, BOOL *stop) {
+                                 TSInteraction *interaction =
+                                     [TSInteraction fetchObjectWithUniqueID:key transaction:transaction];
+                                 if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
+                                     TSIncomingMessage *message = (TSIncomingMessage *)interaction;
 
-                                         // Only groupthread sets authorId, thus this crappy code.
-                                         // TODO ALL incoming messages should have an authorId.
-                                         NSString *messageAuthorId;
-                                         if (message.authorId) { // Group Thread
-                                             messageAuthorId = message.authorId;
-                                         } else { // Contact Thread
-                                             messageAuthorId =
-                                                 [TSContactThread contactIdFromThreadId:message.uniqueThreadId];
-                                         }
+                                     // Only groupthread sets authorId, thus this crappy code.
+                                     // TODO ALL incoming messages should have an authorId.
+                                     NSString *messageAuthorId;
+                                     if (message.authorId) { // Group Thread
+                                         messageAuthorId = message.authorId;
+                                     } else { // Contact Thread
+                                         messageAuthorId =
+                                             [TSContactThread contactIdFromThreadId:message.uniqueThreadId];
+                                     }
 
-                                         if ([messageAuthorId isEqualToString:authorId]) {
-                                             foundMessage = message;
-                                         }
+                                     if ([messageAuthorId isEqualToString:authorId]) {
+                                         foundMessage = message;
                                      }
                                  }
-                          usingTransaction:transaction];
-    }];
+                             }
+                      usingTransaction:transaction];
 
     return foundMessage;
 }

--- a/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.h
@@ -170,8 +170,7 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 - (void)updateWithCustomMessage:(NSString *)customMessage;
 - (void)updateWithWasDeliveredWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 - (void)updateWithWasDelivered;
-- (void)updateWithWasSentAndDelivered;
-- (void)updateWithWasSentAndDeliveredFromLinkedDevice;
+- (void)updateWithWasSentFromLinkedDeviceWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 - (void)updateWithSingleGroupRecipient:(NSString *)singleGroupRecipient
                            transaction:(YapDatabaseReadWriteTransaction *)transaction;
 

--- a/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
@@ -323,27 +323,16 @@ NSString *const kTSOutgoingMessageSentRecipientAll = @"kTSOutgoingMessageSentRec
     }];
 }
 
-- (void)updateWithWasSentAndDelivered
+- (void)updateWithWasSentFromLinkedDeviceWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
 {
-    [self.dbReadWriteConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-        [self applyChangeToSelfAndLatestOutgoingMessage:transaction
-                                            changeBlock:^(TSOutgoingMessage *message) {
-                                                [message setMessageState:TSOutgoingMessageStateSentToService];
-                                                [message setWasDelivered:YES];
-                                            }];
-    }];
-}
+    OWSAssert(transaction);
 
-- (void)updateWithWasSentAndDeliveredFromLinkedDevice
-{
-    [self.dbReadWriteConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
-        [self applyChangeToSelfAndLatestOutgoingMessage:transaction
-                                            changeBlock:^(TSOutgoingMessage *message) {
-                                                [message setMessageState:TSOutgoingMessageStateSentToService];
-                                                [message setWasDelivered:YES];
-                                                [message setIsFromLinkedDevice:YES];
-                                            }];
-    }];
+    [self applyChangeToSelfAndLatestOutgoingMessage:transaction
+                                        changeBlock:^(TSOutgoingMessage *message) {
+                                            [message setMessageState:TSOutgoingMessageStateSentToService];
+                                            [message setWasDelivered:YES];
+                                            [message setIsFromLinkedDevice:YES];
+                                        }];
 }
 
 - (void)updateWithSingleGroupRecipient:(NSString *)singleGroupRecipient

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.h
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.h
@@ -1,0 +1,20 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OWSSignalServiceProtosEnvelope;
+@class YapDatabase;
+
+@interface OWSBatchMessageProcessor : NSObject
+
++ (instancetype)sharedInstance;
++ (void)syncRegisterDatabaseExtension:(YapDatabase *)database;
+
+- (void)enqueueEnvelopeData:(NSData *)envelopeData plaintextData:(NSData *_Nullable)plaintextData;
+- (void)handleAnyUnprocessedEnvelopesAsync;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.h
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.h
@@ -7,6 +7,9 @@ NS_ASSUME_NONNULL_BEGIN
 @class OWSSignalServiceProtosEnvelope;
 @class YapDatabase;
 
+// This class is used to write incoming (decrypted, unprocessed)
+// messages to a durable queue and then process them in batches,
+// in the order in which they were received.
 @interface OWSBatchMessageProcessor : NSObject
 
 + (instancetype)sharedInstance;

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -299,7 +299,7 @@ NSString *const OWSBatchMessageProcessingJobFinderExtensionGroup = @"OWSBatchMes
 {
     AssertIsOnMainThread();
 
-    const NSUInteger kMaxBatchSize = 16;
+    const NSUInteger kMaxBatchSize = 10;
     NSArray<OWSBatchMessageProcessingJob *> *jobs = [self.finder nextJobsForBatchSize:kMaxBatchSize];
     OWSAssert(jobs);
     if (jobs.count < 1) {

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -299,8 +299,7 @@ NSString *const OWSBatchMessageProcessingJobFinderExtensionGroup = @"OWSBatchMes
 {
     AssertIsOnMainThread();
 
-    const NSUInteger kMaxBatchSize = 10;
-    NSArray<OWSBatchMessageProcessingJob *> *jobs = [self.finder nextJobsForBatchSize:kMaxBatchSize];
+    NSArray<OWSBatchMessageProcessingJob *> *jobs = [self.finder nextJobsForBatchSize:kIncomingMessageBatchSize];
     OWSAssert(jobs);
     if (jobs.count < 1) {
         self.isDrainingQueue = NO;

--- a/SignalServiceKit/src/Messages/OWSBlockingManager.h
+++ b/SignalServiceKit/src/Messages/OWSBlockingManager.h
@@ -23,6 +23,8 @@ extern NSString *const kNSNotificationName_BlockedPhoneNumbersDidChange;
 
 - (NSArray<NSString *> *)blockedPhoneNumbers;
 
+- (BOOL)isRecipientIdBlocked:(NSString *)recipientId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Messages/OWSBlockingManager.m
+++ b/SignalServiceKit/src/Messages/OWSBlockingManager.m
@@ -161,6 +161,11 @@ NSString *const kOWSBlockingManager_SyncedBlockedPhoneNumbersKey = @"kOWSBlockin
     }
 }
 
+- (BOOL)isRecipientIdBlocked:(NSString *)recipientId
+{
+    return [self.blockedPhoneNumbers containsObject:recipientId];
+}
+
 // This should be called every time the block list changes.
 
 - (void)handleUpdate

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.h
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.h
@@ -7,6 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class OWSSignalServiceProtosEnvelope;
 @class YapDatabase;
 
+// This class is used to write incoming (encrypted, unprocessed)
+// messages to a durable queue and then decrypt them in the order
+// in which they were received.  Successfully decrypted messages
+// are forwarded to OWSBatchMessageProcessor.
 @interface OWSMessageReceiver : NSObject
 
 + (instancetype)sharedInstance;

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -294,8 +294,7 @@ NSString *const OWSMessageProcessingJobFinderExtensionGroup = @"OWSMessageProces
 {
     AssertIsOnMainThread();
 
-    const NSUInteger kMaxBatchSize = 10;
-    NSArray<OWSMessageProcessingJob *> *jobs = [self.finder nextJobsForBatchSize:kMaxBatchSize];
+    NSArray<OWSMessageProcessingJob *> *jobs = [self.finder nextJobsForBatchSize:kIncomingMessageBatchSize];
     OWSAssert(jobs);
     if (jobs.count < 1) {
         self.isDrainingQueue = NO;

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -115,7 +115,6 @@ NSString *const OWSMessageProcessingJobFinderExtensionGroup = @"OWSMessageProces
                                        NSString *_Nonnull key,
                                        NSUInteger index,
                                        BOOL *_Nonnull stop) {
-                                       DDLogVerbose(@"key: %@", key);
                                        [jobIds addObject:key];
                                        if (jobIds.count >= maxBatchSize) {
                                            *stop = YES;
@@ -295,7 +294,7 @@ NSString *const OWSMessageProcessingJobFinderExtensionGroup = @"OWSMessageProces
 {
     AssertIsOnMainThread();
 
-    const NSUInteger kMaxBatchSize = 16;
+    const NSUInteger kMaxBatchSize = 10;
     NSArray<OWSMessageProcessingJob *> *jobs = [self.finder nextJobsForBatchSize:kMaxBatchSize];
     OWSAssert(jobs);
     if (jobs.count < 1) {

--- a/SignalServiceKit/src/Messages/OWSMessageSender.h
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class TSOutgoingMessage;
 @class TSStorageManager;
 @class TSThread;
+@class YapDatabaseReadWriteTransaction;
 
 @protocol ContactsManagerProtocol;
 
@@ -67,6 +68,10 @@ NS_SWIFT_NAME(MessageSender)
 - (void)sendMessage:(TSOutgoingMessage *)message
             success:(void (^)())successHandler
             failure:(void (^)(NSError *error))failureHandler;
+- (void)sendMessage:(TSOutgoingMessage *)message
+        transaction:(YapDatabaseReadWriteTransaction *_Nullable)transaction
+            success:(void (^)())successHandler
+            failure:(void (^)(NSError *error))failureHandler;
 
 /**
  * Takes care of allocating and uploading the attachment, then sends the message.
@@ -89,7 +94,9 @@ NS_SWIFT_NAME(MessageSender)
                             success:(void (^)())successHandler
                             failure:(void (^)(NSError *error))failureHandler;
 
-- (void)handleMessageSentRemotely:(TSOutgoingMessage *)message sentAt:(uint64_t)sentAt;
+- (void)handleMessageSentRemotely:(TSOutgoingMessage *)message
+                           sentAt:(uint64_t)sentAt
+                      transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 /**
  * Set local configuration to match that of the of `outgoingMessage`'s sender

--- a/SignalServiceKit/src/Messages/OWSMessageSender.h
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.h
@@ -65,6 +65,7 @@ NS_SWIFT_NAME(MessageSender)
  * Send and resend text messages or resend messages with existing attachments.
  * If you haven't yet created the attachment, see the `sendAttachmentData:` variants.
  */
+// TODO: make transaction nonnull and remove `sendMessage:success:failure`
 - (void)sendMessage:(TSOutgoingMessage *)message
             success:(void (^)())successHandler
             failure:(void (^)(NSError *error))failureHandler;

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -636,8 +636,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             // you might, for example, have a pending outgoing message when
             // you block them.
             OWSAssert(recipientContactId.length > 0);
-            NSArray<NSString *> *blockedPhoneNumbers = _blockingManager.blockedPhoneNumbers;
-            if ([blockedPhoneNumbers containsObject:recipientContactId]) {
+            if ([_blockingManager isRecipientIdBlocked:recipientContactId]) {
                 DDLogInfo(@"%@ skipping 1:1 send to blocked contact: %@", self.tag, recipientContactId);
                 NSError *error = OWSErrorMakeMessageSendFailedToBlockListError();
                 // No need to retry - the user will continue to be blocked.

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -1187,6 +1187,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
                     encryptionException = exception;
                 }
             });
+
             if (encryptionException) {
                 DDLogInfo(@"%@ Exception during encryption: %@", self.tag, encryptionException);
                 @throw encryptionException;

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -425,10 +425,21 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             success:(void (^)())successHandler
             failure:(void (^)(NSError *error))failureHandler
 {
-    OWSAssert(message);
-    AssertIsOnMainThread();
+    [self sendMessage:message transaction:nil success:successHandler failure:failureHandler];
+}
 
-    [message updateWithMessageState:TSOutgoingMessageStateAttemptingOut];
+- (void)sendMessage:(TSOutgoingMessage *)message
+        transaction:(YapDatabaseReadWriteTransaction *_Nullable)transaction
+            success:(void (^)())successHandler
+            failure:(void (^)(NSError *error))failureHandler
+{
+    OWSAssert(message);
+
+    if (transaction) {
+        [message updateWithMessageState:TSOutgoingMessageStateAttemptingOut transaction:transaction];
+    } else {
+        [message updateWithMessageState:TSOutgoingMessageStateAttemptingOut];
+    }
     OWSSendMessageOperation *sendMessageOperation = [[OWSSendMessageOperation alloc] initWithMessage:message
                                                                                        messageSender:self
                                                                                              success:successHandler
@@ -1082,9 +1093,14 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
     [OWSDisappearingMessagesJob setExpirationForMessage:message];
 }
 
-- (void)handleMessageSentRemotely:(TSOutgoingMessage *)message sentAt:(uint64_t)sentAt
+- (void)handleMessageSentRemotely:(TSOutgoingMessage *)message
+                           sentAt:(uint64_t)sentAt
+                      transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
-    [message updateWithWasSentAndDeliveredFromLinkedDevice];
+    OWSAssert(message);
+    OWSAssert(transaction);
+
+    [message updateWithWasSentFromLinkedDeviceWithTransaction:transaction];
     [self becomeConsistentWithDisappearingConfigurationForMessage:message];
     [OWSDisappearingMessagesJob setExpirationForMessage:message expirationStartedAt:sentAt];
 }

--- a/SignalServiceKit/src/Messages/TSMessagesManager.h
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ContactsManagerProtocol;
 @protocol OWSCallMessageHandler;
 
+typedef void (^DecryptSuccessBlock)(NSData *_Nullable plaintextData);
+typedef void (^DecryptFailureBlock)();
 typedef void (^MessageManagerCompletionBlock)();
 
 @interface TSMessagesManager : NSObject
@@ -28,8 +30,13 @@ typedef void (^MessageManagerCompletionBlock)();
 @property (nonatomic, readonly) TSNetworkManager *networkManager;
 @property (nonatomic, readonly) ContactsUpdater *contactsUpdater;
 
-- (void)processEnvelope:(OWSSignalServiceProtosEnvelope *)envelope
-             completion:(nullable MessageManagerCompletionBlock)completion;
+// decryptEnvelope: can be called from any thread.
+// successBlock & failureBlock may be called on any thread.
+- (void)decryptEnvelope:(OWSSignalServiceProtosEnvelope *)envelope
+           successBlock:(DecryptSuccessBlock)successBlock
+           failureBlock:(DecryptFailureBlock)failureBlock;
+
+- (void)processEnvelope:(OWSSignalServiceProtosEnvelope *)envelope plaintextData:(NSData *_Nullable)plaintextData;
 
 - (NSUInteger)unreadMessagesCount;
 - (NSUInteger)unreadMessagesCountExcept:(TSThread *)thread;

--- a/SignalServiceKit/src/Messages/TSMessagesManager.h
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.h
@@ -36,7 +36,9 @@ typedef void (^MessageManagerCompletionBlock)();
            successBlock:(DecryptSuccessBlock)successBlock
            failureBlock:(DecryptFailureBlock)failureBlock;
 
-- (void)processEnvelope:(OWSSignalServiceProtosEnvelope *)envelope plaintextData:(NSData *_Nullable)plaintextData;
+- (void)processEnvelope:(OWSSignalServiceProtosEnvelope *)envelope
+          plaintextData:(NSData *_Nullable)plaintextData
+            transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 - (NSUInteger)unreadMessagesCount;
 - (NSUInteger)unreadMessagesCountExcept:(TSThread *)thread;

--- a/SignalServiceKit/src/Messages/TSMessagesManager.h
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.h
@@ -34,10 +34,14 @@ typedef void (^MessageManagerCompletionBlock)();
 
 // decryptEnvelope: can be called from any thread.
 // successBlock & failureBlock may be called on any thread.
+//
+// Exactly one of successBlock & failureBlock will be called,
+// once.
 - (void)decryptEnvelope:(OWSSignalServiceProtosEnvelope *)envelope
            successBlock:(DecryptSuccessBlock)successBlock
            failureBlock:(DecryptFailureBlock)failureBlock;
 
+// processEnvelope: can be called from any thread.
 - (void)processEnvelope:(OWSSignalServiceProtosEnvelope *)envelope
           plaintextData:(NSData *_Nullable)plaintextData
             transaction:(YapDatabaseReadWriteTransaction *)transaction;

--- a/SignalServiceKit/src/Messages/TSMessagesManager.h
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.h
@@ -8,6 +8,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern const NSUInteger kIncomingMessageBatchSize;
+
 @class TSNetworkManager;
 @class TSStorageManager;
 @class OWSSignalServiceProtosEnvelope;

--- a/SignalServiceKit/src/Messages/TSMessagesManager.m
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.m
@@ -45,6 +45,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// We need to use a consistent batch size throughout
+// the incoming message pipeline (i.e. in the
+// "decrypt" and "process" steps), or the pipeline
+// doesn't flow smoothly.
+//
+// We want a value that is just high enough to yield
+// perf benefits.  The right value is probably 5-15.
+const NSUInteger kIncomingMessageBatchSize = 10;
+
 @interface TSMessagesManager ()
 
 @property (nonatomic, readonly) id<OWSCallMessageHandler> callMessageHandler;
@@ -1087,13 +1096,13 @@ NS_ASSUME_NONNULL_BEGIN
             }
             case OWSSignalServiceProtosGroupContextTypeDeliver: {
                 if (body.length == 0 && attachmentIds.count < 1) {
-                    DDLogWarn(@"%@ ignoring empty incoming message from: %@ for group: %@ with timestampe: %lu",
+                    DDLogWarn(@"%@ ignoring empty incoming message from: %@ for group: %@ with timestamp: %lu",
                         self.tag,
                         envelopeAddress(envelope),
                         groupId,
                         (unsigned long)timestamp);
                 } else {
-                    DDLogDebug(@"%@ incoming message from: %@ for group: %@ with timestampe: %lu",
+                    DDLogDebug(@"%@ incoming message from: %@ for group: %@ with timestamp: %lu",
                         self.tag,
                         envelopeAddress(envelope),
                         groupId,
@@ -1111,19 +1120,19 @@ NS_ASSUME_NONNULL_BEGIN
                 break;
             }
             default: {
-                DDLogWarn(@"%@ Ignoring unknown group message type:%d", self.tag, (int)dataMessage.group.type);
+                DDLogWarn(@"%@ Ignoring unknown group message type: %d", self.tag, (int)dataMessage.group.type);
             }
         }
 
         thread = gThread;
     } else {
         if (body.length == 0 && attachmentIds.count < 1) {
-            DDLogWarn(@"%@ ignoring empty incoming message from: %@ with timestampe: %lu",
+            DDLogWarn(@"%@ ignoring empty incoming message from: %@ with timestamp: %lu",
                 self.tag,
                 envelopeAddress(envelope),
                 (unsigned long)timestamp);
         } else {
-            DDLogDebug(@"%@ incoming message from: %@ with timestampe: %lu",
+            DDLogDebug(@"%@ incoming message from: %@ with timestamp: %lu",
                 self.tag,
                 envelopeAddress(envelope),
                 (unsigned long)timestamp);

--- a/SignalServiceKit/src/Messages/TSMessagesManager.m
+++ b/SignalServiceKit/src/Messages/TSMessagesManager.m
@@ -678,6 +678,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                             relay:envelope.relay
                                                            thread:groupThread
                                                    networkManager:self.networkManager
+                                                   storageManager:self.storageManager
                                                       transaction:transaction];
 
     if (!attachmentsProcessor.hasSupportedAttachments) {
@@ -713,6 +714,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                             relay:envelope.relay
                                                            thread:thread
                                                    networkManager:self.networkManager
+                                                   storageManager:self.storageManager
                                                       transaction:transaction];
     if (!attachmentsProcessor.hasSupportedAttachments) {
         DDLogWarn(@"%@ received unsupported media envelope", self.tag);

--- a/SignalServiceKit/src/Storage/OWSIncomingMessageFinder.h
+++ b/SignalServiceKit/src/Storage/OWSIncomingMessageFinder.h
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)existsMessageWithTimestamp:(uint64_t)timestamp
                           sourceId:(NSString *)sourceId
-                    sourceDeviceId:(uint32_t)sourceDeviceId;
+                    sourceDeviceId:(uint32_t)sourceDeviceId
+                       transaction:(YapDatabaseReadTransaction *)transaction;
 
 @end
 

--- a/SignalServiceKit/src/Storage/OWSIncomingMessageFinder.m
+++ b/SignalServiceKit/src/Storage/OWSIncomingMessageFinder.m
@@ -114,6 +114,7 @@ NSString *const OWSIncomingMessageFinderColumnSourceDeviceId = @"OWSIncomingMess
 - (BOOL)existsMessageWithTimestamp:(uint64_t)timestamp
                           sourceId:(NSString *)sourceId
                     sourceDeviceId:(uint32_t)sourceDeviceId
+                       transaction:(YapDatabaseReadTransaction *)transaction
 {
     if (![self.database registeredExtension:OWSIncomingMessageFinderExtensionName]) {
         OWSFail(@"%@ in %s but extension is not registered", self.tag, __PRETTY_FUNCTION__);
@@ -129,13 +130,8 @@ NSString *const OWSIncomingMessageFinderColumnSourceDeviceId = @"OWSIncomingMess
     // YapDatabaseQuery params must be objects
     YapDatabaseQuery *query = [YapDatabaseQuery queryWithFormat:queryFormat, @(timestamp), sourceId, @(sourceDeviceId)];
 
-    __block NSUInteger count;
-    __block BOOL success;
-
-    [self.dbConnection readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
-        success = [[transaction ext:OWSIncomingMessageFinderExtensionName] getNumberOfRows:&count matchingQuery:query];
-    }];
-
+    NSUInteger count;
+    BOOL success = [[transaction ext:OWSIncomingMessageFinderExtensionName] getNumberOfRows:&count matchingQuery:query];
     if (!success) {
         OWSFail(@"%@ Could not execute query", self.tag);
         return NO;

--- a/SignalServiceKit/src/Storage/TSStorageManager.m
+++ b/SignalServiceKit/src/Storage/TSStorageManager.m
@@ -18,6 +18,7 @@
 #import "TSThread.h"
 #import <25519/Randomness.h>
 #import <SAMKeychain/SAMKeychain.h>
+#import <SignalServiceKit/OWSMessageDecrypter.h>
 #import <SignalServiceKit/OWSMessageReceiver.h>
 #import <YapDatabase/YapDatabaseRelationship.h>
 
@@ -305,6 +306,7 @@ void setDatabaseInitialized()
     [TSDatabaseView registerUnreadDatabaseView];
     [self.database registerExtension:[TSDatabaseSecondaryIndexes registerTimeStampIndex] withName:@"idx"];
     [OWSMessageReceiver syncRegisterDatabaseExtension:self.database];
+    //    [OWSMessageDecrypter syncRegisterDatabaseExtension:self.database];
 
     // See comments on OWSDatabaseConnection.
     //

--- a/SignalServiceKit/src/Storage/TSStorageManager.m
+++ b/SignalServiceKit/src/Storage/TSStorageManager.m
@@ -18,7 +18,7 @@
 #import "TSThread.h"
 #import <25519/Randomness.h>
 #import <SAMKeychain/SAMKeychain.h>
-#import <SignalServiceKit/OWSMessageDecrypter.h>
+#import <SignalServiceKit/OWSBatchMessageProcessor.h>
 #import <SignalServiceKit/OWSMessageReceiver.h>
 #import <YapDatabase/YapDatabaseRelationship.h>
 
@@ -306,7 +306,7 @@ void setDatabaseInitialized()
     [TSDatabaseView registerUnreadDatabaseView];
     [self.database registerExtension:[TSDatabaseSecondaryIndexes registerTimeStampIndex] withName:@"idx"];
     [OWSMessageReceiver syncRegisterDatabaseExtension:self.database];
-    //    [OWSMessageDecrypter syncRegisterDatabaseExtension:self.database];
+    [OWSBatchMessageProcessor syncRegisterDatabaseExtension:self.database];
 
     // See comments on OWSDatabaseConnection.
     //

--- a/SignalServiceKit/src/Util/NSArray+OWS.h
+++ b/SignalServiceKit/src/Util/NSArray+OWS.h
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSArray (OWS)
+
+- (NSArray<NSString *> *)uniqueIds;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Util/NSArray+OWS.m
+++ b/SignalServiceKit/src/Util/NSArray+OWS.m
@@ -1,0 +1,25 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "NSArray+OWS.h"
+#import "TSYapDatabaseObject.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation NSArray (OWS)
+
+- (NSArray<NSString *> *)uniqueIds
+{
+    NSMutableArray<NSString *> *result = [NSMutableArray new];
+    for (id object in self) {
+        OWSAssert([object isKindOfClass:[TSYapDatabaseObject class]]);
+        TSYapDatabaseObject *dbObject = object;
+        [result addObject:dbObject.uniqueId];
+    }
+    return result;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Util/OWSAnalyticsEvents.h
+++ b/SignalServiceKit/src/Util/OWSAnalyticsEvents.h
@@ -126,8 +126,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)messageManagerErrorOversizeMessage;
 
-+ (NSString *)messageManagerErrorPrekeyBundleEnvelopeHasNoContent;
-
 + (NSString *)messageManagerErrorSyncMessageFromUnknownSource;
 
 + (NSString *)messageManagerErrorUntrustedIdentityKeyException;

--- a/SignalServiceKit/src/Util/OWSAnalyticsEvents.m
+++ b/SignalServiceKit/src/Util/OWSAnalyticsEvents.m
@@ -297,11 +297,6 @@ NS_ASSUME_NONNULL_BEGIN
     return @"message_manager_error_oversize_message";
 }
 
-+ (NSString *)messageManagerErrorPrekeyBundleEnvelopeHasNoContent
-{
-    return @"message_manager_error_prekey_bundle_envelope_has_no_content";
-}
-
 + (NSString *)messageManagerErrorSyncMessageFromUnknownSource
 {
     return @"message_manager_error_sync_message_from_unknown_source";


### PR DESCRIPTION
Batch decrypt and process of incoming messages.

* There's a significant perf win to processing messages in batches, not least because `YapDatabaseModifiedNotification` is only fired once per batch.
* There's a similar win even when only processing single messages by virtue of using a single transaction, because message processing involves a lot of database reads and writes... and we'll also only fire the "database modified" notification once per message.

PTAL @michaelkirk 
