### PR TITLE
Scroll only as far as necessary

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -4180,13 +4180,10 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
 
                 // Canary check in case we later have another reason to set navigationController.delegate - we don't
                 // want to inadvertently clobber it here.
-                OWSAssert(self.navigationController.delegate == nil) self.navigationController.delegate = self;
-                TSMessage *message = (TSMessage *)interaction;
-                MessageDetailViewController *view =
-                    [[MessageDetailViewController alloc] initWithViewItem:conversationItem
-                                                                  message:message
-                                                                     mode:MessageMetadataViewModeFocusOnMetadata];
-                [self.navigationController pushViewController:view animated:YES];
+                OWSAssert(self.navigationController.delegate == nil);
+                self.navigationController.delegate = self;
+
+                [self showMetadataViewForViewItem:conversationItem];
             } else {
                 OWSFail(@"%@ Can't show message metadata for message of type: %@", self.logTag, [interaction class]);
             }

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -38,7 +38,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
     var messageTextProxyViewHeightConstraint: NSLayoutConstraint?
     var bubbleViewWidthConstraint: NSLayoutConstraint?
 
-    var scrollView: UIScrollView?
+    var scrollView: UIScrollView!
     var contentView: UIView?
 
     var attachment: TSAttachment?
@@ -96,11 +96,22 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
                 view.setNeedsLayout()
                 view.layoutIfNeeded()
 
+                let contentHeight = scrollView.contentSize.height
+                let scrollViewHeight = scrollView.frame.size.height
+                guard contentHeight >=  scrollViewHeight else {
+                    // All content is visible within the scroll view. No need to offset.
+                    return
+                }
+
+                // We want to include at least a little portion of the message, but scroll no farther than necessary.
                 let showAtLeast: CGFloat = 50
-                let middleCenter = CGPoint(x: bubbleView.frame.origin.x + bubbleView.frame.width / 2,
-                                           y: bubbleView.frame.origin.y + bubbleView.frame.height - showAtLeast)
-                let offset = bubbleView.superview!.convert(middleCenter, to: scrollView)
-                self.scrollView!.setContentOffset(offset, animated: false)
+                let bubbleViewBottom = bubbleView.superview!.convert(bubbleView.frame, to: scrollView).maxY
+                let maxOffset =  bubbleViewBottom - showAtLeast
+                let lastPage = contentHeight - scrollViewHeight
+
+                let offset = CGPoint(x: 0, y: min(maxOffset, lastPage))
+
+                scrollView.setContentOffset(offset, animated: false)
             }
         }
     }


### PR DESCRIPTION
On first load, message details for longer messages often get scrolled off the top of the screen.

We should only scroll as far as necessary.
 
**Before**
![before-scroll-fix](https://user-images.githubusercontent.com/217057/32852818-249617fa-ca07-11e7-9210-e02567961002.PNG)

**After**
![after-scroll-fix](https://user-images.githubusercontent.com/217057/32852833-2fd3f68c-ca07-11e7-905f-8951d7c307e8.jpeg)

PTAL @charlesmchen 