### PR TITLE
Charlesmchen/tap vs link vs keyboard

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -1297,6 +1297,8 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
+    _isPresentingMenuController = isPresentingMenuController;
+
     if (isPresentingMenuController) {
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(didHideMenuController:)

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -1132,16 +1132,6 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         [self.expirationTimerView clearAnimations];
     }
-
-    [self debugFirstResponder:self depth:0];
-}
-
-- (void)debugFirstResponder:(UIView *)view depth:(int)depth
-{
-    DDLogError(@"debugFirstResponder[%@ / %d]: %d", view.class, depth, [view canBecomeFirstResponder]);
-    for (UIView *subview in view.subviews) {
-        [self debugFirstResponder:subview depth:depth + 1];
-    }
 }
 
 // case TSInfoMessageAdapter: {


### PR DESCRIPTION
This fixes a number of related issues:

* Disable partial text selection.
* Ignore non-link taps in text messages.
* Ignore taps in non-sent messages.
* Link-ify all links.
* Don't dismiss keyboard when tapping on messages.

PTAL @michaelkirk 
