### PR TITLE
Update dependencies via Carthage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,7 @@
-github "mxcl/PromiseKit"
+# Avoid PromiseKit 5 for now.
+# From the maintainer:
+# > PromiseKit 5 has been released, but is not yet fully documented, 
+# > so we advise sticking with version 4 for the time being.
+github "mxcl/PromiseKit" ~> 4.0
 github "TheLevelUp/ZXingObjC"
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "TheLevelUp/ZXingObjC" "3.2.1"
-github "mxcl/PromiseKit" "4.4.1"
+github "TheLevelUp/ZXingObjC" "3.2.2"
+github "mxcl/PromiseKit" "4.5.0"


### PR DESCRIPTION
Avoid PromiseKit 5 for now.

> PromiseKit 5 has been released, but is not yet fully documented, so we advise sticking with version 4 for the time being.

PTAL @charlesmchen 
