### PR TITLE
Fix NPEs when profiles change while entering conversation view.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -376,8 +376,6 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     _networkManager = [TSNetworkManager sharedManager];
     _blockingManager = [OWSBlockingManager sharedManager];
     _contactsViewHelper = [[ContactsViewHelper alloc] initWithDelegate:self];
-
-    [self addNotificationListeners];
 }
 
 - (void)addNotificationListeners
@@ -650,6 +648,7 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     [self initializeToolbars];
     [self createScrollDownButton];
     [self createHeaderViews];
+    [self addNotificationListeners];
 }
 
 - (void)registerCustomMessageNibs


### PR DESCRIPTION
We don't want to register our notification listeners until the conversation view loads, otherwise profile change events in particular can fire before the view is loaded and NPEs are easy to hit.

// FREEBIE