### PR TITLE
Suppress build warnings for Cocoapods dependencies.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,16 +2,19 @@ platform :ios, '8.0'
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Signal' do
-    pod 'ATAppUpdater'
+	pod '25519', :inhibit_warnings => true
+    pod 'Mantle', :inhibit_warnings => true	
+	pod 'YapDatabase/SQLCipher', '~> 2.9.3', :inhibit_warnings => true	
+    pod 'ATAppUpdater', :inhibit_warnings => true
     pod 'AxolotlKit',                 git: 'https://github.com/WhisperSystems/SignalProtocolKit.git'
     #pod 'AxolotlKit',                 path: '../SignalProtocolKit'
-    pod 'JSQMessagesViewController',  git: 'https://github.com/WhisperSystems/JSQMessagesViewController.git', branch: 'signal-master'
+    pod 'JSQMessagesViewController',  git: 'https://github.com/WhisperSystems/JSQMessagesViewController.git', branch: 'signal-master', :inhibit_warnings => true
     #pod 'JSQMessagesViewController',   path: '../JSQMessagesViewController'
-    pod 'PureLayout'
-    pod 'OpenSSL',                    git: 'https://github.com/WhisperSystems/OpenSSL-Pod'
-    pod 'Reachability'
+    pod 'PureLayout', :inhibit_warnings => true
+    pod 'OpenSSL',                    git: 'https://github.com/WhisperSystems/OpenSSL-Pod', :inhibit_warnings => true
+    pod 'Reachability', :inhibit_warnings => true
     pod 'SignalServiceKit',           path: '.'
-    pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git'
+    pod 'SocketRocket',               :git => 'https://github.com/facebook/SocketRocket.git', :inhibit_warnings => true
     pod 'YYImage'
     target 'SignalTests' do
       inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,6 @@ platform :ios, '8.0'
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Signal' do
-	pod '25519', :inhibit_warnings => true
     pod 'Mantle', :inhibit_warnings => true	
 	pod 'YapDatabase/SQLCipher', '~> 2.9.3', :inhibit_warnings => true	
     pod 'ATAppUpdater', :inhibit_warnings => true

--- a/Podfile
+++ b/Podfile
@@ -2,8 +2,8 @@ platform :ios, '8.0'
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Signal' do
-    pod 'Mantle', :inhibit_warnings => true	
-	pod 'YapDatabase/SQLCipher', '~> 2.9.3', :inhibit_warnings => true	
+    pod 'Mantle', :inhibit_warnings => true    
+    pod 'YapDatabase/SQLCipher', '~> 2.9.3', :inhibit_warnings => true    
     pod 'ATAppUpdater', :inhibit_warnings => true
     pod 'AxolotlKit',                 git: 'https://github.com/WhisperSystems/SignalProtocolKit.git'
     #pod 'AxolotlKit',                 path: '../SignalProtocolKit'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -115,14 +115,17 @@ PODS:
   - YYImage/Core (1.0.4)
 
 DEPENDENCIES:
+  - 25519
   - ATAppUpdater
   - AxolotlKit (from `https://github.com/WhisperSystems/SignalProtocolKit.git`)
   - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController.git`, branch `signal-master`)
+  - Mantle
   - OpenSSL (from `https://github.com/WhisperSystems/OpenSSL-Pod`)
   - PureLayout
   - Reachability
   - SignalServiceKit (from `.`)
   - SocketRocket (from `https://github.com/facebook/SocketRocket.git`)
+  - YapDatabase/SQLCipher (~> 2.9.3)
   - YYImage
 
 EXTERNAL SOURCES:
@@ -176,6 +179,6 @@ SPEC CHECKSUMS:
   YapDatabase: cd911121580ff16675f65ad742a9eb0ab4d9e266
   YYImage: 1e1b62a9997399593e4b9c4ecfbbabbf1d3f3b54
 
-PODFILE CHECKSUM: e02f783a25dea01eb6bf5a9f125d0b1cac21f4dd
+PODFILE CHECKSUM: ed8bcf324d0ef26fe5ef3651ae9e807c96eacb72
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -115,7 +115,6 @@ PODS:
   - YYImage/Core (1.0.4)
 
 DEPENDENCIES:
-  - 25519
   - ATAppUpdater
   - AxolotlKit (from `https://github.com/WhisperSystems/SignalProtocolKit.git`)
   - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController.git`, branch `signal-master`)
@@ -179,6 +178,6 @@ SPEC CHECKSUMS:
   YapDatabase: cd911121580ff16675f65ad742a9eb0ab4d9e266
   YYImage: 1e1b62a9997399593e4b9c4ecfbbabbf1d3f3b54
 
-PODFILE CHECKSUM: ed8bcf324d0ef26fe5ef3651ae9e807c96eacb72
+PODFILE CHECKSUM: 56e535b5c171c6d039d05bfc8995ea1a1a749ac8
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
This PR is intended as a proposal.  

* Working through build errors is so much easier without the huge quantity of warnings from our pods.
* We're less likely to miss/ignore a warning from our own codebase amid the noise.

PTAL @michaelkirk 