### PR TITLE
Make message bubbles a bit wider.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -760,7 +760,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert(self.viewItem);
     OWSAssert([self.viewItem.interaction isKindOfClass:[TSMessage class]]);
 
-    const int maxMessageWidth = (int)floor(contentWidth * 0.7f);
+    const int maxMessageWidth = (int)floor(contentWidth * 0.8f);
 
     CGSize cellSize = CGSizeZero;
     switch (self.cellType) {


### PR DESCRIPTION
This is closer to the previous behavior, at least on 5 and 6 sized devices.

Do you feel like this is *too* wide on your plus sized device @charlesmchen ?