### PR TITLE
Modal conversation picker, hide loading screen when possible

### DIFF
--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -23,7 +23,6 @@ public class ShareViewController: UINavigationController, SAELoadViewDelegate, S
         // We can't show the conversation picker until the DB is set up.
         // Normally this will only take a moment, so rather than flickering and then hiding the loading screen
         // We start as invisible, and only fade it in if it's going to take a while
-        self.view.isHidden = true
         self.view.alpha = 0
         UIView.animate(withDuration: 0.1, delay: 0.5, options: [.curveEaseInOut], animations: {
             self.view.alpha = 1
@@ -288,7 +287,7 @@ public class ShareViewController: UINavigationController, SAELoadViewDelegate, S
         // ensure view is visible.
         self.view.layer.removeAllAnimations()
         UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
-            self.view.isHidden = false
+
             self.view.alpha = 1
         }, completion: nil)
 

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -22,9 +22,12 @@ public class ShareViewController: UINavigationController, SAELoadViewDelegate, S
 
         // We can't show the conversation picker until the DB is set up.
         // Normally this will only take a moment, so rather than flickering and then hiding the loading screen
-        // We start with as invisible, and only fade it in if it's going to take a while
+        // We start as invisible, and only fade it in if it's going to take a while
         self.view.isHidden = true
         self.view.alpha = 0
+        UIView.animate(withDuration: 0.1, delay: 0.5, options: [.curveEaseInOut], animations: {
+            self.view.alpha = 1
+        }, completion: nil)
 
         // This should be the first thing we do.
         let appContext = ShareAppExtensionContext(rootViewController:self)
@@ -282,6 +285,13 @@ public class ShareViewController: UINavigationController, SAELoadViewDelegate, S
     }
 
     private func showErrorView(title: String, message: String) {
+        // ensure view is visible.
+        self.view.layer.removeAllAnimations()
+        UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
+            self.view.isHidden = false
+            self.view.alpha = 1
+        }, completion: nil)
+
         let viewController = SAEFailedViewController(delegate:self, title:title, message:message)
         self.setViewControllers([viewController], animated: false)
     }
@@ -308,14 +318,6 @@ public class ShareViewController: UINavigationController, SAELoadViewDelegate, S
         Logger.debug("\(self.logTag) \(#function)")
 
         super.viewDidAppear(animated)
-
-        // We can't show the conversation picker until the DB is set up.
-        // Normally this will only take a moment, so rather than flickering and then hiding the loading screen
-        // We start with as invisible, and only fade it in if it's going to take a while
-        self.view.isHidden = false
-        UIView.animate(withDuration: 0.1, delay: 0.5, options: [.curveEaseInOut], animations: {
-            self.view.alpha = 1
-        }, completion: nil)
     }
 
     override open func viewWillDisappear(_ animated: Bool) {
@@ -343,6 +345,8 @@ public class ShareViewController: UINavigationController, SAELoadViewDelegate, S
     // MARK: Helpers
 
     private func presentConversationPicker() {
+        // pause any animation revealing the "loading" screen
+        self.view.layer.removeAllAnimations()
         self.buildAttachment().then { attachment -> Void in
             let conversationPicker = SendExternalFileViewController()
             let navigationController = UINavigationController(rootViewController: conversationPicker)


### PR DESCRIPTION
The first usable screen is the conversation picker, that's the first
thing we want to show the user, and the modal presentation feels like
the right way to introduce this new context.

Long load times should be the exception, not the normal flow, so we
delay it's presentation in hopes that it will generally never be seen.

PTAL @charlesmchen 