### PR TITLE
Log timestamp of sent messages

### DIFF
--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -843,7 +843,11 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             success:(void (^)())successHandler
             failure:(RetryableFailureHandler)failureHandler
 {
-    DDLogDebug(@"%@ sending message to service: %@", self.tag, message.debugDescription);
+    DDLogInfo(@"%@ attempting to send message: %@, timestamp: %llu, recipient: %@",
+        self.tag,
+        message.class,
+        message.timestamp,
+        recipient.uniqueId);
     AssertIsOnSendingQueue();
 
     if ([TSPreKeyManager isAppLockedDueToPreKeyUpdateFailures]) {


### PR DESCRIPTION
This is really helpful when cross referencing debug logs with the
recipient. (We already log timestamps on the receiving side).

PTAL @charlesmchen 