### PR TITLE
Fix the add photo permission crash on iOS 11.

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -103,6 +103,8 @@
 	<string>Signal needs access to your microphone to make and receive phone calls and record voice messages.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Signal will let you choose which photos from your library to send.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Signal will save photos to your library.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>dripicons-v2.ttf</string>


### PR DESCRIPTION
https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html

![screen shot 2017-11-29 at 12 43 43 pm](https://user-images.githubusercontent.com/625803/33390111-f54ff590-d502-11e7-828a-5b4b997be776.png)


PTAL @michaelkirk 