### PR TITLE
Fix text message links in conversation view.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -127,7 +127,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.bubbleImageView = [UIImageView new];
     self.bubbleImageView.layoutMargins = UIEdgeInsetsZero;
-    self.bubbleImageView.userInteractionEnabled = NO;
+    // Enable userInteractionEnabled so that links in textView work.
+    self.bubbleImageView.userInteractionEnabled = YES;
     [self.payloadView addSubview:self.bubbleImageView];
     [self.bubbleImageView autoPinToSuperviewEdges];
 


### PR DESCRIPTION
PTAL @michaelkirk 

There's a similar issue in "message detail" view, but I can't find a way to get links working in a way that's compatible with our "render UITextView using proxy view" solution.  And I don't see any alternative to using that.

