### PR TITLE
Fix iOS8 crash on type

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.0</string>
+	<string>2.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -55,7 +55,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.19.0.22</string>
+	<string>2.19.1.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputTextView.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputTextView.m
@@ -198,16 +198,31 @@ NS_ASSUME_NONNULL_BEGIN
     // We don't support shift-return because it is often used for "newline" in other
     // messaging apps.
     return @[
-        [UIKeyCommand keyCommandWithInput:@"\r"
-                            modifierFlags:UIKeyModifierCommand
-                                   action:@selector(modifiedReturnPressed:)
-                     discoverabilityTitle:@"Send Message"],
+        [self keyCommandWithInput:@"\r"
+                    modifierFlags:UIKeyModifierCommand
+                           action:@selector(modifiedReturnPressed:)
+             discoverabilityTitle:@"Send Message"],
         // "Alternate" is option.
-        [UIKeyCommand keyCommandWithInput:@"\r"
-                            modifierFlags:UIKeyModifierAlternate
-                                   action:@selector(modifiedReturnPressed:)
-                     discoverabilityTitle:@"Send Message"],
+        [self keyCommandWithInput:@"\r"
+                    modifierFlags:UIKeyModifierAlternate
+                           action:@selector(modifiedReturnPressed:)
+             discoverabilityTitle:@"Send Message"],
     ];
+}
+
+- (UIKeyCommand *)keyCommandWithInput:(NSString *)input
+                        modifierFlags:(UIKeyModifierFlags)modifierFlags
+                               action:(SEL)action
+                 discoverabilityTitle:(NSString *)discoverabilityTitle
+{
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(9, 0)) {
+        return [UIKeyCommand keyCommandWithInput:input
+                                   modifierFlags:modifierFlags
+                                          action:action
+                            discoverabilityTitle:discoverabilityTitle];
+    } else {
+        return [UIKeyCommand keyCommandWithInput:input modifierFlags:modifierFlags action:action];
+    }
 }
 
 - (void)modifiedReturnPressed:(UIKeyCommand *)sender


### PR DESCRIPTION
We were using an iOS9+ API unguarded.

PTAL @charlesmchen 

Fixes https://github.com/WhisperSystems/Signal-iOS/issues/2821