### PR TITLE
Avoid overzealous assert

### DIFF
--- a/SignalServiceKit/src/Messages/Attachments/TSAttachment.m
+++ b/SignalServiceKit/src/Messages/Attachments/TSAttachment.m
@@ -72,6 +72,7 @@ NSUInteger const TSAttachmentSchemaVersion = 4;
     if (!self) {
         return self;
     }
+    DDLogVerbose(@"%@ init attachment with uniqueId: %@", self.logTag, self.uniqueId);
 
     _contentType = contentType;
     _byteCount = byteCount;

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -526,14 +526,18 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
     void (^successWithDeleteHandler)(void) = ^() {
         successHandler();
 
-        DDLogDebug(@"Removing temporary attachment message.");
+        DDLogDebug(@"%@ Removing successful temporary attachment message with attachment ids: %@",
+            self.logTag,
+            message.attachmentIds);
         [message remove];
     };
 
     void (^failureWithDeleteHandler)(NSError *error) = ^(NSError *error) {
         failureHandler(error);
 
-        DDLogDebug(@"Removing temporary attachment message.");
+        DDLogDebug(@"%@ Removing failed temporary attachment message with attachment ids: %@",
+            self.logTag,
+            message.attachmentIds);
         [message remove];
     };
 

--- a/SignalServiceKit/src/Storage/OWSOrphanedDataCleaner.m
+++ b/SignalServiceKit/src/Storage/OWSOrphanedDataCleaner.m
@@ -91,12 +91,9 @@ NS_ASSUME_NONNULL_BEGIN
     [self printPaths:orphanDiskFilePaths.allObjects label:@"orphan disk file paths"];
     [self printPaths:missingAttachmentFilePaths.allObjects label:@"missing attachment file paths"];
 
-    NSMutableSet *threadIds = [NSMutableSet new];
+    __block NSMutableSet *threadIds;
     [databaseConnection readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
-        [transaction enumerateKeysInCollection:TSThread.collection
-                                    usingBlock:^(NSString *_Nonnull key, BOOL *_Nonnull stop) {
-                                        [threadIds addObject:key];
-                                    }];
+        threadIds = [[NSMutableSet alloc] initWithArray:[transaction allKeysInCollection:TSThread.collection]];
     }];
 
     NSMutableSet<NSString *> *orphanInteractionIds = [NSMutableSet new];
@@ -156,8 +153,9 @@ NS_ASSUME_NONNULL_BEGIN
         for (NSString *attachmentId in orphanAttachmentIds) {
             TSAttachment *attachment = [TSAttachment fetchObjectWithUniqueID:attachmentId transaction:transaction];
             if (!attachment) {
-                // This could just be a race condition, but it should be very unlikely.
-                OWSFail(@"Could not load attachment: %@", attachmentId);
+                // This can happen on launch since we sync contacts/groups, especially if you have a lot of attachments
+                // to churn through, it's likely it's been deleted since starting this job.
+                DDLogWarn(@"%@ Could not load attachment: %@", self.logTag, attachmentId);
                 continue;
             }
             if (![attachment isKindOfClass:[TSAttachmentStream class]]) {


### PR DESCRIPTION
PTAL @charlesmchen 

Open to other approaches on this as well. 

e.g. a heavier weight solution would add a createdAt date to the Attachment model, which we could use to exclude too-young models from consideration. (similar to the `kMinimumOrphanAge` logic)