### PR TITLE
Use up-to-date framework friendly OpenSSL

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,9 +12,8 @@ def shared_pods
   #pod 'HKDFKit', path: '../HKDFKit'
   pod 'Curve25519Kit', git: 'https://github.com/WhisperSystems/Curve25519Kit', branch: 'mkirk/framework-friendly'
   #pod 'Curve25519Kit', path: '../Curve25519Kit'
-  # FIXME SHARINGEXTENSION use up-to-date framework compatible OpenSSL
-  #pod 'OpenSSL', git: 'https://github.com/WhisperSystems/OpenSSL-Pod', inhibit_warnings: true
-  pod 'GRKOpenSSLFramework'
+  pod 'GRKOpenSSLFramework', git: 'https://github.com/WhisperSystems/GRKOpenSSLFramework'
+  #pod 'GRKOpenSSLFramework', path: '../GRKOpenSSLFramework'
 
   # third party pods
   pod 'Mantle', :inhibit_warnings => true

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -118,7 +118,7 @@ DEPENDENCIES:
   - ATAppUpdater
   - AxolotlKit (from `https://github.com/WhisperSystems/SignalProtocolKit.git`, branch `mkirk/framework-friendly`)
   - Curve25519Kit (from `https://github.com/WhisperSystems/Curve25519Kit`, branch `mkirk/framework-friendly`)
-  - GRKOpenSSLFramework
+  - GRKOpenSSLFramework (from `https://github.com/WhisperSystems/GRKOpenSSLFramework`)
   - HKDFKit (from `https://github.com/WhisperSystems/HKDFKit.git`, branch `mkirk/framework-friendly`)
   - JSQMessagesViewController (from `https://github.com/WhisperSystems/JSQMessagesViewController.git`, branch `signal-master`)
   - Mantle
@@ -136,6 +136,8 @@ EXTERNAL SOURCES:
   Curve25519Kit:
     :branch: mkirk/framework-friendly
     :git: https://github.com/WhisperSystems/Curve25519Kit
+  GRKOpenSSLFramework:
+    :git: https://github.com/WhisperSystems/GRKOpenSSLFramework
   HKDFKit:
     :branch: mkirk/framework-friendly
     :git: https://github.com/WhisperSystems/HKDFKit.git
@@ -154,6 +156,9 @@ CHECKOUT OPTIONS:
   Curve25519Kit:
     :commit: 03a19c80aafc10a3464f0c086b1eb38239c507ac
     :git: https://github.com/WhisperSystems/Curve25519Kit
+  GRKOpenSSLFramework:
+    :commit: b11a2ae061a6e607dd4895c81220b07834852bdc
+    :git: https://github.com/WhisperSystems/GRKOpenSSLFramework
   HKDFKit:
     :commit: d2e2e50990e88537d6c4e38cc32a6f6debd83446
     :git: https://github.com/WhisperSystems/HKDFKit.git
@@ -188,6 +193,6 @@ SPEC CHECKSUMS:
   YapDatabase: cd911121580ff16675f65ad742a9eb0ab4d9e266
   YYImage: 1e1b62a9997399593e4b9c4ecfbbabbf1d3f3b54
 
-PODFILE CHECKSUM: 558b99b22f87c7fb6e4a9c3084b14a384203d431
+PODFILE CHECKSUM: df609163e658e2e341c703a666541302f4e1d97f
 
 COCOAPODS: 1.3.1

--- a/SignalServiceKit.podspec
+++ b/SignalServiceKit.podspec
@@ -38,8 +38,6 @@ An Objective-C library for communicating with the Signal messaging service.
   s.dependency 'YapDatabase/SQLCipher', '~> 2.9.3'
   s.dependency 'SocketRocket'
   s.dependency 'libPhoneNumber-iOS'
-  # FIXME SHARINGEXTENSION use up-to-date framework compatible OpenSSL
-  #s.dependency 'OpenSSL'
   s.dependency 'GRKOpenSSLFramework'
   s.dependency 'SAMKeychain'
   s.dependency 'TwistedOakCollapsingFutures'


### PR DESCRIPTION
Based on #2815, so review that one first.

PTAL @charlesmchen 

See the corresponding branch at https://github.com/WhisperSystems/GRKOpenSSLFramework/pull/1