### PR TITLE
Fix "unknown attachment" notifications

### DIFF
--- a/Signal/src/environment/NotificationsManager.m
+++ b/Signal/src/environment/NotificationsManager.m
@@ -251,10 +251,14 @@ NSString *const kNotificationsManagerNewMesssageSoundName = @"NewMessage.aifc";
 - (void)notifyUserForIncomingMessage:(TSIncomingMessage *)message
                             inThread:(TSThread *)thread
                      contactsManager:(id<ContactsManagerProtocol>)contactsManager
+                         transaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSAssert(message);
     OWSAssert(thread);
     OWSAssert(contactsManager);
+
+    // While batch processing, some of the necessary changes have not been commited.
+    NSString *messageDescription = [message previewTextWithTransaction:transaction];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         if (thread.isMuted) {
@@ -263,7 +267,6 @@ NSString *const kNotificationsManagerNewMesssageSoundName = @"NewMessage.aifc";
 
         BOOL shouldPlaySound = [self shouldPlaySoundForNotification];
 
-        NSString *messageDescription = message.description;
         NSString *senderName = [contactsManager displayNameForPhoneIdentifier:message.authorId];
         NSString *groupName = [thread.name stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         if (groupName.length < 1) {

--- a/SignalServiceKit/src/Messages/Interactions/TSMessage.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSMessage.h
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)hasAttachments;
+- (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction;
 
 @end
 

--- a/SignalServiceKit/src/Messages/Interactions/TSMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSMessage.m
@@ -199,6 +199,22 @@ static const NSUInteger OWSMessageSchemaVersion = 3;
     }
 }
 
+- (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction
+{
+    if ([self hasAttachments]) {
+        NSString *attachmentId = self.attachmentIds[0];
+        TSAttachment *attachment = [TSAttachment fetchObjectWithUniqueID:attachmentId transaction:transaction];
+        if (attachment) {
+            return attachment.description;
+        } else {
+            return NSLocalizedString(@"UNKNOWN_ATTACHMENT_LABEL", @"In Inbox view, last message label for thread with corrupted attachment.");
+        }
+    } else {
+        return self.body;
+    }
+}
+
+// TODO deprecate this and implement something like previewTextWithTransaction: for all TSInteractions
 - (NSString *)description
 {
     if ([self hasAttachments]) {

--- a/SignalServiceKit/src/Messages/OWSMessageManager.m
+++ b/SignalServiceKit/src/Messages/OWSMessageManager.m
@@ -948,7 +948,8 @@ NS_ASSUME_NONNULL_BEGIN
 
         [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForIncomingMessage:incomingMessage
                                                                                inThread:thread
-                                                                        contactsManager:self.contactsManager];
+                                                                        contactsManager:self.contactsManager
+                                                                            transaction:transaction];
     }
 
     return incomingMessage;

--- a/SignalServiceKit/src/Protocols/NotificationsProtocol.h
+++ b/SignalServiceKit/src/Protocols/NotificationsProtocol.h
@@ -5,13 +5,15 @@
 @class TSErrorMessage;
 @class TSIncomingMessage;
 @class TSThread;
+@class YapDatabaseReadTransaction;
 @protocol ContactsManagerProtocol;
 
 @protocol NotificationsProtocol <NSObject>
 
 - (void)notifyUserForIncomingMessage:(TSIncomingMessage *)incomingMessage
                             inThread:(TSThread *)thread
-                     contactsManager:(id<ContactsManagerProtocol>)contactsManager;
+                     contactsManager:(id<ContactsManagerProtocol>)contactsManager
+                         transaction:(YapDatabaseReadTransaction *)transaction;
 
 - (void)notifyUserForErrorMessage:(TSErrorMessage *)error inThread:(TSThread *)thread;
 


### PR DESCRIPTION
The transaction in which the attachments were created hasn't been
committed yet.

PTAL @charlesmchen 