### PR TITLE
Ensure we re-upload push tokens after re-registering.

### DIFF
--- a/Signal/src/Models/AccountManager.swift
+++ b/Signal/src/Models/AccountManager.swift
@@ -76,7 +76,9 @@ class AccountManager: NSObject {
 
     private func syncPushTokens() -> Promise<Void> {
         Logger.info("\(self.TAG) in \(#function)")
-        return SyncPushTokensJob.run(accountManager: self, preferences: self.preferences)
+        let job = SyncPushTokensJob(accountManager: self, preferences: self.preferences)
+        job.uploadOnlyIfStale = false
+        return job.run()
     }
 
     private func completeRegistration() {

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
@@ -91,6 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     DDLogInfo(@"%@ re-registering.", self.tag);
     [[TSAccountManager sharedInstance] resetForRegistration];
+    [[Environment getCurrent].preferences unsetRecordedAPNSTokens];
 
     RegistrationViewController *viewController = [RegistrationViewController new];
     OWSNavigationController *navigationController =

--- a/Signal/src/environment/OWSPreferences.h
+++ b/Signal/src/environment/OWSPreferences.h
@@ -79,6 +79,8 @@ extern NSString *const OWSPreferencesKeyEnableDebugLog;
 - (void)setVoipToken:(NSString *)value;
 - (nullable NSString *)getVoipToken;
 
+- (void)unsetRecordedAPNSTokens;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Signal/src/environment/OWSPreferences.m
+++ b/Signal/src/environment/OWSPreferences.m
@@ -267,6 +267,25 @@ NSString *const OWSPreferencesKeyIOSUpgradeNagVersion = @"iOSUpgradeNagVersion";
     return [self tryGetValueForKey:OWSPreferencesKeyLastRecordedVoipToken];
 }
 
+- (void)unsetRecordedAPNSTokens
+{
+    DDLogWarn(@"%@ Forgetting recorded APNS tokens", self.tag);
+    [self setValue:nil forKey:OWSPreferencesKeyLastRecordedPushToken];
+    [self setValue:nil forKey:OWSPreferencesKeyLastRecordedVoipToken];
+}
+
+#pragma mark - Logging
+
++ (NSString *)tag
+{
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag
+{
+    return self.class.tag;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This fixes a situation where a user could send (but not receive) messages after using the new (debug only) re-register functionality.

I fixed the issue twice - either one would be sufficient, but seems good to be robust about this particular issue.

PTAL @charlesmchen 

