### PR TITLE
background push notifications

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -271,13 +271,13 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    DDLogDebug(@"%@ registered vanilla push token: %@", self.tag, deviceToken);
+    DDLogInfo(@"%@ registered vanilla push token: %@", self.tag, deviceToken);
     [PushManager.sharedManager.pushNotificationFutureSource trySetResult:deviceToken];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-    DDLogDebug(@"%@ failed to register vanilla push token with error: %@", self.tag, error);
+    DDLogError(@"%@ failed to register vanilla push token with error: %@", self.tag, error);
 #ifdef DEBUG
     DDLogWarn(@"%@ We're in debug mode. Faking success for remote registration with a fake push identifier", self.tag);
     [PushManager.sharedManager.pushNotificationFutureSource trySetResult:[[NSMutableData dataWithLength:32] copy]];
@@ -290,7 +290,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 - (void)application:(UIApplication *)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
 {
-    DDLogDebug(@"%@ registered user notification settings", self.tag);
+    DDLogInfo(@"%@ registered user notification settings", self.tag);
     [PushManager.sharedManager.userNotificationFutureSource trySetResult:notificationSettings];
 }
 

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -818,6 +818,11 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     if ([TSAccountManager isRegistered]) {
         DDLogInfo(@"localNumber: %@", [TSAccountManager localNumber]);
 
+        // Fetch messages as soon as possible after launching. In particular, when
+        // launching from the background, without this, we end up waiting some extra
+        // seconds before receiving an actionable push notification.
+        [[Environment getCurrent].messageFetcherJob runAsync];
+
         // This should happen at any launch, background or foreground.
         __unused AnyPromise *promise = [OWSSyncPushTokensJob runWithPushManager:[PushManager sharedManager]
                                                                  accountManager:[Environment getCurrent].accountManager

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -271,23 +271,26 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    DDLogDebug(@"%@ Successfully registered for remote notifications with token: %@", self.tag, deviceToken);
+    DDLogDebug(@"%@ registered vanilla push token: %@", self.tag, deviceToken);
     [PushManager.sharedManager.pushNotificationFutureSource trySetResult:deviceToken];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-    OWSProdError([OWSAnalyticsEvents appDelegateErrorFailedToRegisterForRemoteNotifications]);
+    DDLogDebug(@"%@ failed to register vanilla push token with error: %@", self.tag, error);
 #ifdef DEBUG
     DDLogWarn(@"%@ We're in debug mode. Faking success for remote registration with a fake push identifier", self.tag);
     [PushManager.sharedManager.pushNotificationFutureSource trySetResult:[[NSMutableData dataWithLength:32] copy]];
 #else
+    OWSProdError([OWSAnalyticsEvents appDelegateErrorFailedToRegisterForRemoteNotifications]);
     [PushManager.sharedManager.pushNotificationFutureSource trySetFailure:error];
 #endif
 }
 
 - (void)application:(UIApplication *)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+    DDLogDebug(@"%@ registered user notification settings", self.tag);
     [PushManager.sharedManager.userNotificationFutureSource trySetResult:notificationSettings];
 }
 
@@ -480,13 +483,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
             // At this point, potentially lengthy DB locking migrations could be running.
             // Avoid blocking app launch by putting all further possible DB access in async block
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                DDLogInfo(
-                    @"%@ running post launch block for registered user: %@", self.tag, [TSAccountManager localNumber]);
-                __unused AnyPromise *promise =
-                    [OWSSyncPushTokensJob runWithPushManager:[PushManager sharedManager]
-                                              accountManager:[Environment getCurrent].accountManager
-                                                 preferences:[Environment preferences]];
-
+                DDLogInfo(@"%@ running post launch block for registered user: %@", self.tag, [TSAccountManager localNumber]);
+                
                 // Clean up any messages that expired since last launch immediately
                 // and continue cleaning in the background.
                 [[OWSDisappearingMessagesJob sharedJob] startIfNecessary];
@@ -819,6 +817,11 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     if ([TSAccountManager isRegistered]) {
         DDLogInfo(@"localNumber: %@", [TSAccountManager localNumber]);
+
+        // This should happen at any launch, background or foreground.
+        __unused AnyPromise *promise = [OWSSyncPushTokensJob runWithPushManager:[PushManager sharedManager]
+                                                                 accountManager:[Environment getCurrent].accountManager
+                                                                    preferences:[Environment preferences]];
     }
 
     [DeviceSleepManager.sharedInstance removeBlockWithBlockObject:self];

--- a/Signal/src/environment/Environment.h
+++ b/Signal/src/environment/Environment.h
@@ -27,6 +27,7 @@
 @class CallService;
 @class OWSMessageSender;
 @class NotificationsManager;
+@class OWSMessageFetcherJob;
 
 @interface Environment : NSObject
 
@@ -46,7 +47,7 @@
 @property (nonatomic, readonly) NotificationsManager *notificationsManager;
 @property (nonatomic, readonly) OWSMessageSender *messageSender;
 @property (nonatomic, readonly) OWSPreferences *preferences;
-
+@property (nonatomic, readonly) OWSMessageFetcherJob *messageFetcherJob;
 
 @property (nonatomic, readonly) HomeViewController *homeViewController;
 @property (nonatomic, readonly, weak) UINavigationController *signUpFlowNavigationController;

--- a/Signal/src/environment/Environment.m
+++ b/Signal/src/environment/Environment.m
@@ -13,6 +13,8 @@
 #import "TSGroupThread.h"
 #import <SignalServiceKit/ContactsUpdater.h>
 #import <SignalServiceKit/Threading.h>
+#import <SignalServiceKit/OWSSignalService.h>
+#import <SignalServiceKit/OWSMessageReceiver.h>
 
 static Environment *environment = nil;
 
@@ -23,6 +25,7 @@ static Environment *environment = nil;
             callService = _callService,
             contactsManager = _contactsManager,
             contactsUpdater = _contactsUpdater,
+            messageFetcherJob = _messageFetcherJob,
             messageSender = _messageSender,
             networkManager = _networkManager,
             notificationsManager = _notificationsManager,
@@ -135,6 +138,20 @@ static Environment *environment = nil;
 {
     OWSAssert(_networkManager != nil);
     return _networkManager;
+}
+
+- (OWSMessageFetcherJob *)messageFetcherJob
+{
+    @synchronized(self)
+    {
+        if (!_messageFetcherJob) {
+            _messageFetcherJob =
+                [[OWSMessageFetcherJob alloc] initWithMessageReceiver:[OWSMessageReceiver sharedInstance]
+                                                       networkManager:self.networkManager
+                                                        signalService:[OWSSignalService sharedInstance]];
+        }
+    }
+    return _messageFetcherJob;
 }
 
 - (OWSMessageSender *)messageSender

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -52,18 +52,16 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
 
 - (instancetype)initDefault
 {
-    return [self initWithNetworkManager:[Environment getCurrent].networkManager
-                         storageManager:[TSStorageManager sharedManager]
-                          callUIAdapter:[Environment getCurrent].callService.callUIAdapter
-                        messageReceiver:[OWSMessageReceiver sharedInstance]
-                          messageSender:[Environment getCurrent].messageSender];
+    return [self initWithMessageFetcherJob:[Environment getCurrent].messageFetcherJob
+                            storageManager:[TSStorageManager sharedManager]
+                             callUIAdapter:[Environment getCurrent].callService.callUIAdapter
+                             messageSender:[Environment getCurrent].messageSender];
 }
 
-- (instancetype)initWithNetworkManager:(TSNetworkManager *)networkManager
-                        storageManager:(TSStorageManager *)storageManager
-                         callUIAdapter:(CallUIAdapter *)callUIAdapter
-                       messageReceiver:(OWSMessageReceiver *)messageReceiver
-                         messageSender:(OWSMessageSender *)messageSender
+- (instancetype)initWithMessageFetcherJob:(OWSMessageFetcherJob *)messageFetcherJob
+                           storageManager:(TSStorageManager *)storageManager
+                            callUIAdapter:(CallUIAdapter *)callUIAdapter
+                            messageSender:(OWSMessageSender *)messageSender
 {
     self = [super init];
     if (!self) {
@@ -72,12 +70,7 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
 
     _callUIAdapter = callUIAdapter;
     _messageSender = messageSender;
-
-    OWSSignalService *signalService = [OWSSignalService sharedInstance];
-    _messageFetcherJob = [[OWSMessageFetcherJob alloc] initWithMessageReceiver:messageReceiver
-                                                                networkManager:networkManager
-                                                                 signalService:signalService];
-
+    _messageFetcherJob = messageFetcherJob;
     _callBackgroundTask = UIBackgroundTaskInvalid;
     _currentNotifications = [NSMutableArray array];
 


### PR DESCRIPTION
Ensure we register for remote notifications when launched from the background. 

The primary motivation for this change is not always reproducible, but I have a couple of compellign logs that indicate the app *is* launched, but doesn't receive the push notification delegate callback.

Documentation suggests that we register for notifications at launch, which we can't quite do, because we need the DB to be setup to determine if we're registered, but this get us closer.

PTAL @charlesmchen 