### PR TITLE
persist signal accounts

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -38,7 +38,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.2</string>
+	<string>2.19.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -55,7 +55,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.19.2.0</string>
+	<string>2.19.3.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>
@@ -101,10 +101,10 @@
 	<string>Signal uses your contacts to find users you know. We do not store your contacts on the server.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Signal needs access to your microphone to make and receive phone calls and record voice messages.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Signal will let you choose which photos from your library to send.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Signal will save photos to your library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Signal will let you choose which photos from your library to send.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>dripicons-v2.ttf</string>

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -858,6 +858,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     [AppVersion.instance appLaunchDidComplete];
 
+    [[Environment getCurrent].contactsManager loadSignalAccountsFromCache];
+    
     [self ensureRootViewController];
 
     // If there were any messages in our local queue which we hadn't yet processed.

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -881,7 +881,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     [OWSProfileManager.sharedManager fetchLocalUsersProfile];
     [[OWSReadReceiptManager sharedManager] prepareCachedValues];
-    [[Environment getCurrent].contactsManager loadLastKnownContactRecipientIds];
 }
 
 - (void)registrationStateDidChange

--- a/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
+++ b/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert([self.thread isKindOfClass:[TSContactThread class]]);
     TSContactThread *contactThread = (TSContactThread *)self.thread;
     NSString *recipientId = contactThread.contactIdentifier;
-    return [self.contactsManager signalAccountForRecipientId:recipientId] != nil;
+    return [self.contactsManager hasSignalAccountForRecipientId:recipientId];
 }
 
 #pragma mark - ContactEditingDelegate

--- a/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
+++ b/Signal/src/ViewControllers/OWSConversationSettingsViewController.m
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert([self.thread isKindOfClass:[TSContactThread class]]);
     TSContactThread *contactThread = (TSContactThread *)self.thread;
     NSString *recipientId = contactThread.contactIdentifier;
-    return [self.contactsManager.lastKnownContactRecipientIds containsObject:recipientId];
+    return [self.contactsManager signalAccountForRecipientId:recipientId] != nil;
 }
 
 #pragma mark - ContactEditingDelegate

--- a/Signal/src/contact/OWSContactsManager.h
+++ b/Signal/src/contact/OWSContactsManager.h
@@ -30,32 +30,9 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 
 @property (atomic, readonly) NSDictionary<NSString *, Contact *> *allContactsMap;
 
-// signalAccountMap and signalAccounts hold the same data.
-// signalAccountMap is for lookup. signalAccounts contains the accounts
-// ordered by display order.
-@property (atomic, readonly) NSDictionary<NSString *, SignalAccount *> *signalAccountMap;
+// order of the signalAccounts array respects the systems contact sorting preference
 @property (atomic, readonly) NSArray<SignalAccount *> *signalAccounts;
-
-// This value is cached and is available immediately, before system contacts
-// fetch or contacts intersection.
-//
-// In some cases, its better if our UI reflects these values
-// which haven't been updated yet rather than assume that
-// we have no contacts until the first contacts intersection
-// successfully completes.
-//
-// This significantly improves the user experience when:
-//
-// * No contacts intersection has completed because the app has just launched.
-// * Contacts intersection can't complete due to an unreliable connection or
-//   the contacts intersection rate limit.
-@property (atomic, readonly) NSArray<NSString *> *lastKnownContactRecipientIds;
-
 - (nullable SignalAccount *)signalAccountForRecipientId:(NSString *)recipientId;
-
-- (Contact *)getOrBuildContactForPhoneIdentifier:(NSString *)identifier;
-
-- (void)loadLastKnownContactRecipientIds;
 
 #pragma mark - System Contact Fetching
 

--- a/Signal/src/contact/OWSContactsManager.h
+++ b/Signal/src/contact/OWSContactsManager.h
@@ -34,6 +34,7 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 @property (atomic, readonly) NSArray<SignalAccount *> *signalAccounts;
 - (nullable SignalAccount *)signalAccountForRecipientId:(NSString *)recipientId;
 
+- (void)loadSignalAccountsFromCache;
 #pragma mark - System Contact Fetching
 
 // Must call `requestSystemContactsOnce` before accessing this method

--- a/Signal/src/contact/OWSContactsManager.h
+++ b/Signal/src/contact/OWSContactsManager.h
@@ -33,6 +33,7 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 // order of the signalAccounts array respects the systems contact sorting preference
 @property (atomic, readonly) NSArray<SignalAccount *> *signalAccounts;
 - (nullable SignalAccount *)signalAccountForRecipientId:(NSString *)recipientId;
+- (BOOL)hasSignalAccountForRecipientId:(NSString *)recipientId;
 
 - (void)loadSignalAccountsFromCache;
 #pragma mark - System Contact Fetching

--- a/Signal/src/contact/OWSContactsManager.m
+++ b/Signal/src/contact/OWSContactsManager.m
@@ -284,7 +284,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 {
     OWSAssert(recipientId.length > 0);
 
-    SignalAccount *signalAccount = [self signalAccountForRecipientId:recipientId];
+    SignalAccount *_Nullable signalAccount = [self signalAccountForRecipientId:recipientId];
     return signalAccount.displayName;
 }
 
@@ -292,7 +292,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 {
     OWSAssert(recipientId.length > 0);
 
-    SignalAccount *signalAccount = [self signalAccountForRecipientId:recipientId];
+    SignalAccount *_Nullable signalAccount = [self signalAccountForRecipientId:recipientId];
     return signalAccount.contact.firstName;
 }
 
@@ -300,7 +300,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 {
     OWSAssert(recipientId.length > 0);
 
-    SignalAccount *signalAccount = [self signalAccountForRecipientId:recipientId];
+    SignalAccount *_Nullable signalAccount = [self signalAccountForRecipientId:recipientId];
     return signalAccount.contact.lastName;
 }
 
@@ -591,6 +591,11 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
     }
 
     return signalAccount;
+}
+
+- (BOOL)hasSignalAccountForRecipientId:(NSString *)recipientId
+{
+    return [self signalAccountForRecipientId:recipientId] != nil;
 }
 
 - (UIImage * _Nullable)imageForPhoneIdentifier:(NSString * _Nullable)identifier {

--- a/Signal/src/util/ThreadUtil.m
+++ b/Signal/src/util/ThreadUtil.m
@@ -388,7 +388,7 @@ NS_ASSUME_NONNULL_BEGIN
                     shouldHaveAddToProfileWhitelistOffer = NO;
                 }
 
-                BOOL isContact = [contactsManager.lastKnownContactRecipientIds containsObject:recipientId];
+                BOOL isContact = [contactsManager signalAccountForRecipientId:recipientId] != nil;
                 if (isContact) {
                     // Only create "add to contacts" offers for non-contacts.
                     shouldHaveAddToContactsOffer = NO;

--- a/Signal/src/util/ThreadUtil.m
+++ b/Signal/src/util/ThreadUtil.m
@@ -388,8 +388,7 @@ NS_ASSUME_NONNULL_BEGIN
                     shouldHaveAddToProfileWhitelistOffer = NO;
                 }
 
-                BOOL isContact = [contactsManager signalAccountForRecipientId:recipientId] != nil;
-                if (isContact) {
+                if ([contactsManager hasSignalAccountForRecipientId:recipientId]) {
                     // Only create "add to contacts" offers for non-contacts.
                     shouldHaveAddToContactsOffer = NO;
                     // Only create block offers for non-contacts.

--- a/SignalServiceKit/src/Contacts/Contact.h
+++ b/SignalServiceKit/src/Contacts/Contact.h
@@ -3,6 +3,7 @@
 //
 
 #import <AddressBook/AddressBook.h>
+#import <Mantle/MTLModel.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SignalRecipient;
 @class YapDatabaseReadTransaction;
 
-@interface Contact : NSObject
+@interface Contact : MTLModel
 
 @property (nullable, readonly, nonatomic) NSString *firstName;
 @property (nullable, readonly, nonatomic) NSString *lastName;
@@ -30,13 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) NSArray<NSString *> *userTextPhoneNumbers;
 @property (readonly, nonatomic) NSArray<NSString *> *emails;
 @property (readonly, nonatomic) NSString *uniqueId;
+@property (nonatomic, readonly) BOOL isSignalContact;
 #if TARGET_OS_IOS
 @property (nullable, readonly, nonatomic) UIImage *image;
 @property (readonly, nonatomic) ABRecordID recordID;
 @property (nullable, nonatomic, readonly) CNContact *cnContact;
 #endif // TARGET_OS_IOS
 
-- (BOOL)isSignalContact;
 - (NSArray<SignalRecipient *> *)signalRecipientsWithTransaction:(YapDatabaseReadTransaction *)transaction;
 // TODO: Remove this method.
 - (NSArray<NSString *> *)textSecureIdentifiers;

--- a/SignalServiceKit/src/Contacts/SignalAccount.h
+++ b/SignalServiceKit/src/Contacts/SignalAccount.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 // this is a label for the account.
 @property (nonatomic) NSString *multipleAccountLabelText;
 
+- (NSString *)displayName;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithSignalRecipient:(SignalRecipient *)signalRecipient;

--- a/SignalServiceKit/src/Contacts/SignalAccount.h
+++ b/SignalServiceKit/src/Contacts/SignalAccount.h
@@ -2,6 +2,8 @@
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
+#import "TSYapDatabaseObject.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class Contact;
@@ -14,10 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 //   multiple instances of SignalAccount.
 // * For non-contacts, the contact property will be nil.
 //
-// New instances of SignalAccount for active accounts are
-// created every time we do a contacts intersection (e.g.
-// in response to a change to the device contacts).
-@interface SignalAccount : NSObject
+@interface SignalAccount : TSYapDatabaseObject
 
 // An E164 value identifying the signal account.
 //

--- a/SignalServiceKit/src/Contacts/SignalAccount.m
+++ b/SignalServiceKit/src/Contacts/SignalAccount.m
@@ -3,6 +3,7 @@
 //
 
 #import "SignalAccount.h"
+#import "Contact.h"
 #import "SignalRecipient.h"
 #import "TSStorageManager.h"
 
@@ -49,6 +50,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)uniqueId
 {
     return _recipientId;
+}
+
+- (NSString *)displayName
+{
+    NSString *baseName = (self.contact.fullName.length > 0 ? self.contact.fullName : self.recipientId);
+
+    OWSAssert(self.hasMultipleAccountContact == (self.multipleAccountLabelText != nil));
+    NSString *displayName = (self.multipleAccountLabelText
+            ? [NSString stringWithFormat:@"%@ (%@)", baseName, self.multipleAccountLabelText]
+            : baseName);
+
+    return displayName;
 }
 
 @end

--- a/SignalServiceKit/src/Contacts/SignalAccount.m
+++ b/SignalServiceKit/src/Contacts/SignalAccount.m
@@ -46,6 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
     return [SignalRecipient recipientWithTextSecureIdentifier:self.recipientId withTransaction:transaction];
 }
 
+- (nullable NSString *)uniqueId
+{
+    return _recipientId;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Contacts/SignalAccount.m
+++ b/SignalServiceKit/src/Contacts/SignalAccount.m
@@ -21,12 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSignalRecipient:(SignalRecipient *)signalRecipient
 {
-    if (self = [super init]) {
-        OWSAssert(signalRecipient);
-
-        _recipientId = signalRecipient.uniqueId;
-    }
-    return self;
+    OWSAssert(signalRecipient);
+    return [self initWithRecipientId:signalRecipient.recipientId];
 }
 
 - (instancetype)initWithRecipientId:(NSString *)recipientId
@@ -44,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert([NSThread isMainThread]);
     OWSAssert(transaction);
 
+    OWSAssert(self.recipientId.length > 0);
     return [SignalRecipient recipientWithTextSecureIdentifier:self.recipientId withTransaction:transaction];
 }
 


### PR DESCRIPTION
Fixes seeing an empty contact list when launching compose view too soon.
Fixes the flickering contact avatar seen when first launching Signal.

PTAL @charlesmchen 