### PR TITLE
Don't attempt to sync profile until registered.

### DIFF
--- a/Signal/src/Profiles/OWSProfileManager.m
+++ b/Signal/src/Profiles/OWSProfileManager.m
@@ -252,10 +252,15 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         if (isLocalUserProfile) {
-            [MultiDeviceProfileKeyUpdateJob runWithProfileKey:userProfile.profileKey
-                                              identityManager:self.identityManager
-                                                messageSender:self.messageSender
-                                               profileManager:self];
+            // We populate an initial (empty) profile on launch of a new install, but until
+            // we have a registered account, syncing will fail (and there could not be any
+            // linked device to sync to at this point anyway).
+            if ([TSAccountManager isRegistered]) {
+                [MultiDeviceProfileKeyUpdateJob runWithProfileKey:userProfile.profileKey
+                                                  identityManager:self.identityManager
+                                                    messageSender:self.messageSender
+                                                   profileManager:self];
+            }
 
             [[NSNotificationCenter defaultCenter] postNotificationNameAsync:kNSNotificationName_LocalProfileDidChange
                                                                      object:nil


### PR DESCRIPTION
Otherwise there's an unnecessary initial (innocuous) failed HTTP attempt on first launch for unregistered users.

For those users we'll see a [log] line like this shortly after first launch: 
"[MultiDeviceProfileKeyUpdateJob] localNumber was unexpectedly nil"

But shouldn't be a problem.

[log] example log of installing 2.16.1.3:

https://gist.github.com/anonymous/c45decfc8524fb62d5384be6df41e066#file-org-whispersystems-signal-2017-09-21-15-14-log-L48

PTAL @charlesmchen 