### PR TITLE
Auto-dismiss keyboard if user scrolls away from bottom of the convers…

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -543,6 +543,10 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
 {
     [self cancelVoiceMemo];
     self.isUserScrolling = NO;
+    [self saveDraft];
+    [self markVisibleMessagesAsRead];
+    [self.cellMediaCache removeAllObjects];
+    [self cancelReadTimer];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -3517,6 +3521,22 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
 {
     [self updateLastVisibleTimestamp];
     [self autoLoadMoreIfNecessary];
+
+    if ([self isScrolledAwayFromBottom]) {
+        [self.inputToolbar endEditingTextMessage];
+    }
+}
+
+// See the comments on isScrolledToBottom.
+- (BOOL)isScrolledAwayFromBottom
+{
+    CGFloat contentHeight = self.safeContentHeight;
+    // Note the usage of MAX() to handle the case where there isn't enough
+    // content to fill the collection view at its current size.
+    CGFloat contentOffsetYBottom = MAX(0.f, contentHeight - self.collectionView.bounds.size.height);
+    const CGFloat kThreshold = 250;
+    BOOL isScrolledAwayFromBottom = (self.collectionView.contentOffset.y < contentOffsetYBottom - kThreshold);
+    return isScrolledAwayFromBottom;
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView


### PR DESCRIPTION
…ation.

This isn't as "slick" as the old JSQ behavior where the keyboard was dismissed in coordination with the scrolling gesture, but it's a lot simpler code-wise and doesn't require the slightly hacky approach of crawling over the view hierarchy to find the keyboard view.

I thought I'd try this.  If we feel like it isn't as nice an experience, we can always go back to the JSQ way.

PTAL @michaelkirk 