### PR TITLE
Charlesmchen/attachment downloads vs background

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -445,7 +445,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 - (void)applicationWillResignActive:(UIApplication *)application {
     DDLogWarn(@"%@ applicationWillResignActive.", self.logTag);
 
-    UIBackgroundTaskIdentifier bgTask = [application beginBackgroundTaskWithExpirationHandler:nil];
+    __block OWSBackgroundTask *backgroundTask = [OWSBackgroundTask backgroundTaskWithLabelStr:__PRETTY_FUNCTION__];
+
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         if ([TSAccountManager isRegistered]) {
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -454,8 +455,11 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
                     [self showScreenProtection];
                 }
                 [SignalApp.sharedApp.homeViewController updateInboxCountLabel];
-                [application endBackgroundTask:bgTask];
+
+                backgroundTask = nil;
             });
+        } else {
+            backgroundTask = nil;
         }
     });
 

--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -73,6 +73,7 @@
 #import <SignalServiceKit/OWSAnalytics.h>
 #import <SignalServiceKit/OWSAnalyticsEvents.h>
 #import <SignalServiceKit/OWSAttachmentsProcessor.h>
+#import <SignalServiceKit/OWSBackgroundTask.h>
 #import <SignalServiceKit/OWSCallAnswerMessage.h>
 #import <SignalServiceKit/OWSCallBusyMessage.h>
 #import <SignalServiceKit/OWSCallHangupMessage.h>

--- a/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.m
+++ b/SignalServiceKit/src/Messages/Attachments/OWSAttachmentsProcessor.m
@@ -157,7 +157,7 @@ static const CGFloat kAttachmentDownloadProgressTheta = 0.001f;
 {
     OWSAssert(transaction);
 
-    __block OWSBackgroundTask *backgroundTask = [[OWSBackgroundTask alloc] initWithLabelStr:__PRETTY_FUNCTION__];
+    __block OWSBackgroundTask *backgroundTask = [OWSBackgroundTask backgroundTaskWithLabelStr:__PRETTY_FUNCTION__];
 
     [self setAttachment:attachment isDownloadingInMessage:message transaction:transaction];
 

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -336,7 +336,7 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
         return;
     }
 
-    OWSBackgroundTask *backgroundTask = [[OWSBackgroundTask alloc] initWithLabelStr:__PRETTY_FUNCTION__];
+    OWSBackgroundTask *backgroundTask = [OWSBackgroundTask backgroundTaskWithLabelStr:__PRETTY_FUNCTION__];
 
     [self processJobs:jobs];
 

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -5,6 +5,7 @@
 #import "OWSBatchMessageProcessor.h"
 #import "AppContext.h"
 #import "NSArray+OWS.h"
+#import "OWSBackgroundTask.h"
 #import "OWSMessageManager.h"
 #import "OWSQueues.h"
 #import "OWSSignalServiceProtos.pb.h"
@@ -335,9 +336,13 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
         return;
     }
 
+    OWSBackgroundTask *backgroundTask = [[OWSBackgroundTask alloc] initWithLabelStr:__PRETTY_FUNCTION__];
+
     [self processJobs:jobs];
 
     [self.finder removeJobsWithIds:jobs.uniqueIds];
+
+    backgroundTask = nil;
 
     DDLogVerbose(@"%@ completed %zd jobs. %zd jobs left.",
         self.logTag,

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -5,6 +5,7 @@
 #import "OWSMessageReceiver.h"
 #import "AppContext.h"
 #import "NSArray+OWS.h"
+#import "OWSBackgroundTask.h"
 #import "OWSBatchMessageProcessor.h"
 #import "OWSMessageDecrypter.h"
 #import "OWSQueues.h"
@@ -308,6 +309,8 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
         return;
     }
 
+    __block OWSBackgroundTask *backgroundTask = [[OWSBackgroundTask alloc] initWithLabelStr:__PRETTY_FUNCTION__];
+
     [self processJob:job
           completion:^(BOOL success) {
               [self.finder removeJobWithId:job.uniqueId];
@@ -316,6 +319,7 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
                   success ? @"decrypted" : @"failed to decrypt",
                   (unsigned long)[OWSMessageDecryptJob numberOfKeysInCollection]);
               [self drainQueueWorkStep];
+              backgroundTask = nil;
           }];
 }
 

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -309,7 +309,7 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
         return;
     }
 
-    __block OWSBackgroundTask *backgroundTask = [[OWSBackgroundTask alloc] initWithLabelStr:__PRETTY_FUNCTION__];
+    __block OWSBackgroundTask *backgroundTask = [OWSBackgroundTask backgroundTaskWithLabelStr:__PRETTY_FUNCTION__];
 
     [self processJob:job
           completion:^(BOOL success) {

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -234,7 +234,11 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
 
 - (void)endBackgroundTask
 {
+    if (self.backgroundTaskIdentifier == UIBackgroundTaskInvalid) {
+        return;
+    }
     [CurrentAppContext() endBackgroundTask:self.backgroundTaskIdentifier];
+    self.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
 }
 
 - (void)setBackgroundTaskIdentifier:(UIBackgroundTaskIdentifier)backgroundTaskIdentifier

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -7,6 +7,7 @@
 #import "ContactsUpdater.h"
 #import "NSData+keyVersionByte.h"
 #import "NSData+messagePadding.h"
+#import "OWSBackgroundTask.h"
 #import "OWSBlockingManager.h"
 #import "OWSDevice.h"
 #import "OWSDisappearingMessagesJob.h"
@@ -122,11 +123,6 @@ static void *kNSError_MessageSender_IsFatal = &kNSError_MessageSender_IsFatal;
                         success:(void (^)(void))successHandler
                         failure:(void (^)(NSError *_Nonnull error))failureHandler NS_DESIGNATED_INITIALIZER;
 
-#pragma mark - background task mgmt
-
-- (void)startBackgroundTask;
-- (void)endBackgroundTask;
-
 @end
 
 #pragma mark -
@@ -159,7 +155,7 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
 @property (nonatomic, readonly) void (^successHandler)(void);
 @property (nonatomic, readonly) void (^failureHandler)(NSError *_Nonnull error);
 @property (nonatomic) OWSSendMessageOperationState operationState;
-@property (nonatomic) UIBackgroundTaskIdentifier backgroundTaskIdentifier;
+@property (nonatomic) OWSBackgroundTask *backgroundTask;
 
 @end
 
@@ -178,7 +174,7 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
     }
 
     _operationState = OWSSendMessageOperationStateNew;
-    _backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    self.backgroundTask = [OWSBackgroundTask backgroundTaskWithLabelStr:__PRETTY_FUNCTION__];
 
     _message = message;
     _messageSender = messageSender;
@@ -216,42 +212,6 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
     return self;
 }
 
-#pragma mark - background task mgmt
-
-// We want to make sure to finish sending any in-flight messages when the app is backgrounded.
-// We have to call `startBackgroundTask` *before* the task is enqueued, since we can't guarantee when the operation will
-// be dequeued.
-- (void)startBackgroundTask
-{
-    AssertIsOnMainThread();
-    OWSAssert(self.backgroundTaskIdentifier == UIBackgroundTaskInvalid);
-
-    self.backgroundTaskIdentifier = [CurrentAppContext() beginBackgroundTaskWithExpirationHandler:^{
-        DDLogWarn(@"%@ Timed out while in background trying to send message: %@", self.logTag, self.message);
-        [self endBackgroundTask];
-    }];
-}
-
-- (void)endBackgroundTask
-{
-    if (self.backgroundTaskIdentifier == UIBackgroundTaskInvalid) {
-        return;
-    }
-    [CurrentAppContext() endBackgroundTask:self.backgroundTaskIdentifier];
-    self.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-}
-
-- (void)setBackgroundTaskIdentifier:(UIBackgroundTaskIdentifier)backgroundTaskIdentifier
-{
-    AssertIsOnMainThread();
-
-    // Should only be sent once per operation
-    OWSAssert(!CurrentAppContext().isMainApp || _backgroundTaskIdentifier == UIBackgroundTaskInvalid);
-    OWSAssert(!CurrentAppContext().isMainApp || backgroundTaskIdentifier != UIBackgroundTaskInvalid);
-
-    _backgroundTaskIdentifier = backgroundTaskIdentifier;
-}
-
 #pragma mark - NSOperation overrides
 
 - (BOOL)isExecuting
@@ -266,11 +226,6 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
 
 - (void)start
 {
-    // Should call `startBackgroundTask` before enqueuing the operation
-    // to ensure we don't get suspended before the operation completes.
-
-    OWSAssert(!CurrentAppContext().isMainApp || self.backgroundTaskIdentifier != UIBackgroundTaskInvalid);
-
     [self willChangeValueForKey:OWSSendMessageOperationKeyIsExecuting];
     self.operationState = OWSSendMessageOperationStateExecuting;
     [self didChangeValueForKey:OWSSendMessageOperationKeyIsExecuting];
@@ -343,8 +298,6 @@ NSUInteger const OWSSendMessageOperationMaxRetries = 4;
 
     [self didChangeValueForKey:OWSSendMessageOperationKeyIsExecuting];
     [self didChangeValueForKey:OWSSendMessageOperationKeyIsFinished];
-
-    [self endBackgroundTask];
 }
 
 @end
@@ -456,17 +409,9 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
                                                      success:successHandler
                                                      failure:failureHandler];
 
-        // startBackgroundTask must be called on the main thread.
-        dispatch_async(dispatch_get_main_queue(), ^{
-            // We call `startBackgroundTask` here to prevent our app from suspending while being backgrounded
-            // until the operation is completed - at which point the OWSSendMessageOperation ends it's background task.
-
-            [sendMessageOperation startBackgroundTask];
-
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                NSOperationQueue *sendingQueue = [self sendingQueueForMessage:message];
-                [sendingQueue addOperation:sendMessageOperation];
-            });
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            NSOperationQueue *sendingQueue = [self sendingQueueForMessage:message];
+            [sendingQueue addOperation:sendMessageOperation];
         });
     });
 }

--- a/SignalServiceKit/src/Util/OWSAnalytics.m
+++ b/SignalServiceKit/src/Util/OWSAnalytics.m
@@ -4,6 +4,7 @@
 
 #import "OWSAnalytics.h"
 #import "AppContext.h"
+#import "OWSBackgroundTask.h"
 #import "OWSQueues.h"
 #import "TSStorageManager.h"
 #import <CocoaLumberjack/CocoaLumberjack.h>
@@ -231,22 +232,19 @@ NSString *NSStringForOWSAnalyticsSeverity(OWSAnalyticsSeverity severity)
 
     DDLogDebug(@"%@ submitting: %@", self.logTag, eventKey);
 
-    __block UIBackgroundTaskIdentifier task;
-    task = [CurrentAppContext() beginBackgroundTaskWithExpirationHandler:^{
-        failureBlock();
-
-        [CurrentAppContext() endBackgroundTask:task];
-    }];
+    __block OWSBackgroundTask *backgroundTask =
+        [OWSBackgroundTask backgroundTaskWithLabelStr:__PRETTY_FUNCTION__
+                                      completionBlock:^(BackgroundTaskState backgroundTaskState) {
+                                          if (backgroundTaskState == BackgroundTaskState_Success) {
+                                              successBlock();
+                                          } else {
+                                              failureBlock();
+                                          }
+                                      }];
 
     // Until we integrate with an analytics platform, behave as though all event delivery succeeds.
     dispatch_async(self.serialQueue, ^{
-        BOOL success = YES;
-        if (success) {
-            successBlock();
-        } else {
-            failureBlock();
-        }
-        [CurrentAppContext() endBackgroundTask:task];
+        backgroundTask = nil;
     });
 }
 

--- a/SignalServiceKit/src/Util/OWSBackgroundTask.h
+++ b/SignalServiceKit/src/Util/OWSBackgroundTask.h
@@ -10,6 +10,17 @@ typedef NS_ENUM(NSUInteger, BackgroundTaskState) {
 
 typedef void (^BackgroundTaskCompletionBlock)(BackgroundTaskState backgroundTaskState);
 
+// This class makes it easier and safer to use background tasks.
+//
+// * Uses RAII (Resource Acquisition Is Initialization) pattern.
+// * Ensures completion block is called exactly once and on main thread,
+//   to facilitate handling "background task timed out" case, for example.
+// * Ensures we properly handle the "background task could not be created"
+//   case.
+//
+// Usage:
+//
+// * Use factory method to start a background task.
 @interface OWSBackgroundTask : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/SignalServiceKit/src/Util/OWSBackgroundTask.h
+++ b/SignalServiceKit/src/Util/OWSBackgroundTask.h
@@ -21,6 +21,9 @@ typedef void (^BackgroundTaskCompletionBlock)(BackgroundTaskState backgroundTask
 // Usage:
 //
 // * Use factory method to start a background task.
+// * Retain a strong reference to the OWSBackgroundTask during the "work".
+// * Clear all references to the OWSBackgroundTask when the work is done,
+//   if possible.
 @interface OWSBackgroundTask : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/SignalServiceKit/src/Util/OWSBackgroundTask.h
+++ b/SignalServiceKit/src/Util/OWSBackgroundTask.h
@@ -1,0 +1,10 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+@interface OWSBackgroundTask : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithLabelStr:(const char *)labelStr;
+
+@end

--- a/SignalServiceKit/src/Util/OWSBackgroundTask.h
+++ b/SignalServiceKit/src/Util/OWSBackgroundTask.h
@@ -2,9 +2,28 @@
 //  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
 //
 
+typedef NS_ENUM(NSUInteger, BackgroundTaskState) {
+    BackgroundTaskState_Success,
+    BackgroundTaskState_CouldNotStart,
+    BackgroundTaskState_Expired,
+};
+
+typedef void (^BackgroundTaskCompletionBlock)(BackgroundTaskState backgroundTaskState);
+
 @interface OWSBackgroundTask : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithLabelStr:(const char *)labelStr;
+
++ (OWSBackgroundTask *)backgroundTaskWithLabelStr:(const char *)labelStr;
+
+// completionBlock will be called exactly once on the main thread.
++ (OWSBackgroundTask *)backgroundTaskWithLabelStr:(const char *)labelStr
+                                  completionBlock:(BackgroundTaskCompletionBlock)completionBlock;
+
++ (OWSBackgroundTask *)backgroundTaskWithLabel:(NSString *)label;
+
+// completionBlock will be called exactly once on the main thread.
++ (OWSBackgroundTask *)backgroundTaskWithLabel:(NSString *)label
+                               completionBlock:(BackgroundTaskCompletionBlock)completionBlock;
 
 @end

--- a/SignalServiceKit/src/Util/OWSBackgroundTask.m
+++ b/SignalServiceKit/src/Util/OWSBackgroundTask.m
@@ -1,0 +1,85 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "OWSBackgroundTask.h"
+#import "AppContext.h"
+
+@interface OWSBackgroundTask ()
+
+@property (nonatomic) UIBackgroundTaskIdentifier backgroundTaskId;
+@property (nonatomic, readonly) NSString *label;
+
+@end
+
+#pragma mark -
+
+@implementation OWSBackgroundTask
+
+- (instancetype)initWithLabelStr:(const char *)labelStr
+{
+    self = [super init];
+
+    if (!self) {
+        return self;
+    }
+
+    OWSAssert(labelStr);
+
+    _label = [NSString stringWithFormat:@"%s", labelStr];
+
+    [self startBackgroundTask];
+
+    return self;
+}
+
+- (void)dealloc
+{
+    [self endBackgroundTask];
+}
+
+- (void)startBackgroundTask
+{
+    @synchronized(self)
+    {
+        __weak typeof(self) weakSelf = self;
+
+        self.backgroundTaskId = [CurrentAppContext() beginBackgroundTaskWithExpirationHandler:^{
+            OWSAssert([NSThread isMainThread]);
+            __strong typeof(self) strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+            @synchronized(strongSelf)
+            {
+                if (strongSelf.backgroundTaskId == UIBackgroundTaskInvalid) {
+                    return;
+                }
+                DDLogInfo(@"%@ %@ background task expired", strongSelf.logTag, strongSelf.label);
+                strongSelf.backgroundTaskId = UIBackgroundTaskInvalid;
+            }
+        }];
+    }
+}
+
+- (void)endBackgroundTask
+{
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        @synchronized(strongSelf)
+        {
+            if (strongSelf.backgroundTaskId == UIBackgroundTaskInvalid) {
+                return;
+            }
+            DDLogInfo(@"%@ %@ background task completed", strongSelf.logTag, strongSelf.label);
+            [CurrentAppContext() endBackgroundTask:strongSelf.backgroundTaskId];
+            strongSelf.backgroundTaskId = UIBackgroundTaskInvalid;
+        }
+    });
+}
+
+@end


### PR DESCRIPTION
PTAL @michaelkirk 

* Use a background task during attachment downloads.
* Use a background task during message processing.
* Create `OWSBackgroundTask` to DRY up and improve handling of background tasks.  

We often weren't handling edge cases correctly, like:

* Ensuring that completion handlers were called exactly once.
* Handling the "background task could not be completed" case.
* Ensuring that completion handlers were thread-safe.

