### PR TITLE
Increase content insets of attachment button.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -113,6 +113,7 @@ static void *kConversationInputTextViewObservingContext = &kConversationInputTex
                               action:@selector(attachmentButtonPressed)
                     forControlEvents:UIControlEventTouchUpInside];
     [self.attachmentButton setImage:[UIImage imageNamed:@"btnAttachments--blue"] forState:UIControlStateNormal];
+    self.attachmentButton.contentEdgeInsets = UIEdgeInsetsMake(0, 3, 0, 3);
     [self.leftButtonWrapper addSubview:self.attachmentButton];
 
     // TODO: Fix layout in this class.


### PR DESCRIPTION
PTAL @michaelkirk 

The attachment button should be easier to hit _AND_ visually symmetrical with the voice memo button.

![attach](https://user-images.githubusercontent.com/625803/32573069-c75ca246-c49a-11e7-809d-de48dc4ea8ab.png)
