### PR TITLE
track dyload time

### DIFF
--- a/Signal.xcodeproj/xcshareddata/xcschemes/Signal.xcscheme
+++ b/Signal.xcodeproj/xcshareddata/xcschemes/Signal.xcscheme
@@ -101,6 +101,11 @@
             value = "disable"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DYLD_PRINT_STATISTICS"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>


### PR DESCRIPTION
Outputs some statistics about linking time in xcode debug log when app or extension is launched.

PTAL @charlesmchen 