### PR TITLE
GIF picker UX tweaks

### DIFF
--- a/Signal/src/UserInterface/Strings.swift
+++ b/Signal/src/UserInterface/Strings.swift
@@ -11,7 +11,7 @@ import Foundation
 @objc class CommonStrings: NSObject {
     static let dismissButton = NSLocalizedString("DISMISS_BUTTON_TEXT", comment: "Short text to dismiss current modal / actionsheet / screen")
     static let cancelButton = NSLocalizedString("TXT_CANCEL_TITLE", comment:"Label for the cancel button in an alert or action sheet.")
-
+    static let retryButton = NSLocalizedString("RETRY_BUTTON_TEXT", comment:"Generic text for button that retries whatever the last action was.")
 }
 
 @objc class MessageStrings: NSObject {

--- a/Signal/src/ViewControllers/FingerprintViewScanController.m
+++ b/Signal/src/ViewControllers/FingerprintViewScanController.m
@@ -239,14 +239,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                                       preferredStyle:UIAlertControllerStyleAlert];
 
     if (retryBlock) {
-        [alertController
-            addAction:[UIAlertAction
-                          actionWithTitle:NSLocalizedString(@"RETRY_BUTTON_TEXT",
-                                              @"Generic text for button that retries whatever the last action was.")
-                                    style:UIAlertActionStyleDefault
-                                  handler:^(UIAlertAction *action) {
-                                      retryBlock();
-                                  }]];
+        [alertController addAction:[UIAlertAction actionWithTitle:[CommonStrings retryButton]
+                                                            style:UIAlertActionStyleDefault
+                                                          handler:^(UIAlertAction *action) {
+                                                              retryBlock();
+                                                          }]];
     }
 
     [alertController addAction:[OWSAlerts cancelAction]];

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -110,7 +110,7 @@ class GifPickerCell: UICollectionViewCell {
 
         // Record high quality animated rendition, but to save bandwidth, don't start downloading
         // until it's selected.
-        guard let highQualityAnimatedRendition = imageInfo.pickHighQualityAnimatedRendition() else {
+        guard let highQualityAnimatedRendition = imageInfo.pickSendingRendition() else {
             Logger.warn("\(TAG) could not pick gif rendition: \(imageInfo.giphyId)")
             clearAssetRequests()
             return
@@ -119,7 +119,7 @@ class GifPickerCell: UICollectionViewCell {
 
         // The Giphy API returns a slew of "renditions" for a given image. 
         // It's critical that we carefully "pick" the best rendition to use.
-        guard let animatedRendition = imageInfo.pickAnimatedRendition() else {
+        guard let animatedRendition = imageInfo.pickPreviewRendition() else {
             Logger.warn("\(TAG) could not pick gif rendition: \(imageInfo.giphyId)")
             clearAssetRequests()
             return

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -221,7 +221,7 @@ class GifPickerCell: UICollectionViewCell {
             activityIndicator.startAnimating()
 
             // Render activityIndicator on a white tile to ensure it's visible on
-            // when overalayed on a variety of potential gifs.
+            // when overlayed on a variety of potential gifs.
             activityIndicator.backgroundColor = UIColor.white.withAlphaComponent(0.3)
             activityIndicator.autoSetDimension(.width, toSize: 30)
             activityIndicator.autoSetDimension(.height, toSize: 30)
@@ -249,7 +249,7 @@ class GifPickerCell: UICollectionViewCell {
                                                             fulfill(asset)
         },
                                                         failure: { _ in
-                                                            // TODO GiphyDownloader API shoudl pass through a useful failing error
+                                                            // TODO GiphyDownloader API should pass through a useful failing error
                                                             // so we can pass it through here
                                                             Logger.error("\(self.TAG) request failed")
                                                             reject(GiphyError.fetchFailure)

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -226,6 +226,10 @@ class GifPickerCell: UICollectionViewCell {
             activityIndicator.autoSetDimension(.width, toSize: 30)
             activityIndicator.autoSetDimension(.height, toSize: 30)
             activityIndicator.layer.cornerRadius = 3
+            activityIndicator.layer.shadowColor = UIColor.black.cgColor
+            activityIndicator.layer.shadowOffset = CGSize(width: 1, height: 1)
+            activityIndicator.layer.shadowOpacity = 0.7
+            activityIndicator.layer.shadowRadius = 1.0
         } else {
             self.activityIndicator?.stopAnimating()
             self.activityIndicator = nil

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -9,10 +9,6 @@ class GifPickerCell: UICollectionViewCell {
     let TAG = "[GifPickerCell]"
 
     // MARK: Properties
-    enum GifPickerCellError: Error {
-        case assertionError(description: String)
-        case fetchFailure
-    }
 
     var imageInfo: GiphyImageInfo? {
         didSet {
@@ -211,7 +207,7 @@ class GifPickerCell: UICollectionViewCell {
     public func requestRenditionForSending() -> Promise<GiphyAsset> {
         guard let renditionForSending = self.renditionForSending else {
             owsFail("\(TAG) renditionForSending was unexpectedly nil")
-            return Promise(error: GifPickerCellError.assertionError(description: "renditionForSending was unexpectedly nil"))
+            return Promise(error: GiphyError.assertionError(description: "renditionForSending was unexpectedly nil"))
         }
 
         let (promise, fulfill, reject) = Promise<GiphyAsset>.pending()
@@ -227,8 +223,8 @@ class GifPickerCell: UICollectionViewCell {
                                                         failure: { _ in
                                                             // TODO GiphyDownloader API shoudl pass through a useful failing error
                                                             // so we can pass it through here
-                                                            reject(GifPickerCellError.fetchFailure)
-
+                                                            Logger.error("\(self.TAG) request failed")
+                                                            reject(GiphyError.fetchFailure)
         })
 
         return promise

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -35,6 +35,14 @@ class GifPickerCell: UICollectionViewCell {
     var animatedAssetRequest: GiphyAssetRequest?
     var animatedAsset: GiphyAsset?
     var imageView: YYAnimatedImageView?
+    var activityIndicator: UIActivityIndicatorView?
+
+    var isCellSelected: Bool = false {
+        didSet {
+            AssertIsOnMainThread()
+            ensureCellState()
+        }
+    }
 
     // As another bandwidth saving measure, we only fetch the full sized GIF when the user selects it.
     private var renditionForSending: GiphyRendition?
@@ -59,6 +67,8 @@ class GifPickerCell: UICollectionViewCell {
         animatedAssetRequest = nil
         imageView?.removeFromSuperview()
         imageView = nil
+        activityIndicator = nil
+        isCellSelected = false
     }
 
     private func clearStillAssetRequest() {
@@ -202,6 +212,24 @@ class GifPickerCell: UICollectionViewCell {
         }
         imageView.image = image
         self.backgroundColor = nil
+
+        if self.isCellSelected {
+            let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+            self.activityIndicator = activityIndicator
+            addSubview(activityIndicator)
+            activityIndicator.autoCenterInSuperview()
+            activityIndicator.startAnimating()
+
+            // Render activityIndicator on a white tile to ensure it's visible on
+            // when overalayed on a variety of potential gifs.
+            activityIndicator.backgroundColor = UIColor.white.withAlphaComponent(0.3)
+            activityIndicator.autoSetDimension(.width, toSize: 30)
+            activityIndicator.autoSetDimension(.height, toSize: 30)
+            activityIndicator.layer.cornerRadius = 3
+        } else {
+            self.activityIndicator?.stopAnimating()
+            self.activityIndicator = nil
+        }
     }
 
     public func requestRenditionForSending() -> Promise<GiphyAsset> {

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -208,7 +208,7 @@ class GifPickerCell: UICollectionViewCell {
         self.backgroundColor = nil
     }
 
-    public func fetchRenditionForSending() -> Promise<GiphyAsset> {
+    public func requestRenditionForSending() -> Promise<GiphyAsset> {
         guard let renditionForSending = self.renditionForSending else {
             owsFail("\(TAG) renditionForSending was unexpectedly nil")
             return Promise(error: GifPickerCellError.assertionError(description: "renditionForSending was unexpectedly nil"))
@@ -218,15 +218,16 @@ class GifPickerCell: UICollectionViewCell {
 
         // We don't retain a handle on the asset request, since there will only ever
         // be one selected asset, and we never want to cancel it.
-        _ = GiphyDownloader.sharedInstance.requestAsset(rendition: renditionForSending,
-                                                    priority: .high,
-                                                    success: { _, asset in
-                                                        fulfill(asset)
+        _ = GiphyDownloader
+            .sharedInstance.requestAsset(rendition: renditionForSending,
+                                                        priority: .high,
+                                                        success: { _, asset in
+                                                            fulfill(asset)
         },
-                                                    failure: { _ in
-                                                        // TODO GiphyDownloader API shoudl pass through a useful failing error
-                                                        // so we can pass it through here
-                                                        reject(GifPickerCellError.fetchFailure)
+                                                        failure: { _ in
+                                                            // TODO GiphyDownloader API shoudl pass through a useful failing error
+                                                            // so we can pass it through here
+                                                            reject(GifPickerCellError.fetchFailure)
 
         })
 

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -333,7 +333,8 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
         self.collectionView.isUserInteractionEnabled = false
 
-        cell.fetchRenditionForSending().then { (asset: GiphyAsset) -> Void in
+        GiphyDownloader.sharedInstance.cancelAllRequests()
+        cell.requestRenditionForSending().then { (asset: GiphyAsset) -> Void in
             let filePath = asset.filePath
             guard let dataSource = DataSourcePath.dataSource(withFilePath: filePath) else {
                 owsFail("\(self.TAG) couldn't load asset.")

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -161,7 +161,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         self.collectionView.dataSource = self
         self.collectionView.backgroundColor = UIColor.white
         self.collectionView.register(GifPickerCell.self, forCellWithReuseIdentifier: kCellReuseIdentifier)
-        // Inserted below searchbar becase we later occlude the collectionview
+        // Inserted below searchbar because we later occlude the collectionview
         // by inserting a masking layer between the search bar and collectionview
         self.view.insertSubview(self.collectionView, belowSubview: searchBar)
         self.collectionView.autoPinWidthToSuperview()

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -333,6 +333,10 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
         self.collectionView.isUserInteractionEnabled = false
 
+        getFileForCell(cell)
+    }
+
+    public func getFileForCell(_ cell: GifPickerCell) {
         GiphyDownloader.sharedInstance.cancelAllRequests()
         cell.requestRenditionForSending().then { (asset: GiphyAsset) -> Void in
             let filePath = asset.filePath
@@ -349,7 +353,20 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
             self.delegate?.gifPickerDidSend(outgoingMessage: outgoingMessage)
 
             self.dismiss(animated: true, completion: nil)
+        }.catch { error in
+            let alert = UIAlertController(title: NSLocalizedString("GIF_PICKER_FAILURE_ALERT_TITLE", comment: "Shown when selected gif couldn't be fetched"),
+                                          message: error.localizedDescription,
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: CommonStrings.retryButton, style: .default) { _ in
+                    self.getFileForCell(cell)
+            })
+            alert.addAction(UIAlertAction(title: CommonStrings.dismissButton, style: .cancel) { _ in
+                self.dismiss(animated: true, completion: nil)
+            })
+
+            UIApplication.shared.frontmostViewController?.present(alert, animated: true, completion: nil)
         }.retainUntilComplete()
+
     }
 
     public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -268,6 +268,12 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         }
     }
 
+    // MARK: - UIScrollViewDelegate
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        self.searchBar.resignFirstResponder()
+    }
+
     // MARK: - UICollectionViewDataSource
 
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -161,7 +161,9 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         self.collectionView.dataSource = self
         self.collectionView.backgroundColor = UIColor.white
         self.collectionView.register(GifPickerCell.self, forCellWithReuseIdentifier: kCellReuseIdentifier)
-        self.view.addSubview(self.collectionView)
+        // Inserted below searchbar becase we later occlude the collectionview
+        // by inserting a masking layer between the search bar and collectionview
+        self.view.insertSubview(self.collectionView, belowSubview: searchBar)
         self.collectionView.autoPinWidthToSuperview()
         self.collectionView.autoPinEdge(.top, to: .bottom, of: searchBar)
 
@@ -307,7 +309,10 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
         // Fade out all cells except the selected one.
         let maskingView = OWSBezierPathView()
-        self.view.addSubview(maskingView)
+
+        // Selecting cell behind searchbar masks part of search bar.
+        // So we insert mask *behind* the searchbar.
+        self.view.insertSubview(maskingView, belowSubview: searchBar)
         let cellRect = self.collectionView.convert(cell.frame, to: self.view)
         maskingView.configureShapeLayerBlock = { layer, bounds in
             let path = UIBezierPath(rect: bounds)

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -281,9 +281,14 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     }
 
     public  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: kCellReuseIdentifier, for: indexPath)
+
+        guard indexPath.row < imageInfos.count else {
+            Logger.warn("\(TAG) indexPath: \(indexPath.row) out of range for imageInfo count: \(imageInfos.count) ")
+            return cell
+        }
         let imageInfo = imageInfos[indexPath.row]
 
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: kCellReuseIdentifier, for: indexPath)
         guard let gifCell = cell as? GifPickerCell else {
             owsFail("\(TAG) Unexpected cell type.")
             return cell

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -293,6 +293,12 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
             return
         }
 
+        guard cell.stillAsset != nil || cell.animatedAsset != nil else {
+            // we don't want to let the user blindly select a gray cell
+            Logger.debug("\(TAG) ignoring selection of cell with no preview")
+            return
+        }
+
         guard self.selectedCell == nil else {
             owsFail("\(TAG) Already selected cell")
             return
@@ -302,13 +308,9 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         // Fade out all cells except the selected one.
         let maskingView = OWSBezierPathView()
         self.view.addSubview(maskingView)
-
-        maskingView.configureShapeLayerBlock = { [weak self] layer, bounds in
-            guard let strongSelf = self else {
-                return
-            }
+        let cellRect = self.collectionView.convert(cell.frame, to: self.view)
+        maskingView.configureShapeLayerBlock = { layer, bounds in
             let path = UIBezierPath(rect: bounds)
-            let cellRect = strongSelf.collectionView.convert(cell.frame, to: strongSelf.view)
             path.append(UIBezierPath(rect: cellRect))
 
             layer.path = path.cgPath
@@ -318,19 +320,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         }
         maskingView.autoPinEdgesToSuperviewEdges()
 
-        let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
-        cell.contentView.addSubview(activityIndicator)
-        activityIndicator.autoCenterInSuperview()
-
-        activityIndicator.startAnimating()
-
-        // Render activityIndicator on a white tile to ensure it's visible on
-        // when overalayed on a variety of potential gifs.
-        activityIndicator.backgroundColor = UIColor.white.withAlphaComponent(0.3)
-        activityIndicator.autoSetDimension(.width, toSize: 30)
-        activityIndicator.autoSetDimension(.height, toSize: 30)
-        activityIndicator.layer.cornerRadius = 3
-
+        cell.isCellSelected = true
         self.collectionView.isUserInteractionEnabled = false
 
         getFileForCell(cell)

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -40,7 +40,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     var noResultsView: UILabel?
     var searchErrorView: UILabel?
     var activityIndicator: UIActivityIndicatorView?
-    var selectedCell: UICollectionViewCell?
+    var hasSelectedCell: Bool = false
     var imageInfos = [GiphyImageInfo]()
 
     var reachability: Reachability?
@@ -312,11 +312,11 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
             return
         }
 
-        guard self.selectedCell == nil else {
+        guard self.hasSelectedCell == false else {
             owsFail("\(TAG) Already selected cell")
             return
         }
-        self.selectedCell = cell
+        self.hasSelectedCell = true
 
         // Fade out all cells except the selected one.
         let maskingView = OWSBezierPathView()

--- a/Signal/src/ViewControllers/OWSLinkDeviceViewController.m
+++ b/Signal/src/ViewControllers/OWSLinkDeviceViewController.m
@@ -185,7 +185,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                              message:error.localizedDescription
                                                                       preferredStyle:UIAlertControllerStyleAlert];
 
-    UIAlertAction *retryAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"RETRY_BUTTON_TEXT", nil)
+    UIAlertAction *retryAction = [UIAlertAction actionWithTitle:[CommonStrings retryButton]
                                                           style:UIAlertActionStyleDefault
                                                         handler:^(UIAlertAction *action) {
                                                             retryBlock();

--- a/Signal/src/ViewControllers/OWSLinkedDevicesTableViewController.m
+++ b/Signal/src/ViewControllers/OWSLinkedDevicesTableViewController.m
@@ -158,9 +158,7 @@ int const OWSLinkedDevicesTableViewControllerSectionAddDevice = 1;
                                                         message:error.localizedDescription
                                                  preferredStyle:UIAlertControllerStyleAlert];
 
-                NSString *retryTitle = NSLocalizedString(
-                    @"RETRY_BUTTON_TEXT", @"Generic text for button that retries whatever the last action was.");
-                UIAlertAction *retryAction = [UIAlertAction actionWithTitle:retryTitle
+                UIAlertAction *retryAction = [UIAlertAction actionWithTitle:[CommonStrings retryButton]
                                                                       style:UIAlertActionStyleDefault
                                                                     handler:^(UIAlertAction *action) {
                                                                         [wself refreshDevices];
@@ -368,7 +366,7 @@ int const OWSLinkedDevicesTableViewControllerSectionAddDevice = 1;
                                                                        preferredStyle:UIAlertControllerStyleAlert];
 
                                       UIAlertAction *retryAction =
-                                          [UIAlertAction actionWithTitle:NSLocalizedString(@"RETRY_BUTTON_TEXT", nil)
+                                          [UIAlertAction actionWithTitle:[CommonStrings retryButton]
                                                                    style:UIAlertActionStyleDefault
                                                                  handler:^(UIAlertAction *aaction) {
                                                                      [self unlinkDevice:device success:successCallback];

--- a/Signal/src/network/GiphyAPI.swift
+++ b/Signal/src/network/GiphyAPI.swift
@@ -9,6 +9,21 @@ enum GiphyFormat {
     case gif, mp4, jpg
 }
 
+enum GiphyError: Error {
+    case assertionError(description: String)
+    case fetchFailure
+}
+extension GiphyError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .assertionError:
+            return NSLocalizedString("GIF_PICKER_ERROR_GENERIC", comment: "Generic error displayed when picking a gif")
+        case .fetchFailure:
+            return NSLocalizedString("GIF_PICKER_ERROR_FETCH_FAILURE", comment: "Error displayed when there is a failure fetching gifs from the remote service.")
+        }
+    }
+}
+
 // Represents a "rendition" of a GIF.
 // Giphy offers a plethora of renditions for each image.
 // They vary in content size (i.e. width,  height), 

--- a/Signal/src/network/GiphyAPI.swift
+++ b/Signal/src/network/GiphyAPI.swift
@@ -89,8 +89,9 @@ enum GiphyFormat {
 
     // TODO: We may need to tweak these constants.
     let kMaxDimension = UInt(618)
-    let kMinDimension = UInt(101)
-    let kMaxFileSize = UInt(3 * 1024 * 1024)
+    let kMinDimension = UInt(60)
+    let kPreferedPreviewFileSize = UInt(256 * 1024)
+    let kPreferedSendingFileSize = UInt(3 * 1024 * 1024)
 
     private enum PickingStrategy {
         case smallerIsBetter, largerIsBetter
@@ -105,20 +106,33 @@ enum GiphyFormat {
 
     public func pickStillRendition() -> GiphyRendition? {
         // Stills are just temporary placeholders, so use the smallest still possible.
-        return pickRendition(isStill:true, pickingStrategy:.smallerIsBetter, maxFileSize:kMaxFileSize)
+        return pickRendition(isStill:true, pickingStrategy:.smallerIsBetter, maxFileSize:kPreferedPreviewFileSize)
     }
 
     public func pickAnimatedRendition() -> GiphyRendition? {
         // Try to pick a small file...
-        if let rendition = pickRendition(isStill:false, pickingStrategy:.largerIsBetter, maxFileSize:kMaxFileSize) {
+        if let rendition = pickRendition(isStill:false, pickingStrategy:.largerIsBetter, maxFileSize:kPreferedPreviewFileSize) {
             return rendition
         }
         // ...but gradually relax the file restriction...
-        if let rendition = pickRendition(isStill:false, pickingStrategy:.smallerIsBetter, maxFileSize:kMaxFileSize * 2) {
+        if let rendition = pickRendition(isStill:false, pickingStrategy:.smallerIsBetter, maxFileSize:kPreferedPreviewFileSize * 2) {
             return rendition
         }
         // ...and relax even more until we find an animated rendition.
-        return pickRendition(isStill:false, pickingStrategy:.smallerIsBetter, maxFileSize:kMaxFileSize * 3)
+        return pickRendition(isStill:false, pickingStrategy:.smallerIsBetter, maxFileSize:kPreferedPreviewFileSize * 3)
+    }
+
+    public func pickHighQualityAnimatedRendition() -> GiphyRendition? {
+        // Try to pick a small file...
+        if let rendition = pickRendition(isStill:false, pickingStrategy:.largerIsBetter, maxFileSize:kPreferedSendingFileSize) {
+            return rendition
+        }
+        // ...but gradually relax the file restriction...
+        if let rendition = pickRendition(isStill:false, pickingStrategy:.smallerIsBetter, maxFileSize:kPreferedSendingFileSize * 2) {
+            return rendition
+        }
+        // ...and relax even more until we find an animated rendition.
+        return pickRendition(isStill:false, pickingStrategy:.smallerIsBetter, maxFileSize:kPreferedSendingFileSize * 3)
     }
 
     // Picking a rendition must be done very carefully.

--- a/Signal/src/network/GiphyAPI.swift
+++ b/Signal/src/network/GiphyAPI.swift
@@ -125,7 +125,7 @@ extension GiphyError: LocalizedError {
         return pickRendition(renditionType: .stillPreview, pickingStrategy:.smallerIsBetter, maxFileSize:kPreferedPreviewFileSize)
     }
 
-    public func pickAnimatedRendition() -> GiphyRendition? {
+    public func pickPreviewRendition() -> GiphyRendition? {
         // Try to pick a small file...
         if let rendition = pickRendition(renditionType: .animatedLowQuality, pickingStrategy:.largerIsBetter, maxFileSize:kPreferedPreviewFileSize) {
             return rendition
@@ -138,7 +138,7 @@ extension GiphyError: LocalizedError {
         return pickRendition(renditionType: .animatedLowQuality, pickingStrategy:.smallerIsBetter, maxFileSize:kPreferedPreviewFileSize * 3)
     }
 
-    public func pickHighQualityAnimatedRendition() -> GiphyRendition? {
+    public func pickSendingRendition() -> GiphyRendition? {
         // Try to pick a small file...
         if let rendition = pickRendition(renditionType: .animatedHighQuality, pickingStrategy:.largerIsBetter, maxFileSize:kPreferedSendingFileSize) {
             return rendition

--- a/Signal/src/network/GiphyDownloader.swift
+++ b/Signal/src/network/GiphyDownloader.swift
@@ -237,6 +237,10 @@ extension URLSessionTask {
         return assetRequest
     }
 
+    public func cancelAllRequests() {
+        self.assetRequestQueue.forEach { $0.cancel() }
+    }
+
     private func assetRequestDidSucceed(assetRequest: GiphyAssetRequest, asset: GiphyAsset) {
         DispatchQueue.main.async {
             self.assetMap.set(key:assetRequest.rendition.url, value:asset)

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -613,6 +613,15 @@
 /* A label for generic attachments. */
 "GENERIC_ATTACHMENT_LABEL" = "Attachment";
 
+/* Error displayed when there is a failure fetching gifs from the remote service. */
+"GIF_PICKER_ERROR_FETCH_FAILURE" = "Failed to fetch the requested GIF. Please verify you are online.";
+
+/* Generic error displayed when picking a gif */
+"GIF_PICKER_ERROR_GENERIC" = "An unknown error occured.";
+
+/* Shown when selected gif couldn't be fetched */
+"GIF_PICKER_FAILURE_ALERT_TITLE" = "Unable to Choose GIF";
+
 /* Alert message shown when user tries to search for GIFs without entering any search terms. */
 "GIF_PICKER_VIEW_MISSING_QUERY" = "Please enter your search.";
 
@@ -985,7 +994,7 @@
 /* The title for the 'create group' button. */
 "NEW_GROUP_CREATE_BUTTON" = "Create";
 
-/* The navbar title for the 'new group' view. */
+/* Used in place of the group name when a group has not yet been named. */
 "NEW_GROUP_DEFAULT_TITLE" = "New Group";
 
 /* An indicator that a user is a member of the new group. */


### PR DESCRIPTION
Issues Addressed:

## Less time to animated loading

GIF picker can be difficult to use on a slow data connection. Primarily this was because we were downloading a full-sized animated asset for each cell. Now we download a small one for the picker view, and only download a full-sized asset once it's selected. This results in a 65-90% reduction in overall bandwidth used, and also a quicker picker navigation experience.

## Unable to select cells until animated asset was downloaded.

Previously, tapping on the still wouldn't select the GIF, and there was no user feedback as to why. Now, once you tap a cell (as long as at least the still has been loaded), we indicate which cell is selected, show an activity indicator, and block further interaction with the collection view until the asset is completely fetched.

## Dismiss keyboard after progressive search

We were dismissing keyboard when the user hit the "search" button, but if the user scrolls around after the auto-search, we should dismiss the keyboard.

PTAL @charlesmchen 