### PR TITLE
Increase profile disclosure compression resistance

### DIFF
--- a/Signal/src/ViewControllers/AppSettingsViewController.m
+++ b/Signal/src/ViewControllers/AppSettingsViewController.m
@@ -298,6 +298,7 @@
     [disclosureButton autoVCenterInSuperview];
     [disclosureButton autoPinTrailingToSuperview];
     [disclosureButton autoPinLeadingToTrailingOfView:nameView margin:16.f];
+    [disclosureButton setContentCompressionResistancePriority:(UILayoutPriorityDefaultHigh + 1) forAxis:UILayoutConstraintAxisHorizontal];
 
     return cell;
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE Simulator, iOS 10.3
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Prevents disclosure indicator in profile row of settings from collapsing when the profile name is too long.

Fixes #2515.

![long-profile-name](https://user-images.githubusercontent.com/2874864/31703966-f6b88964-b393-11e7-98c3-2aa78c3bdd69.png)
