### PR TITLE
Keyboard covers "Activate" button on iPhone6

### DIFF
--- a/Signal/src/ViewControllers/RegistrationViewController.m
+++ b/Signal/src/ViewControllers/RegistrationViewController.m
@@ -210,7 +210,7 @@ NSString *const kKeychainKey_LastRegisteredPhoneNumber = @"kKeychainKey_LastRegi
     self.activateButton = activateButton;
     [contentView addSubview:activateButton];
     [activateButton autoPinLeadingAndTrailingToSuperview];
-    [activateButton autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:separatorView2 withOffset:ScaleFromIPhone5(24)];
+    [activateButton autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:separatorView2 withOffset:15];
     [activateButton autoSetDimension:ALDimensionHeight toSize:kActivateButtonHeight];
 
     UIActivityIndicatorView *spinnerView =


### PR DESCRIPTION
With https://github.com/WhisperSystems/Signal-iOS/pull/2574 I broke this on iPhone6-sized devices.

After:
![image](https://user-images.githubusercontent.com/217057/31408164-a07e07ae-add5-11e7-976d-bea83d12f0c7.png)

<img width="559" alt="screen shot 2017-10-10 at 4 06 12 pm" src="https://user-images.githubusercontent.com/217057/31408111-6d4a944c-add5-11e7-93c4-5a741234aaae.png">

<img width="598" alt="screen shot 2017-10-10 at 4 06 55 pm" src="https://user-images.githubusercontent.com/217057/31408106-6908bb70-add5-11e7-9c8a-9afae696d6f3.png">

PTAL @charlesmchen 