### PR TITLE
Fix 1-time crash when launching 2.16 from notification

### DIFF
--- a/Signal/src/AppDelegate.h
+++ b/Signal/src/AppDelegate.h
@@ -10,5 +10,6 @@ extern NSString *const AppDelegateStoryboardMain;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
+@property (atomic) BOOL isEnvironmentSetup;
 
 @end

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -493,6 +493,11 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
                 // Clean up any messages that expired since last launch immediately
                 // and continue cleaning in the background.
                 [[OWSDisappearingMessagesJob sharedJob] startIfNecessary];
+
+                // TODO remove this once we're sure our app boot process is coherent.
+                // Currently this happens *before* db registration is complete when
+                // launching the app directly, but *after* db registration is complete when
+                // the app is launched in the background, e.g. from a voip notification.
                 [[OWSProfileManager sharedManager] ensureLocalProfileCached];
 
                 // Mark all "attempting out" messages as "unsent", i.e. any messages that were not successfully
@@ -752,6 +757,11 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 }
 
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification {
+    if (!self.isEnvironmentSetup) {
+        OWSFail(@"%@ ignoring %s because environment is not yet set up.", self.tag, __PRETTY_FUNCTION__);
+        return;
+    }
+
     [AppStoreRating preventPromptAtNextTest];
     [[PushManager sharedManager] application:application didReceiveLocalNotification:notification];
 }
@@ -759,7 +769,13 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 - (void)application:(UIApplication *)application
     handleActionWithIdentifier:(NSString *)identifier
           forLocalNotification:(UILocalNotification *)notification
-             completionHandler:(void (^)())completionHandler {
+             completionHandler:(void (^)())completionHandler
+{
+    if (!self.isEnvironmentSetup) {
+        OWSFail(@"%@ ignoring %s because environment is not yet set up.", self.tag, __PRETTY_FUNCTION__);
+        return;
+    }
+
     [[PushManager sharedManager] application:application
                   handleActionWithIdentifier:identifier
                         forLocalNotification:notification
@@ -770,7 +786,13 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     handleActionWithIdentifier:(NSString *)identifier
           forLocalNotification:(UILocalNotification *)notification
               withResponseInfo:(NSDictionary *)responseInfo
-             completionHandler:(void (^)())completionHandler {
+             completionHandler:(void (^)())completionHandler
+{
+    if (!self.isEnvironmentSetup) {
+        OWSFail(@"%@ ignoring %s because environment is not yet set up.", self.tag, __PRETTY_FUNCTION__);
+        return;
+    }
+
     [[PushManager sharedManager] application:application
                   handleActionWithIdentifier:identifier
                         forLocalNotification:notification
@@ -810,6 +832,10 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     // If there were any messages in our local queue which we hadn't yet processed.
     [[OWSMessageReceiver sharedInstance] handleAnyUnprocessedEnvelopesAsync];
+
+    [[OWSProfileManager sharedManager] ensureLocalProfileCached];
+
+    self.isEnvironmentSetup = YES;
 
     [OWSProfileManager.sharedManager fetchLocalUsersProfile];
 }


### PR DESCRIPTION
didBecomeActive is too late in the case of launching from a
notification.

Also, start tracking when app setup is complete, and prevent certain
actions from occurring in that case. Eventually we'll enqueue these
actions rather than ignoring them, but we'll want to do more testing
before releasing that. In the meanwhile, if the environment isn't setup
at this point, a crash would be eminent anyway.

PTAL @charlesmchen 