### PR TITLE
Skip animations in conversation view.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -2965,10 +2965,9 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     } else {
         // We want these animations to be as short as possible, but `performBatchUpdates`
         // will SIGABORT in some cases if the animation duration is zero.
-        [CATransaction begin];
-        [CATransaction setAnimationDuration:0.001f];
-        [self.collectionView performBatchUpdates:batchUpdates completion:batchUpdatesCompletion];
-        [CATransaction commit];
+        [UIView performWithoutAnimation:^{
+            [self.collectionView performBatchUpdates:batchUpdates completion:batchUpdatesCompletion];
+        }];
     }
 }
 

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -2963,8 +2963,6 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     if (shouldAnimateUpdates) {
         [self.collectionView performBatchUpdates:batchUpdates completion:batchUpdatesCompletion];
     } else {
-        // We want these animations to be as short as possible, but `performBatchUpdates`
-        // will SIGABORT in some cases if the animation duration is zero.
         [UIView performWithoutAnimation:^{
             [self.collectionView performBatchUpdates:batchUpdates completion:batchUpdatesCompletion];
         }];


### PR DESCRIPTION
I'm hoping that it's now safe to remove the "1 ms animation" hack now that we've made other fixes in the `performBatchUpdates` logic.

PTAL @michaelkirk 