### PR TITLE
For most views, only try to dismiss keyboard when scroll drag starts.

### DIFF
--- a/Signal/src/ViewControllers/CountryCodeViewController.m
+++ b/Signal/src/ViewControllers/CountryCodeViewController.m
@@ -152,7 +152,7 @@
 
 #pragma mark - OWSTableViewControllerDelegate
 
-- (void)tableViewDidScroll
+- (void)tableViewWillBeginDragging
 {
     [self.searchBar resignFirstResponder];
 }

--- a/Signal/src/ViewControllers/NewContactThreadViewController.m
+++ b/Signal/src/ViewControllers/NewContactThreadViewController.m
@@ -842,7 +842,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - OWSTableViewControllerDelegate
 
-- (void)tableViewDidScroll
+- (void)tableViewWillBeginDragging
 {
     [self.searchBar resignFirstResponder];
 }

--- a/Signal/src/ViewControllers/NewGroupViewController.m
+++ b/Signal/src/ViewControllers/NewGroupViewController.m
@@ -591,7 +591,7 @@ const NSUInteger kNewGroupViewControllerAvatarWidth = 68;
 
 #pragma mark - OWSTableViewControllerDelegate
 
-- (void)tableViewDidScroll
+- (void)tableViewWillBeginDragging
 {
     [self.groupNameTextField resignFirstResponder];
 }

--- a/Signal/src/ViewControllers/OWSTableViewController.h
+++ b/Signal/src/ViewControllers/OWSTableViewController.h
@@ -100,7 +100,7 @@ typedef UITableViewCell *_Nonnull (^OWSTableCustomCellBlock)(void);
 
 @protocol OWSTableViewControllerDelegate <NSObject>
 
-- (void)tableViewDidScroll;
+- (void)tableViewWillBeginDragging;
 
 @end
 

--- a/Signal/src/ViewControllers/OWSTableViewController.m
+++ b/Signal/src/ViewControllers/OWSTableViewController.m
@@ -616,9 +616,9 @@ NSString * const kOWSTableCellIdentifier = @"kOWSTableCellIdentifier";
 
 #pragma mark - UIScrollViewDelegate
 
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
-    [self.delegate tableViewDidScroll];
+    [self.delegate tableViewWillBeginDragging];
 }
 
 @end

--- a/Signal/src/ViewControllers/SelectRecipientViewController.m
+++ b/Signal/src/ViewControllers/SelectRecipientViewController.m
@@ -573,7 +573,7 @@ NSString *const kSelectRecipientViewControllerCellIdentifier = @"kSelectRecipien
 
 #pragma mark - OWSTableViewControllerDelegate
 
-- (void)tableViewDidScroll
+- (void)tableViewWillBeginDragging
 {
     [self.phoneNumberTextField resignFirstResponder];
 }

--- a/Signal/src/ViewControllers/SelectThreadViewController.m
+++ b/Signal/src/ViewControllers/SelectThreadViewController.m
@@ -279,7 +279,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - OWSTableViewControllerDelegate
 
-- (void)tableViewDidScroll
+- (void)tableViewWillBeginDragging
 {
     [self.searchBar resignFirstResponder];
 }

--- a/Signal/src/ViewControllers/UpdateGroupViewController.m
+++ b/Signal/src/ViewControllers/UpdateGroupViewController.m
@@ -469,7 +469,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - OWSTableViewControllerDelegate
 
-- (void)tableViewDidScroll
+- (void)tableViewWillBeginDragging
 {
     [self.groupNameTextField resignFirstResponder];
 }


### PR DESCRIPTION
We only want to do this (in the general case) a scroll pan gesture starts.  Specifically, we don't want to do this while a scroll pan is settling as it often won't reflect user intent.

PTAL @michaelkirk 