### PR TITLE
restore chrono timestamp

### DIFF
--- a/SignalServiceKit/src/TSPrefix.h
+++ b/SignalServiceKit/src/TSPrefix.h
@@ -2,21 +2,25 @@
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
+#import <CocoaLumberjack/CocoaLumberjack.h>
+
+#define LOG_LEVEL_DEF sskLogLevel
+#define LOG_ASYNC_ENABLED YES
+
+#ifdef DEBUG
+static const NSUInteger sskLogLevel = DDLogLevelAll;
+#else
+static const NSUInteger sskLogLevel = DDLogLevelInfo;
+#endif
+
 #import "Asserts.h"
 #import "Constraints.h"
 #import "NSObject+OWS.h"
 #import "OWSAnalytics.h"
 #import "OWSDispatch.h"
 #import "iOSVersions.h"
-#import <Foundation/Foundation.h>
-
-@import CocoaLumberjack;
-
-#ifdef DEBUG
-static const NSUInteger ddLogLevel = DDLogLevelAll;
-#else
-static const NSUInteger ddLogLevel = DDLogLevelInfo;
-#endif
 
 #define BLOCK_SAFE_RUN(block, ...)                                                        \
     block ? dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), \

--- a/SignalServiceKit/src/Util/NSDate+OWS.mm
+++ b/SignalServiceKit/src/Util/NSDate+OWS.mm
@@ -3,6 +3,7 @@
 //
 
 #import "NSDate+OWS.h"
+#import <chrono>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,9 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (uint64_t)ows_millisecondTimeStamp
 {
-    // FIXME SHARINGEXTENSION revert to using chrono if possible
-    NSDate *now = [self new];
-    return (uint64_t)(now.timeIntervalSince1970 * 1000);
+    uint64_t milliseconds
+        = (uint64_t)(std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1));
+    return milliseconds;
 }
 
 + (NSDate *)ows_dateWithMillisecondsSince1970:(uint64_t)milliseconds


### PR DESCRIPTION
make SSK compatible with c++ by using non-modular imports, which
requires disambiguating our ddLog variable.

PTAL @charlesmchen 