### PR TITLE
attachment captioning

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -53,7 +53,7 @@ static NSString *const kInitialViewControllerIdentifier = @"UserInitialViewContr
 static NSString *const kURLSchemeSGNLKey                = @"sgnl";
 static NSString *const kURLHostVerifyPrefix             = @"verify";
 
-@interface AppDelegate () <AttachmentApprovalViewControllerDelegate>
+@interface AppDelegate ()
 
 @property (nonatomic) UIWindow *screenProtectionWindow;
 @property (nonatomic) BOOL hasInitialRootViewController;
@@ -803,21 +803,10 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     DDLogInfo(@"Presenting initial root view controller");
 
     if ([TSAccountManager isRegistered]) {
-        // DO NOT COMMIT
-        //        SignalAttachment *_Nullable attachment = [SignalAttachment attachmentFromPasteboard];
-        //        if (!attachment.hasError) {
-        //            AttachmentApprovalViewController *approvalVC =
-        //                [[AttachmentApprovalViewController alloc] initWithAttachment:attachment delegate:self];
-        //            UINavigationController *approvalNavController =
-        //                [[UINavigationController alloc] initWithRootViewController:approvalVC];
-        //            approvalNavController.navigationBarHidden = YES;
-        //            self.window.rootViewController = approvalNavController;
-        //        } else {
         HomeViewController *homeView = [HomeViewController new];
         SignalsNavigationController *navigationController =
             [[SignalsNavigationController alloc] initWithRootViewController:homeView];
         self.window.rootViewController = navigationController;
-        //        }
     } else {
         RegistrationViewController *viewController = [RegistrationViewController new];
         OWSNavigationController *navigationController =
@@ -827,18 +816,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     }
 
     [AppUpdateNag.sharedInstance showAppUpgradeNagIfNecessary];
-}
-
-- (void)didApproveAttachmentWithAttachment:(SignalAttachment *_Nonnull)attachment
-{
-    DDLogVerbose(@"%@ in %s", self.logTag, __PRETTY_FUNCTION__);
-    [self.window.rootViewController dismissViewControllerAnimated:YES completion:nil];
-}
-
-- (void)didCancelAttachmentWithAttachment:(SignalAttachment *_Nonnull)attachment
-{
-    DDLogVerbose(@"%@ in %s", self.logTag, __PRETTY_FUNCTION__);
-    [self.window.rootViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -804,20 +804,20 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     if ([TSAccountManager isRegistered]) {
         // DO NOT COMMIT
-        SignalAttachment *_Nullable attachment = [SignalAttachment attachmentFromPasteboard];
-        if (!attachment.hasError) {
-            AttachmentApprovalViewController *approvalVC =
-                [[AttachmentApprovalViewController alloc] initWithAttachment:attachment delegate:self];
-            UINavigationController *approvalNavController =
-                [[UINavigationController alloc] initWithRootViewController:approvalVC];
-            approvalNavController.navigationBarHidden = YES;
-            self.window.rootViewController = approvalNavController;
-        } else {
-            HomeViewController *homeView = [HomeViewController new];
-            SignalsNavigationController *navigationController =
-                [[SignalsNavigationController alloc] initWithRootViewController:homeView];
-            self.window.rootViewController = navigationController;
-        }
+        //        SignalAttachment *_Nullable attachment = [SignalAttachment attachmentFromPasteboard];
+        //        if (!attachment.hasError) {
+        //            AttachmentApprovalViewController *approvalVC =
+        //                [[AttachmentApprovalViewController alloc] initWithAttachment:attachment delegate:self];
+        //            UINavigationController *approvalNavController =
+        //                [[UINavigationController alloc] initWithRootViewController:approvalVC];
+        //            approvalNavController.navigationBarHidden = YES;
+        //            self.window.rootViewController = approvalNavController;
+        //        } else {
+        HomeViewController *homeView = [HomeViewController new];
+        SignalsNavigationController *navigationController =
+            [[SignalsNavigationController alloc] initWithRootViewController:homeView];
+        self.window.rootViewController = navigationController;
+        //        }
     } else {
         RegistrationViewController *viewController = [RegistrationViewController new];
         OWSNavigationController *navigationController =

--- a/Signal/src/OWSMessagesBubbleImageFactory.swift
+++ b/Signal/src/OWSMessagesBubbleImageFactory.swift
@@ -26,12 +26,12 @@ class OWSMessagesBubbleImageFactory: NSObject {
     }()
 
     public lazy var outgoing: JSQMessagesBubbleImage = {
-        let color = UIColor.ows_materialBlue()
+        let color = UIColor.ows_materialBlue
         return self.outgoing(color: color)
     }()
 
     public lazy var currentlyOutgoing: JSQMessagesBubbleImage = {
-        let color = UIColor.ows_fadedBlue()
+        let color = UIColor.ows_fadedBlue
         return self.outgoing(color: color)
     }()
 

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -307,7 +307,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver {
                                                                               comment: "Label for button that shows the privacy settings."),
                                                       font:OWSFlatButton.fontForHeight(buttonHeight),
                                                       titleColor:UIColor.white,
-                                                      backgroundColor:UIColor.ows_signalBrandBlue(),
+                                                      backgroundColor:UIColor.ows_signalBrandBlue,
                                                       target:self,
                                                       selector:#selector(didPressShowCallSettings))
         viewStack.addSubview(callSettingsButton)
@@ -319,7 +319,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver {
                                                                         comment: "Label for button that dismiss the call view's settings nag."),
                                                 font:OWSFlatButton.fontForHeight(buttonHeight),
                                                 titleColor:UIColor.white,
-                                                backgroundColor:UIColor.ows_signalBrandBlue(),
+                                                backgroundColor:UIColor.ows_signalBrandBlue,
                                                 target:self,
                                                 selector:#selector(didPressDismissNag))
         viewStack.addSubview(notNowButton)

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -62,12 +62,15 @@ NS_ASSUME_NONNULL_BEGIN
     // mask orientation manually.
     BOOL hasOutgoingMask = self.isOutgoing ^ self.isRTL;
 
-    // Since the caption has it's own tail, the media bubble looks better
-    // without a tail.
+    // Since the caption has it's own tail, the media bubble just above
+    // it looks better without a tail.
     if (self.hideTail) {
         self.layoutMargins = UIEdgeInsetsMake(0, 0, 2, 8);
         maskedSubview.clipsToBounds = YES;
-        maskedSubview.layer.cornerRadius = 10;
+
+        // I arrived at this cornerRadius by superimposing the generated corner
+        // over that generated from the JSQMessagesMediaViewBubbleImageMasker
+        maskedSubview.layer.cornerRadius = 17;
     } else {
         [JSQMessagesMediaViewBubbleImageMasker applyBubbleImageMaskToMediaView:maskedSubview
                                                                     isOutgoing:hasOutgoingMask];

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -141,12 +141,12 @@ NS_ASSUME_NONNULL_BEGIN
 //@property (nonatomic) BubbleMaskingView *payloadView;
 @property (nonatomic) UIView *myPayloadView;
 @property (nonatomic) BubbleMaskingView *mediaMaskingView;
-@property (nonatomic) BubbleMaskingView *textMaskingView;
+//@property (nonatomic) BubbleMaskingView *textMaskingView;
 @property (nonatomic) UILabel *dateHeaderLabel;
 @property (nonatomic) OWSMessageTextView *textView;
 @property (nonatomic, nullable) UIImageView *failedSendBadgeView;
 @property (nonatomic, nullable) UILabel *tapForMoreLabel;
-@property (nonatomic, nullable) UIImageView *bubbleImageView;
+@property (nonatomic, nullable) UIImageView *myBubbleImageView;
 @property (nonatomic, nullable) AttachmentUploadView *attachmentUploadView;
 @property (nonatomic, nullable) UIImageView *stillImageView;
 @property (nonatomic, nullable) YYAnimatedImageView *animatedImageView;
@@ -196,9 +196,9 @@ NS_ASSUME_NONNULL_BEGIN
     self.mediaMaskingView.layoutMargins = UIEdgeInsetsZero;
     [self.myPayloadView addSubview:self.mediaMaskingView];
 
-    self.textMaskingView = [BubbleMaskingView new];
-    self.textMaskingView.layoutMargins = UIEdgeInsetsZero;
-    [self.myPayloadView addSubview:self.textMaskingView];
+    //    self.textMaskingView = [BubbleMaskingView new];
+    //    self.textMaskingView.layoutMargins = UIEdgeInsetsZero;
+    //    [self.myPayloadView addSubview:self.textMaskingView];
 
     self.footerView = [UIView containerView];
     [self.contentView addSubview:self.footerView];
@@ -209,12 +209,14 @@ NS_ASSUME_NONNULL_BEGIN
     self.dateHeaderLabel.textColor = [UIColor lightGrayColor];
     [self.contentView addSubview:self.dateHeaderLabel];
 
-    self.bubbleImageView = [UIImageView new];
-    self.bubbleImageView.layoutMargins = UIEdgeInsetsZero;
+    self.myBubbleImageView = [UIImageView new];
+    self.myBubbleImageView.layoutMargins = UIEdgeInsetsZero;
     // Enable userInteractionEnabled so that links in textView work.
-    self.bubbleImageView.userInteractionEnabled = YES;
-    [self.textMaskingView addSubview:self.bubbleImageView];
-    [self.bubbleImageView autoPinToSuperviewEdges];
+    self.myBubbleImageView.userInteractionEnabled = YES;
+    //    [self.textMaskingView addSubview:self.bubbleImageView];
+    [self.myPayloadView addSubview:self.myBubbleImageView];
+    //    [self.myBubbleImageView autoPinEdgeToSuperviewEdge:ALEdgeTop];
+    //    [self.myBubbleImageView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
 
     self.textView = [OWSMessageTextView new];
     self.textView.backgroundColor = [UIColor clearColor];
@@ -224,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.textView.textContainerInset = UIEdgeInsetsZero;
     self.textView.contentInset = UIEdgeInsetsZero;
     self.textView.scrollEnabled = NO;
-    [self.bubbleImageView addSubview:self.textView];
+    [self.myBubbleImageView addSubview:self.textView];
     OWSAssert(self.textView.superview);
 
     self.footerLabel = [UILabel new];
@@ -233,7 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.footerView addSubview:self.footerLabel];
 
     // Hide these views by default.
-    self.bubbleImageView.hidden = YES;
+    self.myBubbleImageView.hidden = YES;
     self.textView.hidden = YES;
     self.dateHeaderLabel.hidden = YES;
     self.footerLabel.hidden = YES;
@@ -245,10 +247,12 @@ NS_ASSUME_NONNULL_BEGIN
     [self.mediaMaskingView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
     [self.mediaMaskingView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
 
-    [self.textMaskingView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.mediaMaskingView];
-    [self.textMaskingView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
-    [self.textMaskingView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
-    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.textMaskingView];
+    [self.myBubbleImageView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.mediaMaskingView];
+    // want sized to fit...
+    //    [self.textMaskingView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+    //    [self.textMaskingView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
+    //    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.textMaskingView];
+    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.myBubbleImageView];
 
     [self.footerView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
     [self.footerView autoPinWidthToSuperview];
@@ -404,7 +408,7 @@ NS_ASSUME_NONNULL_BEGIN
         bubbleImageData = [self.bubbleFactory bubbleWithMessage:message];
     }
 
-    self.bubbleImageView.image = bubbleImageData.messageBubbleImage;
+    self.myBubbleImageView.image = bubbleImageData.messageBubbleImage;
 
     [self updateDateHeader];
     [self updateFooter];
@@ -741,6 +745,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray *accumulatedConstraints = [self.contentConstraints mutableCopy];
     [accumulatedConstraints addObjectsFromArray:@[
+        [self.myBubbleImageView autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeLeading : ALEdgeTrailing)],
         [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
         [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
         [self.textView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:attachmentView withOffset:self.textVMargin],
@@ -760,7 +765,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.tapForMoreLabel.font = [self tapForMoreFont];
         self.tapForMoreLabel.textColor = [self.textColor colorWithAlphaComponent:0.85];
         self.tapForMoreLabel.textAlignment = [self.tapForMoreLabel textAlignmentUnnatural];
-        [self.bubbleImageView addSubview:self.tapForMoreLabel];
+        [self.myBubbleImageView addSubview:self.tapForMoreLabel];
 
         self.contentConstraints = @[
             [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
@@ -785,10 +790,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadForTextDisplay
 {
-    self.bubbleImageView.hidden = NO;
+    self.myBubbleImageView.hidden = NO;
     self.textView.hidden = NO;
     self.textView.text = self.displayableText.displayText;
     self.textView.textColor = self.textColor;
+    [self.textView setCompressionResistanceHigh];
+    [self.textView setContentHuggingPriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+    [self.textView setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+
     // Honor dynamic type in the message bodies.
     self.textView.font = [self textMessageFont];
     self.textView.linkTextAttributes = @{
@@ -908,7 +917,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssert(view);
 
-    view.userInteractionEnabled = NO;
+    // FIXME why disable? make sure we can interact with both media and caption
+    //    view.userInteractionEnabled = NO;
     [self.mediaMaskingView addSubview:view];
     self.contentConstraints = [view autoPinToSuperviewEdges];
     [self cropMediaViewToBubbbleShape:view];
@@ -963,6 +973,23 @@ NS_ASSUME_NONNULL_BEGIN
     [self cropMediaViewToBubbbleShape:self.customView];
 }
 
+- (CGSize)textViewSizeForViewWidth:(int)viewWidth maxMessageWidth:(int)maxMessageWidth
+{
+    BOOL isRTL = self.isRTL;
+    CGFloat leftMargin = isRTL ? self.textTrailingMargin : self.textLeadingMargin;
+    CGFloat rightMargin = isRTL ? self.textLeadingMargin : self.textTrailingMargin;
+    CGFloat textVMargin = self.textVMargin;
+    const int maxTextWidth = (int)floor(maxMessageWidth - (leftMargin + rightMargin));
+
+    self.textView.text = self.displayableText.displayText;
+    // Honor dynamic type in the message bodies.
+    self.textView.font = [self textMessageFont];
+    CGSize textSize = [self.textView sizeThatFits:CGSizeMake(maxTextWidth, CGFLOAT_MAX)];
+    CGFloat tapForMoreHeight = (self.displayableText.isTextTruncated ? [self tapForMoreHeight] : 0.f);
+    return CGSizeMake((CGFloat)ceil(textSize.width + leftMargin + rightMargin),
+        (CGFloat)ceil(textSize.height + textVMargin * 2 + tapForMoreHeight));
+}
+
 - (CGSize)cellSizeForViewWidth:(int)viewWidth contentWidth:(int)contentWidth
 {
     OWSAssert(self.viewItem);
@@ -974,19 +1001,21 @@ NS_ASSUME_NONNULL_BEGIN
     CGSize textContentSize = CGSizeZero;
 
     if (self.viewItem.hasText) {
-        BOOL isRTL = self.isRTL;
-        CGFloat leftMargin = isRTL ? self.textTrailingMargin : self.textLeadingMargin;
-        CGFloat rightMargin = isRTL ? self.textLeadingMargin : self.textTrailingMargin;
-        CGFloat textVMargin = self.textVMargin;
-        const int maxTextWidth = (int)floor(maxMessageWidth - (leftMargin + rightMargin));
+        //        BOOL isRTL = self.isRTL;
+        //        CGFloat leftMargin = isRTL ? self.textTrailingMargin : self.textLeadingMargin;
+        //        CGFloat rightMargin = isRTL ? self.textLeadingMargin : self.textTrailingMargin;
+        //        CGFloat textVMargin = self.textVMargin;
+        //        const int maxTextWidth = (int)floor(maxMessageWidth - (leftMargin + rightMargin));
+        //
+        //        self.textView.text = self.displayableText.displayText;
+        //        // Honor dynamic type in the message bodies.
+        //        self.textView.font = [self textMessageFont];
+        //        CGSize textSize = [self.textView sizeThatFits:CGSizeMake(maxTextWidth, CGFLOAT_MAX)];
+        //        CGFloat tapForMoreHeight = (self.displayableText.isTextTruncated ? [self tapForMoreHeight] : 0.f);
+        //        textContentSize = CGSizeMake((CGFloat)ceil(textSize.width + leftMargin + rightMargin),
+        //            (CGFloat)ceil(textSize.height + textVMargin * 2 + tapForMoreHeight));
 
-        self.textView.text = self.displayableText.displayText;
-        // Honor dynamic type in the message bodies.
-        self.textView.font = [self textMessageFont];
-        CGSize textSize = [self.textView sizeThatFits:CGSizeMake(maxTextWidth, CGFLOAT_MAX)];
-        CGFloat tapForMoreHeight = (self.displayableText.isTextTruncated ? [self tapForMoreHeight] : 0.f);
-        textContentSize = CGSizeMake((CGFloat)ceil(textSize.width + leftMargin + rightMargin),
-            (CGFloat)ceil(textSize.height + textVMargin * 2 + tapForMoreHeight));
+        textContentSize = [self textViewSizeForViewWidth:viewWidth maxMessageWidth:maxMessageWidth];
     }
 
     switch (self.cellType) {
@@ -1136,11 +1165,11 @@ NS_ASSUME_NONNULL_BEGIN
     self.tapForMoreLabel = nil;
     self.footerLabel.text = nil;
     self.footerLabel.hidden = YES;
-    self.bubbleImageView.image = nil;
-    self.bubbleImageView.hidden = YES;
+    self.myBubbleImageView.image = nil;
+    self.myBubbleImageView.hidden = YES;
     //    self.payloadView.maskedSubview = nil;
     self.mediaMaskingView.maskedSubview = nil;
-    self.textMaskingView.maskedSubview = nil;
+    //    self.textMaskingView.maskedSubview = nil;
 
     [self.stillImageView removeFromSuperview];
     self.stillImageView = nil;

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -522,6 +522,9 @@ NS_ASSUME_NONNULL_BEGIN
 // cell is no longer visible.
 - (void)ensureViewMediaState
 {
+    CGSize mediaSize = [self mediaBubbleSizeForContentWidth:self.contentWidth];
+    [self.contentConstraints addObjectsFromArray:[self.mediaMaskingView autoSetDimensionsToSize:mediaSize]];
+
     if (!self.isCellVisible) {
         // Eagerly unload.
         self.stillImageView.image = nil;
@@ -781,6 +784,9 @@ NS_ASSUME_NONNULL_BEGIN
         self.textView.shouldIgnoreEvents = NO;
     }
 
+    OWSAssert(self.contentWidth);
+    CGSize textBubbleSize = [self textBubbleSizeForContentWidth:self.contentWidth];
+
     if (self.displayableText.isTextTruncated) {
         self.tapForMoreLabel = [UILabel new];
         self.tapForMoreLabel.text = NSLocalizedString(@"CONVERSATION_VIEW_OVERSIZE_TEXT_TAP_FOR_MORE",
@@ -791,6 +797,8 @@ NS_ASSUME_NONNULL_BEGIN
         [self.textBubbleImageView addSubview:self.tapForMoreLabel];
 
         [self.contentConstraints addObjectsFromArray:@[
+            [self.textBubbleImageView autoSetDimension:ALDimensionWidth toSize:textBubbleSize.width],
+            [self.textBubbleImageView autoSetDimension:ALDimensionHeight toSize:textBubbleSize.height],
             [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
             [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
             [self.textView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.textVMargin],
@@ -802,9 +810,6 @@ NS_ASSUME_NONNULL_BEGIN
             [self.tapForMoreLabel autoSetDimension:ALDimensionHeight toSize:self.tapForMoreHeight],
         ]];
     } else {
-        OWSAssert(self.contentWidth);
-        CGSize textBubbleSize = [self textBubbleSizeForContentWidth:self.contentWidth];
-
         [self.contentConstraints addObjectsFromArray:@[
             [self.textBubbleImageView autoSetDimension:ALDimensionWidth toSize:textBubbleSize.width],
             [self.textBubbleImageView autoSetDimension:ALDimensionHeight toSize:textBubbleSize.height],
@@ -934,12 +939,10 @@ NS_ASSUME_NONNULL_BEGIN
     view.userInteractionEnabled = NO;
     [self.mediaMaskingView addSubview:view];
 
-    CGSize mediaSize = [self mediaBubbleSizeForContentWidth:self.contentWidth];
-
     [self.contentConstraints
         addObject:[self.mediaMaskingView
                       autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeLeading : ALEdgeTrailing)]];
-    [self.contentConstraints addObjectsFromArray:[self.mediaMaskingView autoSetDimensionsToSize:mediaSize]];
+
     [self.contentConstraints addObjectsFromArray:[view autoPinEdgesToSuperviewMargins]];
 
     [self cropMediaViewToBubbbleShape:view];

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -65,7 +65,11 @@ NS_ASSUME_NONNULL_BEGIN
     // Since the caption has it's own tail, the media bubble just above
     // it looks better without a tail.
     if (self.hideTail) {
-        self.layoutMargins = UIEdgeInsetsMake(0, 0, 2, 8);
+        if (hasOutgoingMask) {
+            self.layoutMargins = UIEdgeInsetsMake(0, 0, 2, 8);
+        } else {
+            self.layoutMargins = UIEdgeInsetsMake(0, 8, 2, 0);
+        }
         maskedSubview.clipsToBounds = YES;
 
         // I arrived at this cornerRadius by superimposing the generated corner

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface BubbleMaskingView : UIView
 
 @property (nonatomic) BOOL isOutgoing;
-@property (nonatomic) BOOL hasCaption;
+@property (nonatomic) BOOL hideTail;
 @property (nonatomic, nullable, weak) UIView *maskedSubview;
 
 @end
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Since the caption has it's own tail, the media bubble looks better
     // without a tail.
-    if (self.hasCaption) {
+    if (self.hideTail) {
         self.layoutMargins = UIEdgeInsetsMake(0, 0, 2, 8);
         maskedSubview.clipsToBounds = YES;
         maskedSubview.layer.cornerRadius = 10;
@@ -149,15 +149,13 @@ NS_ASSUME_NONNULL_BEGIN
 // The nullable properties are created as needed.
 // The non-nullable properties are so frequently used that it's easier
 // to always keep one around.
-//@property (nonatomic) BubbleMaskingView *payloadView;
-@property (nonatomic) UIView *myPayloadView;
+@property (nonatomic) UIView *payloadView;
 @property (nonatomic) BubbleMaskingView *mediaMaskingView;
-//@property (nonatomic) BubbleMaskingView *textMaskingView;
 @property (nonatomic) UILabel *dateHeaderLabel;
 @property (nonatomic) OWSMessageTextView *textView;
 @property (nonatomic, nullable) UIImageView *failedSendBadgeView;
 @property (nonatomic, nullable) UILabel *tapForMoreLabel;
-@property (nonatomic, nullable) UIImageView *myBubbleImageView;
+@property (nonatomic, nullable) UIImageView *textBubbleImageView;
 @property (nonatomic, nullable) AttachmentUploadView *attachmentUploadView;
 @property (nonatomic, nullable) UIImageView *stillImageView;
 @property (nonatomic, nullable) YYAnimatedImageView *animatedImageView;
@@ -173,8 +171,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSMutableArray<NSLayoutConstraint *> *contentConstraints;
 @property (nonatomic, nullable) NSArray<NSLayoutConstraint *> *footerConstraints;
 @property (nonatomic) BOOL isPresentingMenuController;
-//@property (nonatomic) NSLayoutConstraint *textViewWidthConstraint;
-//@property (nonatomic) NSLayoutConstraint *textViewHeightConstraint;
 
 @end
 
@@ -199,21 +195,13 @@ NS_ASSUME_NONNULL_BEGIN
     self.layoutMargins = UIEdgeInsetsZero;
     self.contentView.layoutMargins = UIEdgeInsetsZero;
 
-    //    self.payloadView = [BubbleMaskingView new];
-    //    self.payloadView.layoutMargins = UIEdgeInsetsZero;
-    //    [self.contentView addSubview:self.payloadView];
-
-    self.myPayloadView = [UIView new];
-    self.myPayloadView.layoutMargins = UIEdgeInsetsZero;
-    [self.contentView addSubview:self.myPayloadView];
+    self.payloadView = [UIView new];
+    self.payloadView.layoutMargins = UIEdgeInsetsZero;
+    [self.contentView addSubview:self.payloadView];
 
     self.mediaMaskingView = [BubbleMaskingView new];
     self.mediaMaskingView.layoutMargins = UIEdgeInsetsZero;
-    [self.myPayloadView addSubview:self.mediaMaskingView];
-
-    //    self.textMaskingView = [BubbleMaskingView new];
-    //    self.textMaskingView.layoutMargins = UIEdgeInsetsZero;
-    //    [self.myPayloadView addSubview:self.textMaskingView];
+    [self.payloadView addSubview:self.mediaMaskingView];
 
     self.footerView = [UIView containerView];
     [self.contentView addSubview:self.footerView];
@@ -224,14 +212,12 @@ NS_ASSUME_NONNULL_BEGIN
     self.dateHeaderLabel.textColor = [UIColor lightGrayColor];
     [self.contentView addSubview:self.dateHeaderLabel];
 
-    self.myBubbleImageView = [UIImageView new];
-    self.myBubbleImageView.layoutMargins = UIEdgeInsetsZero;
+    self.textBubbleImageView = [UIImageView new];
+    self.textBubbleImageView.layoutMargins = UIEdgeInsetsZero;
     // Enable userInteractionEnabled so that links in textView work.
-    self.myBubbleImageView.userInteractionEnabled = YES;
-    //    [self.textMaskingView addSubview:self.bubbleImageView];
-    [self.myPayloadView addSubview:self.myBubbleImageView];
-    //    [self.myBubbleImageView autoPinEdgeToSuperviewEdge:ALEdgeTop];
-    //    [self.myBubbleImageView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
+    self.textBubbleImageView.userInteractionEnabled = YES;
+
+    [self.payloadView addSubview:self.textBubbleImageView];
 
     self.textView = [OWSMessageTextView new];
     self.textView.backgroundColor = [UIColor clearColor];
@@ -241,10 +227,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.textView.textContainerInset = UIEdgeInsetsZero;
     self.textView.contentInset = UIEdgeInsetsZero;
     self.textView.scrollEnabled = NO;
-    //    self.textViewWidthConstraint = [self.textView autoSetDimension:ALDimensionWidth toSize:0];
-    //    self.textViewHeightConstraint = [self.textView autoSetDimension:ALDimensionHeight toSize:0];
 
-    [self.myBubbleImageView addSubview:self.textView];
+    [self.textBubbleImageView addSubview:self.textView];
 
     OWSAssert(self.textView.superview);
 
@@ -254,26 +238,20 @@ NS_ASSUME_NONNULL_BEGIN
     [self.footerView addSubview:self.footerLabel];
 
     // Hide these views by default.
-    self.myBubbleImageView.hidden = YES;
+    self.textBubbleImageView.hidden = YES;
     self.textView.hidden = YES;
     self.dateHeaderLabel.hidden = YES;
     self.footerLabel.hidden = YES;
 
-    [self.myPayloadView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.dateHeaderLabel];
-    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.myPayloadView];
+    [self.payloadView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.dateHeaderLabel];
+    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.payloadView];
 
     [self.mediaMaskingView autoPinEdgeToSuperviewEdge:ALEdgeTop];
     [self.mediaMaskingView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
     [self.mediaMaskingView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
 
-    [self.myBubbleImageView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.mediaMaskingView];
-    [self.myBubbleImageView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
-
-    // want sized to fit...
-    //    [self.textMaskingView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
-    //    [self.textMaskingView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
-    //    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.textMaskingView];
-    //    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.myBubbleImageView];
+    [self.textBubbleImageView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.mediaMaskingView];
+    [self.textBubbleImageView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
 
     [self.footerView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
     [self.footerView autoPinWidthToSuperview];
@@ -412,15 +390,15 @@ NS_ASSUME_NONNULL_BEGIN
         [self.contentView addSubview:self.failedSendBadgeView];
 
         self.payloadConstraints = @[
-            [self.myPayloadView autoPinLeadingToSuperview],
-            [self.failedSendBadgeView autoPinLeadingToTrailingOfView:self.myPayloadView],
+            [self.payloadView autoPinLeadingToSuperview],
+            [self.failedSendBadgeView autoPinLeadingToTrailingOfView:self.payloadView],
             [self.failedSendBadgeView autoPinTrailingToSuperview],
-            [self.failedSendBadgeView autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.myPayloadView],
+            [self.failedSendBadgeView autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.payloadView],
             [self.failedSendBadgeView autoSetDimension:ALDimensionWidth toSize:self.failedSendBadgeSize],
             [self.failedSendBadgeView autoSetDimension:ALDimensionHeight toSize:self.failedSendBadgeSize],
         ];
     } else {
-        self.payloadConstraints = [self.myPayloadView autoPinWidthToSuperview];
+        self.payloadConstraints = [self.payloadView autoPinWidthToSuperview];
     }
 
     JSQMessagesBubbleImage *_Nullable bubbleImageData;
@@ -429,7 +407,7 @@ NS_ASSUME_NONNULL_BEGIN
         bubbleImageData = [self.bubbleFactory bubbleWithMessage:message];
     }
 
-    self.myBubbleImageView.image = bubbleImageData.messageBubbleImage;
+    self.textBubbleImageView.image = bubbleImageData.messageBubbleImage;
 
     [self updateDateHeader];
     [self updateFooter];
@@ -439,11 +417,11 @@ NS_ASSUME_NONNULL_BEGIN
             OWSFail(@"Unknown cell type for viewItem: %@", self.viewItem);
             break;
         case OWSMessageCellType_TextMessage:
-            [self loadForStandaloneTextDisplay];
+            [self loadForTextDisplay];
             break;
         case OWSMessageCellType_OversizeTextMessage:
             OWSAssert(self.viewItem.attachmentStream);
-            [self loadForStandaloneTextDisplay];
+            [self loadForTextDisplay];
             break;
         case OWSMessageCellType_StillImage:
             OWSAssert(self.viewItem.attachmentStream);
@@ -466,7 +444,7 @@ NS_ASSUME_NONNULL_BEGIN
             self.attachmentView =
                 [[OWSGenericAttachmentView alloc] initWithAttachment:self.attachmentStream isIncoming:self.isIncoming];
             [self.attachmentView createContents];
-            [self replaceBubbleWithView:self.attachmentView];
+            [self setMediaView:self.attachmentView];
             [self addAttachmentUploadViewIfNecessary:self.attachmentView];
             [self addCaptionIfNecessary];
             break;
@@ -757,101 +735,12 @@ NS_ASSUME_NONNULL_BEGIN
     return [UIFont systemFontOfSize:12.0f];
 }
 
-- (void)loadCaptionForAttachmentView
-{
-    [self loadForStandaloneTextDisplay];
-    return;
-    //    [self loadForTextDisplay];
-    //
-    //    NSMutableArray *accumulatedConstraints = [self.contentConstraints mutableCopy];
-    //    [accumulatedConstraints addObjectsFromArray:@[
-    //        [self.myBubbleImageView autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeLeading : ALEdgeTrailing)],
-    ////        [self.myBubbleImageView autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeTrailing :
-    /// ALEdgeLeading)withInset:0 /
-    /// relation:NSLayoutRelationGreaterThanOrEqual],
-    //        [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
-    //        [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
-    //        [self.textView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.textVMargin],
-    //        [self.textView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:self.textVMargin],
-    //    ]];
-    //
-    //    self.contentConstraints = [accumulatedConstraints copy];
-}
-
-- (void)loadForStandaloneTextDisplay
-{
-    [self loadForTextDisplay];
-
-    if (self.displayableText.isTextTruncated) {
-        self.tapForMoreLabel = [UILabel new];
-        self.tapForMoreLabel.text = NSLocalizedString(@"CONVERSATION_VIEW_OVERSIZE_TEXT_TAP_FOR_MORE",
-            @"Indicator on truncated text messages that they can be tapped to see the entire text message.");
-        self.tapForMoreLabel.font = [self tapForMoreFont];
-        self.tapForMoreLabel.textColor = [self.textColor colorWithAlphaComponent:0.85];
-        self.tapForMoreLabel.textAlignment = [self.tapForMoreLabel textAlignmentUnnatural];
-        [self.myBubbleImageView addSubview:self.tapForMoreLabel];
-
-        [self.contentConstraints addObjectsFromArray:@[
-            [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
-            [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
-            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.textVMargin],
-
-            [self.tapForMoreLabel autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
-            [self.tapForMoreLabel autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
-            [self.tapForMoreLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.textView],
-            [self.tapForMoreLabel autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:self.textVMargin],
-            [self.tapForMoreLabel autoSetDimension:ALDimensionHeight toSize:self.tapForMoreHeight],
-        ]];
-    } else {
-        //        __block NSLayoutConstraint *tryToGrow;
-        //
-        //        [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultLow forConstraints:^{
-        //            tryToGrow = [self.myBubbleImageView autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeTrailing :
-        //            ALEdgeLeading) withInset:0];
-        //        }];
-
-        OWSAssert(self.contentWidth);
-        CGSize textBubbleSize = [self textBubbleSizeForContentWidth:self.contentWidth];
-
-        [self.contentConstraints addObjectsFromArray:@[
-            [self.myBubbleImageView autoSetDimension:ALDimensionWidth toSize:textBubbleSize.width],
-            [self.myBubbleImageView autoSetDimension:ALDimensionHeight toSize:textBubbleSize.height],
-            [self.myBubbleImageView autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeLeading : ALEdgeTrailing)],
-            [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
-            [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
-            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.textVMargin],
-            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:self.textVMargin],
-        ]];
-
-
-        //        self.contentConstraints = @[
-        //            [self.myBubbleImageView autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeLeading :
-        //            ALEdgeTrailing)],
-        ////            [self.myBubbleImageView
-        ////                autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeTrailing : ALEdgeLeading)withInset:0
-        ////                                  relation:NSLayoutRelationGreaterThanOrEqual],
-        //
-        //            [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
-        //            [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
-        //            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.textVMargin],
-        //            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:self.textVMargin],
-        //        ];
-    }
-}
-
 - (void)loadForTextDisplay
 {
-    self.myBubbleImageView.hidden = NO;
+    self.textBubbleImageView.hidden = NO;
     self.textView.hidden = NO;
     self.textView.text = self.displayableText.displayText;
     self.textView.textColor = self.textColor;
-
-    //    [self.textView setCompressionResistanceHigh];
-    //    [self.textView setContentCompressionResistancePriority:UILayoutPriorityRequired
-    //    forAxis:UILayoutConstraintAxisHorizontal]; [self.textView
-    //    setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
-    //    [self.textView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
-    //    [self.textView setContentHuggingPriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisVertical];
 
     // Honor dynamic type in the message bodies.
     self.textView.font = [self textMessageFont];
@@ -870,6 +759,41 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         self.textView.shouldIgnoreEvents = NO;
     }
+
+    if (self.displayableText.isTextTruncated) {
+        self.tapForMoreLabel = [UILabel new];
+        self.tapForMoreLabel.text = NSLocalizedString(@"CONVERSATION_VIEW_OVERSIZE_TEXT_TAP_FOR_MORE",
+            @"Indicator on truncated text messages that they can be tapped to see the entire text message.");
+        self.tapForMoreLabel.font = [self tapForMoreFont];
+        self.tapForMoreLabel.textColor = [self.textColor colorWithAlphaComponent:0.85];
+        self.tapForMoreLabel.textAlignment = [self.tapForMoreLabel textAlignmentUnnatural];
+        [self.textBubbleImageView addSubview:self.tapForMoreLabel];
+
+        [self.contentConstraints addObjectsFromArray:@[
+            [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
+            [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
+            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.textVMargin],
+
+            [self.tapForMoreLabel autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
+            [self.tapForMoreLabel autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
+            [self.tapForMoreLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.textView],
+            [self.tapForMoreLabel autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:self.textVMargin],
+            [self.tapForMoreLabel autoSetDimension:ALDimensionHeight toSize:self.tapForMoreHeight],
+        ]];
+    } else {
+        OWSAssert(self.contentWidth);
+        CGSize textBubbleSize = [self textBubbleSizeForContentWidth:self.contentWidth];
+
+        [self.contentConstraints addObjectsFromArray:@[
+            [self.textBubbleImageView autoSetDimension:ALDimensionWidth toSize:textBubbleSize.width],
+            [self.textBubbleImageView autoSetDimension:ALDimensionHeight toSize:textBubbleSize.height],
+            [self.textBubbleImageView autoPinEdgeToSuperviewEdge:(self.isIncoming ? ALEdgeLeading : ALEdgeTrailing)],
+            [self.textView autoPinLeadingToSuperviewWithMargin:self.textLeadingMargin],
+            [self.textView autoPinTrailingToSuperviewWithMargin:self.textTrailingMargin],
+            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.textVMargin],
+            [self.textView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:self.textVMargin],
+        ]];
+    }
 }
 
 - (void)loadForStillImageDisplay
@@ -885,7 +809,7 @@ NS_ASSUME_NONNULL_BEGIN
     // some performance cost.
     self.stillImageView.layer.minificationFilter = kCAFilterTrilinear;
     self.stillImageView.layer.magnificationFilter = kCAFilterTrilinear;
-    [self replaceBubbleWithView:self.stillImageView];
+    [self setMediaView:self.stillImageView];
     [self addAttachmentUploadViewIfNecessary:self.stillImageView];
     [self addCaptionIfNecessary];
 }
@@ -899,7 +823,7 @@ NS_ASSUME_NONNULL_BEGIN
     // We need to specify a contentMode since the size of the image
     // might not match the aspect ratio of the view.
     self.animatedImageView.contentMode = UIViewContentModeScaleAspectFill;
-    [self replaceBubbleWithView:self.animatedImageView];
+    [self setMediaView:self.animatedImageView];
     [self addAttachmentUploadViewIfNecessary:self.animatedImageView];
     [self addCaptionIfNecessary];
 }
@@ -907,9 +831,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addCaptionIfNecessary
 {
     if (self.viewItem.hasText) {
-        [self loadCaptionForAttachmentView];
+        [self loadForTextDisplay];
     } else {
-        [self.contentConstraints addObject:[self.myBubbleImageView autoSetDimension:ALDimensionHeight toSize:0]];
+        [self.contentConstraints addObject:[self.textBubbleImageView autoSetDimension:ALDimensionHeight toSize:0]];
     }
 }
 
@@ -923,7 +847,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                    viewItem:self.viewItem];
     self.viewItem.lastAudioMessageView = self.audioMessageView;
     [self.audioMessageView createContents];
-    [self replaceBubbleWithView:self.audioMessageView];
+    [self setMediaView:self.audioMessageView];
     [self addAttachmentUploadViewIfNecessary:self.audioMessageView];
     [self addCaptionIfNecessary];
 }
@@ -941,7 +865,7 @@ NS_ASSUME_NONNULL_BEGIN
     // some performance cost.
     self.stillImageView.layer.minificationFilter = kCAFilterTrilinear;
     self.stillImageView.layer.magnificationFilter = kCAFilterTrilinear;
-    [self replaceBubbleWithView:self.stillImageView];
+    [self setMediaView:self.stillImageView];
 
     UIImage *videoPlayIcon = [UIImage imageNamed:@"play_button"];
     UIImageView *videoPlayButton = [[UIImageView alloc] initWithImage:videoPlayIcon];
@@ -972,7 +896,7 @@ NS_ASSUME_NONNULL_BEGIN
             self.customView.backgroundColor = [UIColor grayColor];
             break;
     }
-    [self replaceBubbleWithView:self.customView];
+    [self setMediaView:self.customView];
 
     self.attachmentPointerView =
         [[AttachmentPointerView alloc] initWithAttachmentPointer:self.attachmentPointer isIncoming:self.isIncoming];
@@ -982,12 +906,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self addCaptionIfNecessary];
 }
 
-- (void)replaceBubbleWithView:(UIView *)view
+- (void)setMediaView:(UIView *)view
 {
     OWSAssert(view);
 
-    // FIXME why disable? make sure we can interact with both media and caption
-    //    view.userInteractionEnabled = NO;
+    view.userInteractionEnabled = NO;
     [self.mediaMaskingView addSubview:view];
     [self.contentConstraints addObjectsFromArray:[view autoPinEdgesToSuperviewMargins]];
     [self cropMediaViewToBubbbleShape:view];
@@ -1025,7 +948,8 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert(view.superview == self.mediaMaskingView);
 
     self.mediaMaskingView.isOutgoing = self.isOutgoing;
-    self.mediaMaskingView.hasCaption = self.viewItem.hasText;
+    // Hide tail on attachments followed by a caption
+    self.mediaMaskingView.hideTail = self.viewItem.hasText;
     self.mediaMaskingView.maskedSubview = view;
     [self.mediaMaskingView updateMask];
 }
@@ -1038,7 +962,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.customView = [UIView new];
     self.customView.backgroundColor = [UIColor colorWithWhite:0.85f alpha:1.f];
     self.customView.userInteractionEnabled = NO;
-    [self.myPayloadView addSubview:self.customView];
+    [self.payloadView addSubview:self.customView];
     [self.contentConstraints addObjectsFromArray:[self.customView autoPinToSuperviewEdges]];
     [self cropMediaViewToBubbbleShape:self.customView];
 }
@@ -1061,9 +985,6 @@ NS_ASSUME_NONNULL_BEGIN
     CGSize textViewSize = CGSizeMake((CGFloat)ceil(textSize.width + leftMargin + rightMargin),
         (CGFloat)ceil(textSize.height + textVMargin * 2 + tapForMoreHeight));
 
-    //    self.textViewWidthConstraint.constant = textViewSize.width;
-    //    self.textViewHeightConstraint.constant = textViewSize.height;
-    //
     return textViewSize;
 }
 
@@ -1082,24 +1003,10 @@ NS_ASSUME_NONNULL_BEGIN
     CGSize textContentSize = CGSizeZero;
 
     if (self.viewItem.hasText) {
-        //        BOOL isRTL = self.isRTL;
-        //        CGFloat leftMargin = isRTL ? self.textTrailingMargin : self.textLeadingMargin;
-        //        CGFloat rightMargin = isRTL ? self.textLeadingMargin : self.textTrailingMargin;
-        //        CGFloat textVMargin = self.textVMargin;
-        //        const int maxTextWidth = (int)floor(maxMessageWidth - (leftMargin + rightMargin));
-        //
-        //        self.textView.text = self.displayableText.displayText;
-        //        // Honor dynamic type in the message bodies.
-        //        self.textView.font = [self textMessageFont];
-        //        CGSize textSize = [self.textView sizeThatFits:CGSizeMake(maxTextWidth, CGFLOAT_MAX)];
-        //        CGFloat tapForMoreHeight = (self.displayableText.isTextTruncated ? [self tapForMoreHeight] : 0.f);
-        //        textContentSize = CGSizeMake((CGFloat)ceil(textSize.width + leftMargin + rightMargin),
-        //            (CGFloat)ceil(textSize.height + textVMargin * 2 + tapForMoreHeight));
-
         textContentSize = [self textBubbleSizeForContentWidth:contentWidth];
     }
-
     switch (self.cellType) {
+        case OWSMessageCellType_Unknown:
         case OWSMessageCellType_TextMessage:
         case OWSMessageCellType_OversizeTextMessage: {
             break;
@@ -1240,20 +1147,16 @@ NS_ASSUME_NONNULL_BEGIN
     self.textView.text = nil;
     self.textView.hidden = YES;
     self.textView.dataDetectorTypes = UIDataDetectorTypeNone;
-    //    self.textViewWidthConstraint.constant = 0;
-    //    self.textViewHeightConstraint.constant = 0;
     [self.failedSendBadgeView removeFromSuperview];
     self.failedSendBadgeView = nil;
     [self.tapForMoreLabel removeFromSuperview];
     self.tapForMoreLabel = nil;
     self.footerLabel.text = nil;
     self.footerLabel.hidden = YES;
-    self.myBubbleImageView.image = nil;
-    self.myBubbleImageView.hidden = YES;
-    //    self.payloadView.maskedSubview = nil;
+    self.textBubbleImageView.image = nil;
+    self.textBubbleImageView.hidden = YES;
     self.mediaMaskingView.maskedSubview = nil;
-    self.mediaMaskingView.hasCaption = NO;
-    //    self.textMaskingView.maskedSubview = nil;
+    self.mediaMaskingView.hideTail = NO;
     self.mediaMaskingView.layoutMargins = UIEdgeInsetsZero;
 
     [self.stillImageView removeFromSuperview];

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -697,7 +697,7 @@ static void *kConversationInputTextViewObservingContext = &kConversationInputTex
 {
     if (context == kConversationInputTextViewObservingContext) {
 
-        if (object == self.inputTextView && [keyPath isEqualToString:NSStringFromSelector(@selector(mediaSize))]) {
+        if (object == self.inputTextView && [keyPath isEqualToString:NSStringFromSelector(@selector(contentSize))]) {
             CGSize textContentSize = self.inputTextView.contentSize;
             NSValue *_Nullable lastTextContentSize = self.lastTextContentSize;
             self.lastTextContentSize = [NSValue valueWithCGSize:textContentSize];

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -123,7 +123,6 @@ static void *kConversationInputTextViewObservingContext = &kConversationInputTex
         setTitle:NSLocalizedString(@"SEND_BUTTON_TITLE", @"Label for the send button in the conversation view.")
         forState:UIControlStateNormal];
     [self.sendButton setTitleColor:[UIColor ows_materialBlueColor] forState:UIControlStateNormal];
-    self.sendButton.titleLabel.font = [UIFont ows_regularFontWithSize:17.0f];
     self.sendButton.titleLabel.textAlignment = NSTextAlignmentCenter;
     self.sendButton.titleLabel.font = [UIFont ows_mediumFontWithSize:16.f];
     [self.sendButton addTarget:self action:@selector(sendButtonPressed) forControlEvents:UIControlEventTouchUpInside];

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -697,7 +697,7 @@ static void *kConversationInputTextViewObservingContext = &kConversationInputTex
 {
     if (context == kConversationInputTextViewObservingContext) {
 
-        if (object == self.inputTextView && [keyPath isEqualToString:NSStringFromSelector(@selector(contentSize))]) {
+        if (object == self.inputTextView && [keyPath isEqualToString:NSStringFromSelector(@selector(mediaSize))]) {
             CGSize textContentSize = self.inputTextView.contentSize;
             NSValue *_Nullable lastTextContentSize = self.lastTextContentSize;
             self.lastTextContentSize = [NSValue valueWithCGSize:textContentSize];

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.h
@@ -90,11 +90,15 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);
 
 #pragma mark - UIMenuController
 
-- (NSArray<UIMenuItem *> *)menuControllerItems;
+- (NSArray<UIMenuItem *> *)textMenuControllerItems;
+- (NSArray<UIMenuItem *> *)mediaMenuControllerItems;
+
 - (BOOL)canPerformAction:(SEL)action;
-- (void)copyAction;
-- (void)shareAction;
-- (void)saveAction;
+- (void)copyMediaAction;
+- (void)copyTextAction;
+- (void)shareMediaAction;
+- (void)shareTextAction;
+- (void)saveMediaAction;
 - (void)deleteAction;
 - (SEL)metadataActionSelector;
 

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.h
@@ -8,6 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, OWSMessageCellType) {
+    OWSMessageCellType_Unknown,
     OWSMessageCellType_TextMessage,
     OWSMessageCellType_OversizeTextMessage,
     OWSMessageCellType_StillImage,
@@ -16,8 +17,6 @@ typedef NS_ENUM(NSInteger, OWSMessageCellType) {
     OWSMessageCellType_Video,
     OWSMessageCellType_GenericAttachment,
     OWSMessageCellType_DownloadingAttachment,
-    // Treat invalid messages as empty text messages.
-    OWSMessageCellType_Unknown = OWSMessageCellType_TextMessage,
 };
 
 NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);
@@ -44,7 +43,7 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);
 @property (nonatomic, readonly) TSInteraction *interaction;
 
 @property (nonatomic, readonly) BOOL isGroupThread;
-
+@property (nonatomic, readonly) BOOL hasText;
 @property (nonatomic) BOOL shouldShowDate;
 @property (nonatomic) BOOL shouldHideRecipientStatus;
 
@@ -83,7 +82,7 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);
 - (nullable DisplayableText *)displayableText;
 - (nullable TSAttachmentStream *)attachmentStream;
 - (nullable TSAttachmentPointer *)attachmentPointer;
-- (CGSize)contentSize;
+- (CGSize)mediaSize;
 
 // We don't want to try to load the media for this item (if any)
 // if a load has previously failed.

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
@@ -377,6 +377,7 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
                 self.messageCellType = OWSMessageCellType_OversizeTextMessage;
                 self.displayableText =
                     [self displayableTextForAttachmentStream:self.attachmentStream interactionId:message.uniqueId];
+                self.hasText = YES;
             } else if ([self.attachmentStream isAnimated] || [self.attachmentStream isImage] ||
                 [self.attachmentStream isVideo]) {
                 if ([self.attachmentStream isAnimated]) {

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
@@ -492,12 +492,12 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
         [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_MESSAGE_METADATA_ACTION",
                                               @"Short name for edit menu item to show message metadata.")
                                    action:self.metadataActionSelector],
-        // FIXME this is going to be confusing if the text/attachment look like separate entities.
-        // we can re-enable this once it's clear that deleting the text would also delete the attachment.
-        //        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_DELETE_ACTION",
-        //                                              @"Short name for edit menu item to delete contents of media
-        //                                              message.")
-        //                                   action:self.deleteActionSelector],
+        // FIXME: when deleting a caption, users will be surprised that it also deletes the attachment.
+        // We either need to implement a way to remove the caption separate from the attachment
+        // or make a design change which clarifies that the whole message is getting deleted.
+        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_DELETE_ACTION",
+                                                            @"Short name for edit menu item to delete contents of media message.")
+                                                            action:self.deleteActionSelector]
     ];
 }
 - (NSArray<UIMenuItem *> *)mediaMenuControllerItems

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ConversationViewLayout ()
 
-@property (nonatomic) CGSize contentSize;
+@property (nonatomic) CGSize mediaSize;
 
 @property (nonatomic, readonly) NSMutableDictionary<NSNumber *, UICollectionViewLayoutAttributes *> *itemAttributesMap;
 
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearState
 {
-    self.contentSize = CGSizeZero;
+    self.mediaSize = CGSizeZero;
     [self.itemAttributesMap removeAllObjects];
     self.hasLayout = NO;
 }
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     contentBottom += vInset;
-    self.contentSize = CGSizeMake(viewWidth, contentBottom);
+    self.mediaSize = CGSizeMake(viewWidth, contentBottom);
 }
 
 - (nullable NSArray<__kindof UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect
@@ -158,7 +158,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGSize)collectionViewContentSize
 {
-    return self.contentSize;
+    return self.mediaSize;
 }
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ConversationViewLayout ()
 
-@property (nonatomic) CGSize mediaSize;
+@property (nonatomic) CGSize contentSize;
 
 @property (nonatomic, readonly) NSMutableDictionary<NSNumber *, UICollectionViewLayoutAttributes *> *itemAttributesMap;
 
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearState
 {
-    self.mediaSize = CGSizeZero;
+    self.contentSize = CGSizeZero;
     [self.itemAttributesMap removeAllObjects];
     self.hasLayout = NO;
 }
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     contentBottom += vInset;
-    self.mediaSize = CGSizeMake(viewWidth, contentBottom);
+    self.contentSize = CGSizeMake(viewWidth, contentBottom);
 }
 
 - (nullable NSArray<__kindof UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect
@@ -158,7 +158,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGSize)collectionViewContentSize
 {
-    return self.mediaSize;
+    return self.contentSize;
 }
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
@@ -1012,6 +1012,7 @@ NS_ASSUME_NONNULL_BEGIN
                 TSOutgoingMessage *message =
                     [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                         inThread:thread
+                                                     messageBody:nil
                                                   isVoiceMessage:NO
                                                 expiresInSeconds:0];
                 DDLogError(@"%@ sendFakeMessages outgoing attachment timestamp: %llu.", self.logTag, message.timestamp);
@@ -1049,6 +1050,7 @@ NS_ASSUME_NONNULL_BEGIN
         YapDatabaseReadWriteTransaction *transaction) {
         TSOutgoingMessage *message = [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                                                          inThread:thread
+                                                                      messageBody:nil
                                                                    isVoiceMessage:NO
                                                                  expiresInSeconds:0];
         DDLogError(@"%@ sendFakeMessages outgoing attachment timestamp: %llu.", self.logTag, message.timestamp);

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
@@ -668,8 +668,9 @@ NS_ASSUME_NONNULL_BEGIN
     OWSMessageSender *messageSender = [Environment current].messageSender;
     DataSource *_Nullable dataSource =
         [DataSourceValue dataSourceWithData:[self createRandomNSDataOfSize:length] utiType:uti];
-    SignalAttachment *attachment = [SignalAttachment attachmentWithDataSource:dataSource dataUTI:uti];
-    
+    SignalAttachment *attachment =
+        [SignalAttachment attachmentWithDataSource:dataSource dataUTI:uti imageQuality:TSImageQualityOriginal];
+
     if (arc4random_uniform(100) > 50) {
         // give 1/2 our attachments captions, and add a hint that it's a caption since we style them indistinguishably
         // from a separate text message.

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
@@ -378,7 +378,12 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *utiType = [MIMETypeUtil utiTypeForFileExtension:filename.pathExtension];
     DataSource *_Nullable dataSource = [DataSourcePath dataSourceWithFilePath:filePath];
     [dataSource setSourceFilename:filename];
-    SignalAttachment *attachment = [SignalAttachment attachmentWithDataSource:dataSource dataUTI:utiType];
+    SignalAttachment *attachment =
+        [SignalAttachment attachmentWithDataSource:dataSource dataUTI:utiType imageQuality:TSImageQualityOriginal];
+    if (arc4random_uniform(100) > 50) {
+        attachment.captionText = [self randomCaptionText];
+    }
+
     OWSAssert(attachment);
     if ([attachment hasError]) {
         DDLogError(@"attachment[%@]: %@", [attachment sourceFilename], [attachment errorName]);
@@ -663,6 +668,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self sendRandomAttachment:thread uti:uti length:256];
 }
 
++ (NSString *)randomCaptionText
+{
+    return [NSString stringWithFormat:@"%@ (caption)", [self randomText]];
+}
+
 + (void)sendRandomAttachment:(TSThread *)thread uti:(NSString *)uti length:(NSUInteger)length
 {
     OWSMessageSender *messageSender = [Environment current].messageSender;
@@ -672,9 +682,9 @@ NS_ASSUME_NONNULL_BEGIN
         [SignalAttachment attachmentWithDataSource:dataSource dataUTI:uti imageQuality:TSImageQualityOriginal];
 
     if (arc4random_uniform(100) > 50) {
-        // give 1/2 our attachments captions, and add a hint that it's a caption since we style them indistinguishably
-        // from a separate text message.
-        attachment.captionText = [NSString stringWithFormat:@"%@ (caption)", [self randomText]];
+        // give 1/2 our attachments captions, and add a hint that it's a caption since we
+        // style them indistinguishably from a separate text message.
+        attachment.captionText = [self randomCaptionText];
     }
     [ThreadUtil sendMessageWithAttachment:attachment inThread:thread messageSender:messageSender ignoreErrors:YES];
 }

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
@@ -669,6 +669,12 @@ NS_ASSUME_NONNULL_BEGIN
     DataSource *_Nullable dataSource =
         [DataSourceValue dataSourceWithData:[self createRandomNSDataOfSize:length] utiType:uti];
     SignalAttachment *attachment = [SignalAttachment attachmentWithDataSource:dataSource dataUTI:uti];
+    
+    if (arc4random_uniform(100) > 50) {
+        // give 1/2 our attachments captions, and add a hint that it's a caption since we style them indistinguishably
+        // from a separate text message.
+        attachment.captionText = [NSString stringWithFormat:@"%@ (caption)", [self randomText]];
+    }
     [ThreadUtil sendMessageWithAttachment:attachment inThread:thread messageSender:messageSender ignoreErrors:YES];
 }
 + (OWSSignalServiceProtosEnvelope *)createEnvelopeForThread:(TSThread *)thread

--- a/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
+++ b/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
@@ -94,7 +94,7 @@ private class IntroductingReadReceiptsExperienceUpgradeViewController: Experienc
         let button = MultiLineButton()
         view.addSubview(button)
         button.setTitle(title, for: .normal)
-        button.setTitleColor(UIColor.ows_signalBrandBlue(), for: .normal)
+        button.setTitleColor(UIColor.ows_signalBrandBlue, for: .normal)
         button.isUserInteractionEnabled = true
         button.addTarget(self, action:#selector(didTapButton), for: .touchUpInside)
         button.contentEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
@@ -198,7 +198,7 @@ private class IntroductingProfilesExperienceUpgradeViewController: ExperienceUpg
         let buttonTitle = NSLocalizedString("UPGRADE_EXPERIENCE_INTRODUCING_PROFILES_BUTTON", comment: "button label shown one time, after user upgrades app")
         button.setTitle(buttonTitle, for: .normal)
         button.setTitleColor(UIColor.white, for: .normal)
-        button.backgroundColor = UIColor.ows_materialBlue()
+        button.backgroundColor = UIColor.ows_materialBlue
 
         button.isUserInteractionEnabled = true
         button.addTarget(self, action:#selector(didTapButton), for: .touchUpInside)
@@ -259,7 +259,7 @@ private class CallKitExperienceUpgradeViewController: ExperienceUpgradeViewContr
         view.addSubview(privacySettingsButton)
         let privacyTitle = NSLocalizedString("UPGRADE_EXPERIENCE_CALLKIT_PRIVACY_SETTINGS_BUTTON", comment: "button label shown once when when user upgrades app, in context of call kit")
         privacySettingsButton.setTitle(privacyTitle, for: .normal)
-        privacySettingsButton.setTitleColor(UIColor.ows_signalBrandBlue(), for: .normal)
+        privacySettingsButton.setTitleColor(UIColor.ows_signalBrandBlue, for: .normal)
         privacySettingsButton.isUserInteractionEnabled = true
         privacySettingsButton.addTarget(self, action:#selector(didTapPrivacySettingsButton), for: .touchUpInside)
         privacySettingsButton.titleLabel?.font = bodyLabel.font
@@ -368,7 +368,7 @@ func setPageControlAppearance() {
     if #available(iOS 9.0, *) {
         let pageControl = UIPageControl.appearance(whenContainedInInstancesOf: [UIPageViewController.self])
         pageControl.pageIndicatorTintColor = UIColor.lightGray
-        pageControl.currentPageIndicatorTintColor = UIColor.ows_materialBlue()
+        pageControl.currentPageIndicatorTintColor = UIColor.ows_materialBlue
     } else {
         // iOS8 won't see the page controls =(
     }
@@ -429,13 +429,13 @@ class ExperienceUpgradesPageViewController: OWSViewController, UIPageViewControl
         // Header Background
         let headerBackgroundView = UIView()
         view.addSubview(headerBackgroundView)
-        headerBackgroundView.backgroundColor = UIColor.ows_materialBlue()
+        headerBackgroundView.backgroundColor = UIColor.ows_materialBlue
 
         // Dismiss button
         let dismissButton = UIButton()
         view.addSubview(dismissButton)
         dismissButton.setTitle(CommonStrings.dismissButton, for: .normal)
-        dismissButton.setTitleColor(UIColor.ows_signalBrandBlue(), for: .normal)
+        dismissButton.setTitleColor(UIColor.ows_signalBrandBlue, for: .normal)
         dismissButton.isUserInteractionEnabled = true
         dismissButton.addTarget(self, action:#selector(didTapDismissButton), for: .touchUpInside)
         dismissButton.titleLabel?.font = UIFont.ows_mediumFont(withSize: ScaleFromIPhone5(16))

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -305,9 +305,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
     }
 
     private func displayableTextIfText() -> String? {
-        let messageCellType = viewItem.messageCellType()
-        guard messageCellType == .textMessage ||
-            messageCellType == .oversizeTextMessage else {
+        guard viewItem.hasText else {
                 return nil
         }
         guard let displayableText = viewItem.displayableText() else {
@@ -327,6 +325,10 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
     private func contentRows() -> [UIView] {
         var rows = [UIView]()
 
+        if message.attachmentIds.count > 0 {
+            rows += addAttachmentRows()
+        }
+
         if let messageBody = displayableTextIfText() {
 
             self.messageBody = messageBody
@@ -334,10 +336,10 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
             let isIncoming = self.message as? TSIncomingMessage != nil
 
             // UITextView can't render extremely long text due to constraints
-            // on the size of its backing buffer, especially when we're 
+            // on the size of its backing buffer, especially when we're
             // embedding it "full-size' within a UIScrollView as we do in this view.
             //
-            // Therefore we're doing something unusual here.  
+            // Therefore we're doing something unusual here.
             // See comments on updateTextLayout.
             let messageTextView = UITextView()
             self.messageTextView = messageTextView
@@ -382,9 +384,9 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
             bubbleView.autoPinEdge(toSuperviewEdge: isIncoming ? .leading : .trailing, withInset: bubbleViewHMargin)
             self.bubbleViewWidthConstraint = bubbleView.autoSetDimension(.width, toSize:0)
             rows.append(row)
-        } else if message.attachmentIds.count > 0 {
-            rows += addAttachmentRows()
-        } else {
+        }
+
+        if rows.count == 0 {
             // Neither attachment nor body.
             owsFail("\(self.TAG) Message has neither attachment nor body.")
             rows.append(valueRow(name: NSLocalizedString("MESSAGE_METADATA_VIEW_NO_ATTACHMENT_OR_BODY",

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -434,7 +434,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
 
         let contentType = attachment.contentType
         if let dataUTI = MIMETypeUtil.utiType(forMIMEType: contentType) {
-            let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: dataUTI)
+            let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: dataUTI, imageQuality: .original)
             let mediaMessageView = MediaMessageView(attachment: attachment, mode: .small)
             mediaMessageView.backgroundColor = UIColor.white
             self.mediaMessageView = mediaMessageView

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -300,7 +300,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
         }
 
         if let mediaMessageView = mediaMessageView {
-            mediaMessageView.autoPinToSquareAspectRatio()
+            mediaMessageView.autoMatch(.height, to: .width, of: mediaMessageView, withOffset:0, relation: .lessThanOrEqual)
         }
     }
 

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -150,7 +150,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
 
         if hasMediaAttachment {
             let footer = UIToolbar()
-            footer.barTintColor = UIColor.ows_materialBlue()
+            footer.barTintColor = UIColor.ows_materialBlue
             view.addSubview(footer)
             footer.autoPinWidthToSuperview(withMargin: 0)
             footer.autoPinEdge(.top, to: .bottom, of: scrollView)
@@ -239,7 +239,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
                     cell.configure(withRecipientId: recipientId, contactsManager: self.contactsManager)
                     let statusLabel = UILabel()
                     statusLabel.text = statusMessage
-                    statusLabel.textColor = UIColor.ows_darkGray()
+                    statusLabel.textColor = UIColor.ows_darkGray
                     statusLabel.font = UIFont.ows_footnote()
                     statusLabel.sizeToFit()
                     cell.accessoryView = statusLabel
@@ -530,7 +530,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate {
 
         if subtitle.count > 0 {
             let subtitleLabel = self.valueLabel(text: subtitle)
-            subtitleLabel.textColor = UIColor.ows_darkGray()
+            subtitleLabel.textColor = UIColor.ows_darkGray
             row.addSubview(subtitleLabel)
             subtitleLabel.autoPinTrailingToSuperview()
             subtitleLabel.autoPinLeading(toTrailingOf: nameLabel, margin: 10)

--- a/Signal/src/ViewControllers/ModalActivityIndicatorViewController.swift
+++ b/Signal/src/ViewControllers/ModalActivityIndicatorViewController.swift
@@ -79,7 +79,7 @@ class ModalActivityIndicatorViewController: OWSViewController {
             let cancelButton = UIButton(type:.custom)
             cancelButton.setTitle(CommonStrings.cancelButton, for: .normal)
             cancelButton.setTitleColor(UIColor.white, for: .normal)
-            cancelButton.backgroundColor = UIColor.ows_darkGray()
+            cancelButton.backgroundColor = UIColor.ows_darkGray
             cancelButton.titleLabel?.font = UIFont.ows_mediumFont(withSize:ScaleFromIPhone5To7Plus(18, 22))
             cancelButton.layer.cornerRadius = ScaleFromIPhone5To7Plus(4, 5)
             cancelButton.clipsToBounds = true

--- a/Signal/src/views/GroupTableViewCell.swift
+++ b/Signal/src/views/GroupTableViewCell.swift
@@ -26,7 +26,7 @@ import SignalServiceKit
         // Font config
         nameLabel.font = UIFont.ows_dynamicTypeBody()
         subtitleLabel.font = UIFont.ows_footnote()
-        subtitleLabel.textColor = UIColor.ows_darkGray()
+        subtitleLabel.textColor = UIColor.ows_darkGray
 
         // Listen to notifications...
         // TODO avatar, group name change, group membership change, group member name change

--- a/Signal/src/views/ReminderView.swift
+++ b/Signal/src/views/ReminderView.swift
@@ -48,7 +48,7 @@ class ReminderView: UIView {
     }
 
     func setupSubviews() {
-        self.backgroundColor = UIColor.ows_reminderYellow()
+        self.backgroundColor = UIColor.ows_reminderYellow
         self.clipsToBounds = true
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(gestureRecognizer:)))

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -211,15 +211,15 @@ public class AttachmentApprovalViewController: OWSViewController, MessagingToolb
 
     // MARK: MessagingToolbarDelegate
 
-    func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar) {
-        self.sendAttachment()
+    func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar, captionText: String?) {
+        self.sendAttachment(captionText: captionText)
     }
 
     func messagingToolbar(_ messagingToolbar: MessagingToolbar, didChangeHeight newHeight: CGFloat) {
         self.scrollView.contentInset.bottom = newHeight
     }
 
-    func sendAttachment() {
+    func sendAttachment(captionText: String?) {
         // disable controls after send was tapped.
         self.bottomToolbar.isUserInteractionEnabled = false
 
@@ -231,6 +231,7 @@ public class AttachmentApprovalViewController: OWSViewController, MessagingToolb
         activityIndicatorView.autoCenterInSuperview()
         activityIndicatorView.startAnimating()
 
+        attachment.captionText = captionText
         self.delegate?.didApproveAttachment(attachment: attachment)
     }
 }
@@ -325,7 +326,7 @@ private class GradientView: UIView {
 }
 
 protocol MessagingToolbarDelegate: class {
-    func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar)
+    func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar, captionText: String?)
     func messagingToolbar(_ messagingToolbar: MessagingToolbar, didChangeHeight newHeight: CGFloat)
 }
 
@@ -397,7 +398,7 @@ class MessagingToolbar: UIView, UITextViewDelegate {
     }
 
     func didTapSend() {
-        self.messagingToolbarDelegate?.messagingToolbarDidTapSend(self)
+        self.messagingToolbarDelegate?.messagingToolbarDidTapSend(self, captionText: self.textView.text)
     }
 
     // MARK: - UITextViewDelegate

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -366,6 +366,7 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
         }
     }
 
+    let kSendButtonShadowOffset: CGFloat = 1
     init() {
         self.textView =  MessageTextView()
         self.sendButton = UIButton(type: .system)
@@ -389,8 +390,15 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
         sendButton.titleLabel?.font = UIFont.ows_mediumFont(withSize: 16)
         sendButton.titleLabel?.textAlignment = .center
         sendButton.tintColor = UIColor.white
-        sendButton.backgroundColor = UIColor.ows_materialBlue()
+        sendButton.backgroundColor = UIColor.ows_systemPrimaryButton
         sendButton.layer.cornerRadius = 4
+
+        // Send Button Shadow - without this the send button bottom doesn't align with the toolbar.
+        sendButton.layer.shadowColor = UIColor.darkGray.cgColor
+        sendButton.layer.shadowOffset = CGSize(width: 0, height: kSendButtonShadowOffset)
+        sendButton.layer.shadowOpacity = 0.8
+        sendButton.layer.shadowRadius = 0.0
+        sendButton.layer.masksToBounds = false
 
         // Increase hit area of send button
         sendButton.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 6, right: 8)
@@ -438,7 +446,7 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
 
         // position in bottom right corner
         let sendButtonX = frame.size.width - kToolbarMargin - sendButton.frame.size.width
-        let sendButtonY = frame.size.height - kToolbarMargin - sendButton.frame.size.height
+        let sendButtonY = frame.size.height - kToolbarMargin - sendButton.frame.size.height - kSendButtonShadowOffset
         sendButton.frame = CGRect(origin: CGPoint(x: sendButtonX, y: sendButtonY), size: sendButton.frame.size)
 
         Logger.debug("After layout >>> self: \(self.frame) textView: \(self.textView.frame), sendButton:\(sendButton.frame)")

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -245,7 +245,7 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
             super.init(frame: CGRect.zero)
 
             let kToolbarMargin: CGFloat = 4
-            let kSendButtonWidth: CGFloat = 40
+            let kSendButtonWidth: CGFloat = 80
             let kMinToolbarHeight: CGFloat = 40
 
             self.backgroundColor = UIColor.ows_inputToolbarBackground()
@@ -256,7 +256,7 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
 
             let textViewItem = UIBarButtonItem(customView: textView)
             // TODO is this necessary?
-            textView.translatesAutoresizingMaskIntoConstraints = false
+//            textView.translatesAutoresizingMaskIntoConstraints = false
 
             let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
 
@@ -280,7 +280,7 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
             textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
             textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
 
-            let kTrailingOffset: CGFloat = kSendButtonWidth + kToolbarMargin * 2
+            let kTrailingOffset: CGFloat = kSendButtonWidth
             textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
             textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
 
@@ -291,22 +291,22 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
 
         public func textViewDidChange(_ textView: UITextView) {
             Logger.debug("\(self.logTag) in \(#function)")
-            //        CGFloat fixedWidth = textView.frame.size.width;
-            //        CGSize newSize = [textView sizeThatFits:CGSizeMake(fixedWidth, MAXFLOAT)];
-            //        CGRect newFrame = textView.frame;
-            //        newFrame.size = CGSizeMake(fmaxf(newSize.width, fixedWidth), newSize.height);
-            //        textView.frame = newFrame;
+            let kMaxTextViewHeight: CGFloat = 160
+
             let fixedWidth = textView.frame.size.width
             let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-            //        let newFrame = CGRect(x: textView.frame.origin.x, y: textView.frame.origin.y, width: fixedWidth, height: newSize.height)
-            //        Logger.debug("\(self.logTag) oldFrame: \(textView.frame), newFrame: \(newFrame)")
 
-            Logger.debug("\(self.logTag) oldHeight: \(self.textViewHeightConstraint.constant), newHeight: \(newSize.height)")
-            // TODO clamp to a max, only when changed
-            self.textViewHeightConstraint.constant = max(MessagingToolbar.kMinTextViewHeight, newSize.height)
-            setNeedsLayout()
-            layoutIfNeeded()
-            //        textView.frame = newFrame
+            let newHeight = Clamp(newSize.height, MessagingToolbar.kMinTextViewHeight, kMaxTextViewHeight)
+            if newHeight != self.textViewHeightConstraint.constant {
+                Logger.debug("\(self.logTag) oldHeight: \(self.textViewHeightConstraint.constant), newHeight: \(newHeight)")
+                self.textViewHeightConstraint.constant = max(MessagingToolbar.kMinTextViewHeight, newHeight)
+                UIView.animate(withDuration: 0.1) {
+                    self.setNeedsLayout()
+                    self.layoutIfNeeded()
+                }
+            } else {
+                Logger.debug("\(self.logTag) height unchanged: \(self.textViewHeightConstraint.constant)")
+            }
         }
 
 //        override func layoutSubviews() {

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -24,7 +24,7 @@ public class AttachmentApprovalViewController: OWSViewController {
     private(set) var bottomToolbar: UIView!
     private(set) var mediaMessageView: MediaMessageView!
     private(set) var scrollView: UIScrollView!
-    private var textField: UITextField!
+    private var textView: UITextView!
 
     // MARK: Initializers
 
@@ -173,10 +173,15 @@ public class AttachmentApprovalViewController: OWSViewController {
         // Bottom Toolbar
         let bottomToolbar: UIToolbar = makeClearToolbar()
         self.bottomToolbar = bottomToolbar
-        self.textField = UITextField()
-        let textFieldItem = UIBarButtonItem(customView: textField)
-        //        textField.autoresizingMask = [.flexibleWidth, .flexibleHeight];
-        textField.translatesAutoresizingMaskIntoConstraints = false
+        self.textView = UITextView()
+        self.textView.backgroundColor = UIColor.white
+        self.textView.layer.cornerRadius = 4.0
+        
+        textView.autoSetDimensions(to: CGSize(width: 200, height: 40))
+        
+        let textViewItem = UIBarButtonItem(customView: textView)
+        //        textView.autoresizingMask = [.flexibleWidth, .flexibleHeight];
+        textView.translatesAutoresizingMaskIntoConstraints = false
 
         let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
         let sendButton = UIBarButtonItem(title:  sendTitle,
@@ -186,11 +191,20 @@ public class AttachmentApprovalViewController: OWSViewController {
         sendButton.tintColor = UIColor.white
 
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        bottomToolbar.items = [textFieldItem, sendButton]
+        bottomToolbar.items = [textViewItem, sendButton]
 //        bottomToolbar.items = [flexibleSpace, sendButton]
         bottomToolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
-        bottomToolbar.backgroundColor = UIColor.clear
+//        bottomToolbar.backgroundColor = UIColor.clear
+        bottomToolbar.backgroundColor = UIColor.yellow
         bottomToolbar.autoSetDimension(.height, toSize: 40)
+        
+        let kToolbarMargin: CGFloat = 4.0
+        textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
+        textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
+        // TODO get actualy offset based on button size.
+        let kTrailingOffset: CGFloat = 80
+        textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
+        textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
 
 //        self.bottomToolbar = MessagingToolbar()
         // Making a toolbar transparent requires setting an empty uiimage
@@ -212,26 +226,26 @@ public class AttachmentApprovalViewController: OWSViewController {
 
     class MessagingToolbar: UIToolbar {
         let sendButton: UIButton
-        let textField: UITextField
+        let textView: UITextView
 
         init() {
             self.sendButton = UIButton(type: .system)
             self.sendButton.setTitle("Send", for: .normal)
             self.sendButton.tintColor = UIColor.white
 
-            self.textField = UITextField()
-            textField.backgroundColor = UIColor.white
-            textField.layer.cornerRadius = 2.0
+            self.textView = UITextView()
+            textView.backgroundColor = UIColor.white
+            textView.layer.cornerRadius = 2.0
             super.init(frame: CGRect.zero)
 
             backgroundColor = UIColor.green
 
             addSubview(sendButton)
-            addSubview(textField)
+            addSubview(textView)
 
-//            textField.autoPinEdge(toSuperviewEdge: .leading, withInset: 4.0)
-//            textField.autoPinEdge(.trailing, to: .leading, of: sendButton, withOffset: -4.0)
-//            textField.autoPinHeightToSuperview(withMargin: 2.0)
+//            textView.autoPinEdge(toSuperviewEdge: .leading, withInset: 4.0)
+//            textView.autoPinEdge(.trailing, to: .leading, of: sendButton, withOffset: -4.0)
+//            textView.autoPinHeightToSuperview(withMargin: 2.0)
 //            sendButton.autoPinEdge(toSuperviewEdge: .trailing, withInset: 4.0)
 //            sendButton.autoPinHeightToSuperview(withMargin: 2.0)
 //            self.autoSetDimension(.height, toSize: 40, relation: .greaterThanOrEqual)
@@ -241,20 +255,20 @@ public class AttachmentApprovalViewController: OWSViewController {
             super.layoutSubviews()
 
             let kMargin = 4
-            let kTextFieldHeight = 40
-            let kTextFieldWidth = 200
+            let kTextViewHeight = 40
+            let kTextViewWidth = 200
 
             let kSendButtonHeight = 40
             let kSendButtonWidth = 100
 
-            self.textField.frame = CGRect(x: kMargin, y: kMargin, width: kTextFieldWidth, height: kTextFieldHeight)
-            self.sendButton.frame = CGRect(x: kMargin * 2 + kTextFieldWidth, y: kMargin, width: kSendButtonWidth, height: kSendButtonHeight)
-            self.frame = CGRect(x: 0, y: 0, width: 320, height: kTextFieldHeight + 2 * kMargin)
+            self.textView.frame = CGRect(x: kMargin, y: kMargin, width: kTextViewWidth, height: kTextViewHeight)
+            self.sendButton.frame = CGRect(x: kMargin * 2 + kTextViewWidth, y: kMargin, width: kSendButtonWidth, height: kSendButtonHeight)
+            self.frame = CGRect(x: 0, y: 0, width: 320, height: kTextViewHeight + 2 * kMargin)
             self.bounds = self.frame
 
-//            self.textField.sizeToFit()
+//            self.textView.sizeToFit()
 
-//            let maxHeight = max(self.sendButton.frame.size.height, self.textField.frame.size.height)
+//            let maxHeight = max(self.sendButton.frame.size.height, self.textView.frame.size.height)
 //            let fittedFrame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: maxHeight)
 //            self.frame = fittedFrame
 //            self.bounds = fittedFrame

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -405,27 +405,7 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
         self.captioningToolbarDelegate?.captioningToolbarDidTapSend(self, captionText: self.textView.text)
     }
 
-    // MARK: - UITextViewDelegate
-
-    public func textViewDidChange(_ textView: UITextView) {
-        Logger.debug("\(self.logTag) in \(#function)")
-
-        // compute new height assuming width is unchanged
-        let currentSize = textView.frame.size
-        let newHeight = clampedTextViewHeight(fixedWidth: currentSize.width)
-
-        if newHeight != self.textViewHeight {
-            Logger.debug("\(self.logTag) TextView height changed: \(self.textViewHeight) -> \(newHeight)")
-            self.textViewHeight = newHeight
-            self.setNeedsLayout()
-            self.layoutIfNeeded()
-        }
-    }
-
-    private func clampedTextViewHeight(fixedWidth: CGFloat) -> CGFloat {
-        let contentSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-        return Clamp(contentSize.height, kMinTextViewHeight, maxTextViewHeight)
-    }
+    // MARK: - UIView Overrides
 
     // We do progammatic layout, explicitly computing and setting frames since autoLayout does
     // not seem to work with inputAccessory views, even when forcing a layout.
@@ -463,4 +443,40 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
 
         Logger.debug("After layout >>> self: \(self.frame) textView: \(self.textView.frame), sendButton:\(sendButton.frame)")
     }
+
+    // MARK: - UITextViewDelegate
+
+    public func textViewDidChange(_ textView: UITextView) {
+        Logger.debug("\(self.logTag) in \(#function)")
+
+        // compute new height assuming width is unchanged
+        let currentSize = textView.frame.size
+        let newHeight = clampedTextViewHeight(fixedWidth: currentSize.width)
+
+        if newHeight != self.textViewHeight {
+            Logger.debug("\(self.logTag) TextView height changed: \(self.textViewHeight) -> \(newHeight)")
+            self.textViewHeight = newHeight
+            self.setNeedsLayout()
+            self.layoutIfNeeded()
+        }
+    }
+
+    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        // Though we can wrap the text, we don't want to encourage multline captions, plus a "done" button
+        // allows the user to get the keyboard out of the way while in the attachment approval view.
+        if text == "\n" {
+            textView.resignFirstResponder()
+            return false
+        } else {
+            return true
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func clampedTextViewHeight(fixedWidth: CGFloat) -> CGFloat {
+        let contentSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+        return Clamp(contentSize.height, kMinTextViewHeight, maxTextViewHeight)
+    }
+
 }

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -221,7 +221,11 @@ public class AttachmentApprovalViewController: OWSViewController, MessagingToolb
     }
 
     override public var inputAccessoryView: UIView? {
-        return self.bottomToolbar
+        self.bottomToolbar.layoutIfNeeded()
+        return self.bottomToolbarO
+//        let toolbar = UIView(frame: CGRect(origin: CGPoint.zero, size: CGSize(width: 50, height: 100)))
+//        toolbar.backgroundColor = UIColor.purple
+//        return toolbar
     }
 
     override public var canBecomeFirstResponder: Bool {
@@ -391,7 +395,7 @@ protocol MessagingToolbarDelegate: class {
     func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar)
 }
 
-class MessagingToolbar: UIToolbar, UITextViewDelegate {
+class MessagingToolbar: UIView, UITextViewDelegate {
     //        let toolbar: UIToolbar
     //        var sendButton: UIBarButtonItem!
     private var sendButton: UIButton!
@@ -459,36 +463,40 @@ class MessagingToolbar: UIToolbar, UITextViewDelegate {
         sendButton.titleLabel?.font = UIFont.ows_mediumFont(withSize: 16)
         sendButton.titleLabel?.textAlignment = .center
         sendButton.tintColor = UIColor.ows_materialBlue()
-
-        let sendButtonItem = UIBarButtonItem(customView: sendButton)
-
-        //            self.items = [textViewItem, sendButton]
-        self.items = [textViewItem, sendButtonItem]
-
-        // toolbar doesn't render without some minimum height set.
-        //            self.heightConstraint = self.autoSetDimension(.height,
+        // Increase hit area of send button
+        sendButton.contentEdgeInsets = UIEdgeInsets(top: 20, left: 8, bottom: 4, right: 8)
+        
+        addSubview(sendButton)
+        addSubview(textView)
+        
+//
+//        let sendButtonItem = UIBarButtonItem(customView: sendButton)
+//
+//        //            self.items = [textViewItem, sendButton]
+//        self.items = [textViewItem, sendButtonItem]
+//
+//        // toolbar doesn't render without some minimum height set.
+//        //            self.heightConstraint = self.autoSetDimension(.height,
         self.autoSetDimension(.height,
                               toSize: kMinTextViewHeight + kToolbarMargin * 2,
                               relation: .greaterThanOrEqual)
-
+//
         // Adding textView to a toolbar item inserts it into a "hostView"
-        // This isn't really documentd, but I've verified it works on iOS10
+        // This isn't really documentd, but I've verified it works on iOS9 and iOS10
         self.textViewHeightConstraint = textView.autoSetDimension(.height, toSize: kMinTextViewHeight)
         textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
         textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
         textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
-
-        //            let kTrailingOffset: CGFloat = kSendButtonWidth
-        //            textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
-
+//
+//        //            let kTrailingOffset: CGFloat = kSendButtonWidth
+//        //            textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
+//
         textView.autoPinEdge(.trailing, to: .leading, of: sendButton, withOffset: -8)
 
         sendButton.sizeToFit()
         sendButton.autoPinEdge(toSuperviewEdge: .trailing, withInset: kToolbarMargin)
         sendButton.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
-        // Increase hit area of send button
-        sendButton.contentEdgeInsets = UIEdgeInsets(top: 20, left: 8, bottom: 4, right: 8)
-
+        
         textView.delegate = self
     }
 

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -21,9 +21,10 @@ public class AttachmentApprovalViewController: OWSViewController {
 
     let attachment: SignalAttachment
 
-    private(set) var bottomToolbar: UIToolbar!
+    private(set) var bottomToolbar: UIView!
     private(set) var mediaMessageView: MediaMessageView!
     private(set) var scrollView: UIScrollView!
+    private var textField: UITextField!
 
     // MARK: Initializers
 
@@ -170,10 +171,12 @@ public class AttachmentApprovalViewController: OWSViewController {
         topToolbar.items = [cancelButton]
 
         // Bottom Toolbar
-        self.bottomToolbar = makeClearToolbar()
-        // Making a toolbar transparent requires setting an empty uiimage
-        bottomToolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
-        bottomToolbar.backgroundColor = UIColor.clear
+        let bottomToolbar: UIToolbar = makeClearToolbar()
+        self.bottomToolbar = bottomToolbar
+        self.textField = UITextField()
+        let textFieldItem = UIBarButtonItem(customView: textField)
+        //        textField.autoresizingMask = [.flexibleWidth, .flexibleHeight];
+        textField.translatesAutoresizingMaskIntoConstraints = false
 
         let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
         let sendButton = UIBarButtonItem(title:  sendTitle,
@@ -183,13 +186,83 @@ public class AttachmentApprovalViewController: OWSViewController {
         sendButton.tintColor = UIColor.white
 
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        bottomToolbar.items = [flexibleSpace, sendButton]
+        bottomToolbar.items = [textFieldItem, sendButton]
+//        bottomToolbar.items = [flexibleSpace, sendButton]
+        bottomToolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
+        bottomToolbar.backgroundColor = UIColor.clear
+        bottomToolbar.autoSetDimension(.height, toSize: 40)
 
-        self.view.addSubview(bottomToolbar)
-        bottomToolbar.autoPin(toBottomLayoutGuideOf: self, withInset: 0)
-        bottomToolbar.autoPinWidthToSuperview()
-        bottomToolbar.setCompressionResistanceVerticalHigh()
-        bottomToolbar.setContentHuggingVerticalHigh()
+//        self.bottomToolbar = MessagingToolbar()
+        // Making a toolbar transparent requires setting an empty uiimage
+
+//        self.view.addSubview(bottomToolbar)
+//        bottomToolbar.autoPin(toBottomLayoutGuideOf: self, withInset: 0)
+//        bottomToolbar.autoPinWidthToSuperview()
+//        bottomToolbar.setCompressionResistanceVerticalHigh()
+//        bottomToolbar.setContentHuggingVerticalHigh()
+    }
+
+    override public var inputAccessoryView: UIView? {
+        return self.bottomToolbar
+    }
+
+    override public var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    class MessagingToolbar: UIToolbar {
+        let sendButton: UIButton
+        let textField: UITextField
+
+        init() {
+            self.sendButton = UIButton(type: .system)
+            self.sendButton.setTitle("Send", for: .normal)
+            self.sendButton.tintColor = UIColor.white
+
+            self.textField = UITextField()
+            textField.backgroundColor = UIColor.white
+            textField.layer.cornerRadius = 2.0
+            super.init(frame: CGRect.zero)
+
+            backgroundColor = UIColor.green
+
+            addSubview(sendButton)
+            addSubview(textField)
+
+//            textField.autoPinEdge(toSuperviewEdge: .leading, withInset: 4.0)
+//            textField.autoPinEdge(.trailing, to: .leading, of: sendButton, withOffset: -4.0)
+//            textField.autoPinHeightToSuperview(withMargin: 2.0)
+//            sendButton.autoPinEdge(toSuperviewEdge: .trailing, withInset: 4.0)
+//            sendButton.autoPinHeightToSuperview(withMargin: 2.0)
+//            self.autoSetDimension(.height, toSize: 40, relation: .greaterThanOrEqual)
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+
+            let kMargin = 4
+            let kTextFieldHeight = 40
+            let kTextFieldWidth = 200
+
+            let kSendButtonHeight = 40
+            let kSendButtonWidth = 100
+
+            self.textField.frame = CGRect(x: kMargin, y: kMargin, width: kTextFieldWidth, height: kTextFieldHeight)
+            self.sendButton.frame = CGRect(x: kMargin * 2 + kTextFieldWidth, y: kMargin, width: kSendButtonWidth, height: kSendButtonHeight)
+            self.frame = CGRect(x: 0, y: 0, width: 320, height: kTextFieldHeight + 2 * kMargin)
+            self.bounds = self.frame
+
+//            self.textField.sizeToFit()
+
+//            let maxHeight = max(self.sendButton.frame.size.height, self.textField.frame.size.height)
+//            let fittedFrame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: maxHeight)
+//            self.frame = fittedFrame
+//            self.bounds = fittedFrame
+        }
+
+        required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
     }
 
     private func makeClearToolbar() -> UIToolbar {

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -215,11 +215,9 @@ public class AttachmentApprovalViewController: OWSViewController, MessagingToolb
         self.sendAttachment(captionText: captionText)
     }
 
-    func messagingToolbar(_ messagingToolbar: MessagingToolbar, didChangeHeight newHeight: CGFloat) {
-        self.scrollView.contentInset.bottom = newHeight
-    }
+    // MARK: Helpers
 
-    func sendAttachment(captionText: String?) {
+    private func sendAttachment(captionText: String?) {
         // disable controls after send was tapped.
         self.bottomToolbar.isUserInteractionEnabled = false
 
@@ -327,7 +325,6 @@ private class GradientView: UIView {
 
 protocol MessagingToolbarDelegate: class {
     func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar, captionText: String?)
-    func messagingToolbar(_ messagingToolbar: MessagingToolbar, didChangeHeight newHeight: CGFloat)
 }
 
 class MessagingToolbar: UIView, UITextViewDelegate {
@@ -342,14 +339,9 @@ class MessagingToolbar: UIView, UITextViewDelegate {
         // Otherwise we risk obscuring too much of the content.
         return UIDevice.current.orientation.isPortrait ? 160 : 100
     }
-    let kMinTextViewHeight: CGFloat = 38
 
-    var textViewHeight: CGFloat {
-        didSet {
-            // TODO magic numbers
-            self.messagingToolbarDelegate?.messagingToolbar(self, didChangeHeight: textViewHeight + 2 * 4)
-        }
-    }
+    let kMinTextViewHeight: CGFloat = 38
+    var textViewHeight: CGFloat
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -173,59 +173,11 @@ public class AttachmentApprovalViewController: OWSViewController, MessagingToolb
         let messagingToolbar = MessagingToolbar()
         messagingToolbar.messagingToolbarDelegate = self
         self.bottomToolbar = messagingToolbar
-////        let bottomToolbar: UIToolbar = makeClearToolbar()
-//        self.bottomToolbar = bottomToolbar
-//        self.textView = UITextView()
-//        textView.delegate = self
-//        self.textView.backgroundColor = UIColor.white
-//        self.textView.layer.cornerRadius = 4.0
-//
-//        let textViewItem = UIBarButtonItem(customView: textView)
-//        //        textView.autoresizingMask = [.flexibleWidth, .flexibleHeight];
-//        textView.translatesAutoresizingMaskIntoConstraints = false
-//
-//        let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
-//        let sendButton = UIBarButtonItem(title:  sendTitle,
-//                                         style: .plain,
-//                                         target: self,
-//                                         action: #selector(sendPressed))
-//        sendButton.tintColor = UIColor.white
-//
-//        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-//        bottomToolbar.items = [textViewItem, sendButton]
-////        bottomToolbar.items = [flexibleSpace, sendButton]
-//        bottomToolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
-////        bottomToolbar.backgroundColor = UIColor.clear
-//        bottomToolbar.backgroundColor = UIColor.yellow
-//        bottomToolbar.autoSetDimension(.height, toSize: 40, relation: .greaterThanOrEqual)
-//
-//        let kToolbarMargin: CGFloat = 4.0
-//        //        textView.autoSetDimensions(to: CGSize(width: 200, height: 40))
-//        textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
-//        textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
-//        // TODO get actualy offset based on button size.
-//        let kTrailingOffset: CGFloat = 80
-//        textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
-//        textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
-//
-//        self.textViewHeightConstraint = textView.autoSetDimension(.height, toSize: kMinTextViewHeight)
-
-//        self.bottomToolbar = MessagingToolbar()
-        // Making a toolbar transparent requires setting an empty uiimage
-
-//        self.view.addSubview(bottomToolbar)
-//        bottomToolbar.autoPin(toBottomLayoutGuideOf: self, withInset: 0)
-//        bottomToolbar.autoPinWidthToSuperview()
-//        bottomToolbar.setCompressionResistanceVerticalHigh()
-//        bottomToolbar.setContentHuggingVerticalHigh()
     }
 
     override public var inputAccessoryView: UIView? {
         self.bottomToolbar.layoutIfNeeded()
         return self.bottomToolbar
-//        let toolbar = UIView(frame: CGRect(origin: CGPoint.zero, size: CGSize(width: 50, height: 100)))
-//        toolbar.backgroundColor = UIColor.purple
-//        return toolbar
     }
 
     override public var canBecomeFirstResponder: Bool {
@@ -246,29 +198,6 @@ public class AttachmentApprovalViewController: OWSViewController, MessagingToolb
         return toolbar
     }
 
-//    // MARK: - UITextViewDelegate
-//
-//    public func textViewDidChange(_ textView: UITextView) {
-//        Logger.debug("\(self.logTag) in \(#function)")
-////        CGFloat fixedWidth = textView.frame.size.width;
-////        CGSize newSize = [textView sizeThatFits:CGSizeMake(fixedWidth, MAXFLOAT)];
-////        CGRect newFrame = textView.frame;
-////        newFrame.size = CGSizeMake(fmaxf(newSize.width, fixedWidth), newSize.height);
-////        textView.frame = newFrame;
-//        let fixedWidth = textView.frame.size.width
-//        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-////        let newFrame = CGRect(x: textView.frame.origin.x, y: textView.frame.origin.y, width: fixedWidth, height: newSize.height)
-////        Logger.debug("\(self.logTag) oldFrame: \(textView.frame), newFrame: \(newFrame)")
-//
-//        Logger.debug("\(self.logTag) oldHeight: \(self.textViewHeightConstraint.constant), newHeight: \(newSize.height)")
-//        // TODO clamp to a max.
-//        self.textViewHeightConstraint.constant = max(kMinTextViewHeight, newSize.height)
-//        self.bottomToolbar.setNeedsLayout()
-//        self.bottomToolbar.layoutIfNeeded()
-////        textView.frame = newFrame
-//    }
-//    - (void)textViewDidChange:(UITextView *)textView
-
     // MARK: - Event Handlers
 
     @objc
@@ -284,6 +213,10 @@ public class AttachmentApprovalViewController: OWSViewController, MessagingToolb
 
     func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar) {
         self.sendAttachment()
+    }
+
+    func messagingToolbar(_ messagingToolbar: MessagingToolbar, didChangeHeight newHeight: CGFloat) {
+        self.scrollView.contentInset.bottom = newHeight
     }
 
     func sendAttachment() {
@@ -393,25 +326,28 @@ private class GradientView: UIView {
 
 protocol MessagingToolbarDelegate: class {
     func messagingToolbarDidTapSend(_ messagingToolbar: MessagingToolbar)
+    func messagingToolbar(_ messagingToolbar: MessagingToolbar, didChangeHeight newHeight: CGFloat)
 }
 
 class MessagingToolbar: UIView, UITextViewDelegate {
-    //        let toolbar: UIToolbar
-    //        var sendButton: UIBarButtonItem!
-    private var sendButton: UIButton!
 
     weak var messagingToolbarDelegate: MessagingToolbarDelegate?
-
+    private let sendButton: UIButton
     private let textView: UITextView
-    private let kToolbarMargin: CGFloat = 4
-    private let kTextViewPadding: CGFloat = 4.0
 
-    private var textViewHeightConstraint: NSLayoutConstraint!
-    //        private(set) var heightConstraint: NSLayoutConstraint!
+    // Layout Constants
+    var maxTextViewHeight: CGFloat {
+        // About ~4 lines in portrait and ~3 lines in landscape.
+        // Otherwise we risk obscuring too much of the content.
+        return UIDevice.current.orientation.isPortrait ? 160 : 100
+    }
+    let kMinTextViewHeight: CGFloat = 38
 
-    private var kMinTextViewHeight: CGFloat {
-        //            return UIFont.ows_dynamicTypeBody().lineHeight
-        return 38
+    var textViewHeight: CGFloat {
+        didSet {
+            // TODO magic numbers
+            self.messagingToolbarDelegate?.messagingToolbar(self, didChangeHeight: textViewHeight + 2 * 4)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -429,77 +365,35 @@ class MessagingToolbar: UIView, UITextViewDelegate {
     }
 
     init() {
-        let textView = MessageTextView()
-        self.textView = textView
+        self.textView =  MessageTextView()
+        self.sendButton = UIButton(type: .system)
+        self.textViewHeight = kMinTextViewHeight
 
         super.init(frame: CGRect.zero)
 
-        let kSendButtonWidth: CGFloat = 100
-        let kMinToolbarHeight: CGFloat = 40
-
         self.backgroundColor = UIColor.ows_inputToolbarBackground()
 
+        textView.delegate = self
         textView.backgroundColor = UIColor.white
         textView.layer.cornerRadius = 4.0
         textView.addBorder(with: UIColor.lightGray)
         textView.font = UIFont.ows_dynamicTypeBody()
 
-        let textViewItem = UIBarButtonItem(customView: textView)
         let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
-
-        let sendButton = UIButton(type: .system)
         sendButton.setTitle(sendTitle, for: .normal)
         sendButton.addTarget(self, action: #selector(didTapSend), for: .touchUpInside)
 
-        //            let sendButton = UIBarButtonItem(title: sendTitle,
-        //                                             style: .plain,
-        //                                             target: self,
-        //                                             action: #selector(sendPressed))
-        //                        sendButton.width = kSendButtonWidth
-        self.sendButton = sendButton
-        // TODO
-        // self.sendButton.titleLabel.font = [UIFont ows_mediumFontWithSize:16.f];
-        // center text alignment
         sendButton.titleLabel?.font = UIFont.ows_mediumFont(withSize: 16)
         sendButton.titleLabel?.textAlignment = .center
         sendButton.tintColor = UIColor.ows_materialBlue()
+
         // Increase hit area of send button
         sendButton.contentEdgeInsets = UIEdgeInsets(top: 20, left: 8, bottom: 4, right: 8)
 
         addSubview(sendButton)
         addSubview(textView)
 
-//
-//        let sendButtonItem = UIBarButtonItem(customView: sendButton)
-//
-//        //            self.items = [textViewItem, sendButton]
-//        self.items = [textViewItem, sendButtonItem]
-//
-//        // toolbar doesn't render without some minimum height set.
-//        //            self.heightConstraint = self.autoSetDimension(.height,
-//        self.autoSetDimension(.height,
-//                              toSize: kMinTextViewHeight + kToolbarMargin * 2,
-//                              relation: .greaterThanOrEqual)
-//
-        self.autoMatch(.height, to: .height, of: textView, withMultiplier:1, relation: .greaterThanOrEqual)
-        
-        // Adding textView to a toolbar item inserts it into a "hostView"
-        // This isn't really documentd, but I've verified it works on iOS9 and iOS10
-        self.textViewHeightConstraint = textView.autoSetDimension(.height, toSize: kMinTextViewHeight)
-        textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
-        textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
-        textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
-//
-//        //            let kTrailingOffset: CGFloat = kSendButtonWidth
-//        //            textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
-//
-        textView.autoPinEdge(.trailing, to: .leading, of: sendButton, withOffset: -8)
-
         sendButton.sizeToFit()
-        sendButton.autoPinEdge(toSuperviewEdge: .trailing, withInset: kToolbarMargin)
-        sendButton.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
-
-        textView.delegate = self
     }
 
     func didTapSend() {
@@ -511,60 +405,57 @@ class MessagingToolbar: UIView, UITextViewDelegate {
     public func textViewDidChange(_ textView: UITextView) {
         Logger.debug("\(self.logTag) in \(#function)")
 
-        // We don't want the textView to grow indefinitely
-        let kMaxTextViewHeight: CGFloat = 160
+        // compute new height assuming width is unchanged
+        let currentSize = textView.frame.size
+        let newHeight = clampedTextViewHeight(fixedWidth: currentSize.width)
 
-        let fixedWidth = textView.frame.size.width
-        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-        let newHeight = Clamp(newSize.height, kMinTextViewHeight, kMaxTextViewHeight)
-
-        if newHeight != self.textViewHeightConstraint.constant {
-            Logger.debug("\(self.logTag) oldHeight: \(self.textViewHeightConstraint.constant), newHeight: \(newHeight)")
-            self.textViewHeightConstraint.constant = newHeight
-            self.textView.frame = CGRect(x: 0, y: 0, width: self.textView.frame.size.width, height: newHeight)
-            //                UIView.animate(withDuration: 0.1) {
+        if newHeight != self.textViewHeight {
+            Logger.debug("\(self.logTag) TextView height changed: \(self.textViewHeight) -> \(newHeight)")
+            self.textViewHeight = newHeight
             self.setNeedsLayout()
             self.layoutIfNeeded()
-            self.textView.reloadInputViews()
-        } else {
-            Logger.debug("\(self.logTag) height unchanged: \(self.textViewHeightConstraint.constant)")
         }
     }
 
+    private func clampedTextViewHeight(fixedWidth: CGFloat) -> CGFloat {
+        let contentSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+        return Clamp(contentSize.height, kMinTextViewHeight, maxTextViewHeight)
+    }
+
+    // We do progammatic layout, explicitly computing and setting frames since autoLayout does
+    // not seem to work with inputAccessory views, even when forcing a layout.
     override func layoutSubviews() {
         super.layoutSubviews()
-        Logger.info("\(self.logTag) in \(#function)")
-        Logger.info("textView: \(self.textView.frame), sendButton:\(sendButton.frame)")
-        
-        // Updating the autoLayout constraints was not sufficient to properly set the frame of the inputAccessoryView,
-        // so we manually update the relevant frames here.
-        let originalTextViewFrame = self.textView.frame
-        let newTextViewFrame = CGRect(x: originalTextViewFrame.origin.x, y: originalTextViewFrame.origin.y, width: originalTextViewFrame.width, height: self.textViewHeightConstraint.constant)
-        self.textView.frame = newTextViewFrame
-        
-        let diffY = newTextViewFrame.height - originalTextViewFrame.height
-        let originalFrame = self.frame
-        let newFrame = CGRect(x: originalFrame.origin.x, y: originalFrame.origin.y - diffY, width: originalFrame.width, height: originalFrame.size.height + diffY)
-        self.frame = newFrame
+        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("Before layout >>> self: \(self.frame) textView: \(self.textView.frame), sendButton:\(sendButton.frame)")
 
-        //
-        //            let kMargin = 4
-        //            let kTextViewHeight = 40
-        //            let kTextViewWidth = 200
-        //
-        //            let kSendButtonHeight = 40
-        //            let kSendButtonWidth = 100
-        //
-        //            self.textView.frame = CGRect(x: kMargin, y: kMargin, width: kTextViewWidth, height: kTextViewHeight)
-        //            self.sendButton.frame = CGRect(x: kMargin * 2 + kTextViewWidth, y: kMargin, width: kSendButtonWidth, height: kSendButtonHeight)
-        //            self.frame = CGRect(x: 0, y: 0, width: 320, height: kTextViewHeight + 2 * kMargin)
-        //            self.bounds = self.frame
-        //
-        ////            self.textView.sizeToFit()
-        //
-        ////            let maxHeight = max(self.sendButton.frame.size.height, self.textView.frame.size.height)
-        ////            let fittedFrame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: maxHeight)
-        ////            self.frame = fittedFrame
-        ////            self.bounds = fittedFrame
+        let kToolbarMargin: CGFloat = 4
+
+        let sendButtonWidth = sendButton.frame.size.width
+
+        let kOriginalToolbarHeight = kMinTextViewHeight + 2 * kToolbarMargin
+        // Assume send button has proper size.
+        let textViewWidth = frame.size.width - 3 * kToolbarMargin - sendButtonWidth
+
+        // determine height given a fixed width
+        let textViewHeight = clampedTextViewHeight(fixedWidth: textViewWidth)
+        textView.frame = CGRect(x: kToolbarMargin, y: kToolbarMargin, width: textViewWidth, height: textViewHeight)
+        assert(self.textViewHeight == textViewHeight, "textView.height inconsistent with what was computed in textViewDidChange")
+
+        let newToolbarHeight = textViewHeight + 2 * kToolbarMargin
+
+        // frame origin is with respect to the initial height of the toolbar, so we must offset the toolbar frame
+        // by the difference, else the toolbar will extend into and behind the keyboard.
+        let toolbarHeightOffset = kOriginalToolbarHeight - newToolbarHeight
+        self.frame = CGRect(x: 0, y: toolbarHeightOffset, width: frame.size.width, height: newToolbarHeight)
+
+        // Send Button
+
+        // position in bottom right corner
+        let sendButtonX = frame.size.width - kToolbarMargin - sendButton.frame.size.width
+        let sendButtonY = frame.size.height - kToolbarMargin - sendButton.frame.size.height
+        sendButton.frame = CGRect(origin: CGPoint(x: sendButtonX, y: sendButtonY), size: sendButton.frame.size)
+
+        Logger.debug("After layout >>> self: \(self.frame) textView: \(self.textView.frame), sendButton:\(sendButton.frame)")
     }
 }

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -11,9 +11,6 @@ public protocol AttachmentApprovalViewControllerDelegate: class {
     func didCancelAttachment(attachment: SignalAttachment)
 }
 
-// TODO
-let kMinTextViewHeight: CGFloat = 80
-
 @objc
 public class AttachmentApprovalViewController: OWSViewController, UITextViewDelegate {
 
@@ -27,8 +24,6 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
     private(set) var bottomToolbar: UIView!
     private(set) var mediaMessageView: MediaMessageView!
     private(set) var scrollView: UIScrollView!
-    private var textView: UITextView!
-    private(set) var textViewHeightConstraint: NSLayoutConstraint!
 
     // MARK: Initializers
 
@@ -175,42 +170,43 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
         topToolbar.items = [cancelButton]
 
         // Bottom Toolbar
-        let bottomToolbar: UIToolbar = makeClearToolbar()
-        self.bottomToolbar = bottomToolbar
-        self.textView = UITextView()
-        textView.delegate = self
-        self.textView.backgroundColor = UIColor.white
-        self.textView.layer.cornerRadius = 4.0
-
-        let textViewItem = UIBarButtonItem(customView: textView)
-        //        textView.autoresizingMask = [.flexibleWidth, .flexibleHeight];
-        textView.translatesAutoresizingMaskIntoConstraints = false
-
-        let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
-        let sendButton = UIBarButtonItem(title:  sendTitle,
-                                         style: .plain,
-                                         target: self,
-                                         action: #selector(sendPressed))
-        sendButton.tintColor = UIColor.white
-
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        bottomToolbar.items = [textViewItem, sendButton]
-//        bottomToolbar.items = [flexibleSpace, sendButton]
-        bottomToolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
-//        bottomToolbar.backgroundColor = UIColor.clear
-        bottomToolbar.backgroundColor = UIColor.yellow
-        bottomToolbar.autoSetDimension(.height, toSize: 40, relation: .greaterThanOrEqual)
-
-        let kToolbarMargin: CGFloat = 4.0
-        //        textView.autoSetDimensions(to: CGSize(width: 200, height: 40))
-        textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
-        textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
-        // TODO get actualy offset based on button size.
-        let kTrailingOffset: CGFloat = 80
-        textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
-        textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
-
-        self.textViewHeightConstraint = textView.autoSetDimension(.height, toSize: kMinTextViewHeight)
+        self.bottomToolbar = MessagingToolbar()
+////        let bottomToolbar: UIToolbar = makeClearToolbar()
+//        self.bottomToolbar = bottomToolbar
+//        self.textView = UITextView()
+//        textView.delegate = self
+//        self.textView.backgroundColor = UIColor.white
+//        self.textView.layer.cornerRadius = 4.0
+//
+//        let textViewItem = UIBarButtonItem(customView: textView)
+//        //        textView.autoresizingMask = [.flexibleWidth, .flexibleHeight];
+//        textView.translatesAutoresizingMaskIntoConstraints = false
+//
+//        let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
+//        let sendButton = UIBarButtonItem(title:  sendTitle,
+//                                         style: .plain,
+//                                         target: self,
+//                                         action: #selector(sendPressed))
+//        sendButton.tintColor = UIColor.white
+//
+//        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+//        bottomToolbar.items = [textViewItem, sendButton]
+////        bottomToolbar.items = [flexibleSpace, sendButton]
+//        bottomToolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
+////        bottomToolbar.backgroundColor = UIColor.clear
+//        bottomToolbar.backgroundColor = UIColor.yellow
+//        bottomToolbar.autoSetDimension(.height, toSize: 40, relation: .greaterThanOrEqual)
+//
+//        let kToolbarMargin: CGFloat = 4.0
+//        //        textView.autoSetDimensions(to: CGSize(width: 200, height: 40))
+//        textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
+//        textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
+//        // TODO get actualy offset based on button size.
+//        let kTrailingOffset: CGFloat = 80
+//        textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
+//        textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
+//
+//        self.textViewHeightConstraint = textView.autoSetDimension(.height, toSize: kMinTextViewHeight)
 
 //        self.bottomToolbar = MessagingToolbar()
         // Making a toolbar transparent requires setting an empty uiimage
@@ -230,55 +226,111 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
         return true
     }
 
-    class MessagingToolbar: UIToolbar {
-        let sendButton: UIButton
+    class MessagingToolbar: UIToolbar, UITextViewDelegate {
+//        let toolbar: UIToolbar
+//        let sendButton: UIButton
         let textView: UITextView
 
-        init() {
-            self.sendButton = UIButton(type: .system)
-            self.sendButton.setTitle("Send", for: .normal)
-            self.sendButton.tintColor = UIColor.white
+        private(set) var textViewHeightConstraint: NSLayoutConstraint!
 
-            self.textView = UITextView()
-            textView.backgroundColor = UIColor.white
-            textView.layer.cornerRadius = 2.0
+        private static var kMinTextViewHeight: CGFloat {
+            return UIFont.ows_dynamicTypeBody().lineHeight + 4
+        }
+
+        init() {
+            let textView = UITextView()
+            self.textViewHeightConstraint = textView.autoSetDimension(.height, toSize: MessagingToolbar.kMinTextViewHeight)
+            self.textView = textView
+
             super.init(frame: CGRect.zero)
 
-            backgroundColor = UIColor.green
+            let kToolbarMargin: CGFloat = 4
+            let kSendButtonWidth: CGFloat = 40
+            let kMinToolbarHeight: CGFloat = 40
 
-            addSubview(sendButton)
-            addSubview(textView)
+            self.backgroundColor = UIColor.ows_inputToolbarBackground()
 
-//            textView.autoPinEdge(toSuperviewEdge: .leading, withInset: 4.0)
-//            textView.autoPinEdge(.trailing, to: .leading, of: sendButton, withOffset: -4.0)
-//            textView.autoPinHeightToSuperview(withMargin: 2.0)
-//            sendButton.autoPinEdge(toSuperviewEdge: .trailing, withInset: 4.0)
-//            sendButton.autoPinHeightToSuperview(withMargin: 2.0)
-//            self.autoSetDimension(.height, toSize: 40, relation: .greaterThanOrEqual)
+            textView.backgroundColor = UIColor.white
+            textView.layer.cornerRadius = 4.0
+            textView.font = UIFont.ows_dynamicTypeBody()
+
+            let textViewItem = UIBarButtonItem(customView: textView)
+            // TODO is this necessary?
+            textView.translatesAutoresizingMaskIntoConstraints = false
+
+            let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
+
+            let sendButton = UIBarButtonItem(title:  sendTitle,
+                                             style: .plain,
+                                             target: self,
+                                             action: #selector(sendPressed))
+            // TODO
+            // self.sendButton.titleLabel.font = [UIFont ows_mediumFontWithSize:16.f];
+            // center text alignment
+            sendButton.tintColor = UIColor.ows_materialBlue()
+            sendButton.width = kSendButtonWidth
+
+            self.items = [textViewItem, sendButton]
+
+            // toolbar doesn't render without some minimum height set.
+            self.autoSetDimension(.height, toSize: kMinToolbarHeight, relation: .greaterThanOrEqual)
+
+            // Adding textView to a toolbar item inserts it into a "hostView"
+            // This isn't really documentd, but I've verified it works on iOS10
+            textView.autoPinEdge(toSuperviewEdge: .leading, withInset: kToolbarMargin)
+            textView.autoPinEdge(toSuperviewEdge: .top, withInset: kToolbarMargin)
+
+            let kTrailingOffset: CGFloat = kSendButtonWidth + kToolbarMargin * 2
+            textView.autoPinEdge(toSuperviewEdge: .trailing, withInset: kTrailingOffset)
+            textView.autoPinEdge(toSuperviewEdge: .bottom, withInset: kToolbarMargin)
+
+            textView.delegate = self
         }
 
-        override func layoutSubviews() {
-            super.layoutSubviews()
+        // MARK: - UITextViewDelegate
 
-            let kMargin = 4
-            let kTextViewHeight = 40
-            let kTextViewWidth = 200
+        public func textViewDidChange(_ textView: UITextView) {
+            Logger.debug("\(self.logTag) in \(#function)")
+            //        CGFloat fixedWidth = textView.frame.size.width;
+            //        CGSize newSize = [textView sizeThatFits:CGSizeMake(fixedWidth, MAXFLOAT)];
+            //        CGRect newFrame = textView.frame;
+            //        newFrame.size = CGSizeMake(fmaxf(newSize.width, fixedWidth), newSize.height);
+            //        textView.frame = newFrame;
+            let fixedWidth = textView.frame.size.width
+            let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+            //        let newFrame = CGRect(x: textView.frame.origin.x, y: textView.frame.origin.y, width: fixedWidth, height: newSize.height)
+            //        Logger.debug("\(self.logTag) oldFrame: \(textView.frame), newFrame: \(newFrame)")
 
-            let kSendButtonHeight = 40
-            let kSendButtonWidth = 100
-
-            self.textView.frame = CGRect(x: kMargin, y: kMargin, width: kTextViewWidth, height: kTextViewHeight)
-            self.sendButton.frame = CGRect(x: kMargin * 2 + kTextViewWidth, y: kMargin, width: kSendButtonWidth, height: kSendButtonHeight)
-            self.frame = CGRect(x: 0, y: 0, width: 320, height: kTextViewHeight + 2 * kMargin)
-            self.bounds = self.frame
-
-//            self.textView.sizeToFit()
-
-//            let maxHeight = max(self.sendButton.frame.size.height, self.textView.frame.size.height)
-//            let fittedFrame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: maxHeight)
-//            self.frame = fittedFrame
-//            self.bounds = fittedFrame
+            Logger.debug("\(self.logTag) oldHeight: \(self.textViewHeightConstraint.constant), newHeight: \(newSize.height)")
+            // TODO clamp to a max, only when changed
+            self.textViewHeightConstraint.constant = max(MessagingToolbar.kMinTextViewHeight, newSize.height)
+            setNeedsLayout()
+            layoutIfNeeded()
+            //        textView.frame = newFrame
         }
+
+//        override func layoutSubviews() {
+//            super.layoutSubviews()
+//
+//            let kMargin = 4
+//            let kTextViewHeight = 40
+//            let kTextViewWidth = 200
+//
+//            let kSendButtonHeight = 40
+//            let kSendButtonWidth = 100
+//
+//            self.textView.frame = CGRect(x: kMargin, y: kMargin, width: kTextViewWidth, height: kTextViewHeight)
+//            self.sendButton.frame = CGRect(x: kMargin * 2 + kTextViewWidth, y: kMargin, width: kSendButtonWidth, height: kSendButtonHeight)
+//            self.frame = CGRect(x: 0, y: 0, width: 320, height: kTextViewHeight + 2 * kMargin)
+//            self.bounds = self.frame
+//
+////            self.textView.sizeToFit()
+//
+////            let maxHeight = max(self.sendButton.frame.size.height, self.textView.frame.size.height)
+////            let fittedFrame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: maxHeight)
+////            self.frame = fittedFrame
+////            self.bounds = fittedFrame
+//        }
 
         required init?(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
@@ -299,27 +351,27 @@ public class AttachmentApprovalViewController: OWSViewController, UITextViewDele
         return toolbar
     }
 
-    // MARK: - UITextViewDelegate
-
-    public func textViewDidChange(_ textView: UITextView) {
-        Logger.debug("\(self.logTag) in \(#function)")
-//        CGFloat fixedWidth = textView.frame.size.width;
-//        CGSize newSize = [textView sizeThatFits:CGSizeMake(fixedWidth, MAXFLOAT)];
-//        CGRect newFrame = textView.frame;
-//        newFrame.size = CGSizeMake(fmaxf(newSize.width, fixedWidth), newSize.height);
-//        textView.frame = newFrame;
-        let fixedWidth = textView.frame.size.width
-        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-//        let newFrame = CGRect(x: textView.frame.origin.x, y: textView.frame.origin.y, width: fixedWidth, height: newSize.height)
-//        Logger.debug("\(self.logTag) oldFrame: \(textView.frame), newFrame: \(newFrame)")
-
-        Logger.debug("\(self.logTag) oldHeight: \(self.textViewHeightConstraint.constant), newHeight: \(newSize.height)")
-        // TODO clamp to a max.
-        self.textViewHeightConstraint.constant = max(kMinTextViewHeight, newSize.height)
-        self.bottomToolbar.setNeedsLayout()
-        self.bottomToolbar.layoutIfNeeded()
-//        textView.frame = newFrame
-    }
+//    // MARK: - UITextViewDelegate
+//
+//    public func textViewDidChange(_ textView: UITextView) {
+//        Logger.debug("\(self.logTag) in \(#function)")
+////        CGFloat fixedWidth = textView.frame.size.width;
+////        CGSize newSize = [textView sizeThatFits:CGSizeMake(fixedWidth, MAXFLOAT)];
+////        CGRect newFrame = textView.frame;
+////        newFrame.size = CGSizeMake(fmaxf(newSize.width, fixedWidth), newSize.height);
+////        textView.frame = newFrame;
+//        let fixedWidth = textView.frame.size.width
+//        let newSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+////        let newFrame = CGRect(x: textView.frame.origin.x, y: textView.frame.origin.y, width: fixedWidth, height: newSize.height)
+////        Logger.debug("\(self.logTag) oldFrame: \(textView.frame), newFrame: \(newFrame)")
+//
+//        Logger.debug("\(self.logTag) oldHeight: \(self.textViewHeightConstraint.constant), newHeight: \(newSize.height)")
+//        // TODO clamp to a max.
+//        self.textViewHeightConstraint.constant = max(kMinTextViewHeight, newSize.height)
+//        self.bottomToolbar.setNeedsLayout()
+//        self.bottomToolbar.layoutIfNeeded()
+////        textView.frame = newFrame
+//    }
 //    - (void)textViewDidChange:(UITextView *)textView
 
     // MARK: - Event Handlers

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -131,12 +131,6 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
             topGradient.autoPinWidthToSuperview()
             topGradient.autoPinEdge(toSuperviewEdge: .top)
             topGradient.autoSetDimension(.height, toSize: ScaleFromIPhone5(60))
-
-            let bottomGradient = GradientView(from: UIColor.clear, to: backgroundColor)
-            self.view.addSubview(bottomGradient)
-            bottomGradient.autoPinWidthToSuperview()
-            bottomGradient.autoPinEdge(toSuperviewEdge: .bottom)
-            bottomGradient.autoSetDimension(.height, toSize: ScaleFromIPhone5(100))
         }
 
         // Hide the play button embedded in the MediaView and replace it with our own.
@@ -440,6 +434,12 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
 
         // Increase hit area of send button
         sendButton.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 6, right: 8)
+
+        let bottomGradient = GradientView(from: UIColor.clear, to: UIColor.black)
+        self.addSubview(bottomGradient)
+        bottomGradient.autoPinWidthToSuperview()
+        bottomGradient.autoPinEdge(toSuperviewEdge: .bottom)
+        bottomGradient.autoSetDimension(.height, toSize: ScaleFromIPhone5(100))
 
         addSubview(sendButton)
         addSubview(textView)

--- a/SignalMessaging/attachments/FullImageViewController.m
+++ b/SignalMessaging/attachments/FullImageViewController.m
@@ -311,30 +311,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)longPressTextGesture:(UIGestureRecognizer *)sender
-{
-    // We "eagerly" respond when the long press begins, not when it ends.
-    if (sender.state == UIGestureRecognizerStateBegan) {
-        if (!self.viewItem) {
-            return;
-        }
-
-        [self.view becomeFirstResponder];
-
-        if ([UIMenuController sharedMenuController].isMenuVisible) {
-            [[UIMenuController sharedMenuController] setMenuVisible:NO animated:NO];
-        }
-
-        NSArray *menuItems = self.viewItem.textMenuControllerItems;
-        [UIMenuController sharedMenuController].menuItems = menuItems;
-        CGPoint location = [sender locationInView:self.view];
-        CGRect targetRect = CGRectMake(location.x, location.y, 1, 1);
-        [[UIMenuController sharedMenuController] setTargetRect:targetRect inView:self.view];
-        [[UIMenuController sharedMenuController] setMenuVisible:YES animated:YES];
-    }
-}
-
-- (void)longPressMediaGesture:(UIGestureRecognizer *)sender
+- (void)longPressGesture:(UIGestureRecognizer *)sender
 {
     // We "eagerly" respond when the long press begins, not when it ends.
     if (sender.state == UIGestureRecognizerStateBegan) {
@@ -365,19 +342,9 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.viewItem canPerformAction:action];
 }
 
-- (void)copyTextAction:(nullable id)sender
-{
-    [self.viewItem copyTextAction];
-}
-
 - (void)copyMediaAction:(nullable id)sender
 {
     [self.viewItem copyMediaAction];
-}
-
-- (void)shareTextAction:(nullable id)sender
-{
-    [self.viewItem shareTextAction];
 }
 
 - (void)shareMediaAction:(nullable id)sender

--- a/SignalMessaging/attachments/FullImageViewController.m
+++ b/SignalMessaging/attachments/FullImageViewController.m
@@ -311,7 +311,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)longPressGesture:(UIGestureRecognizer *)sender
+- (void)longPressTextGesture:(UIGestureRecognizer *)sender
 {
     // We "eagerly" respond when the long press begins, not when it ends.
     if (sender.state == UIGestureRecognizerStateBegan) {
@@ -325,7 +325,30 @@ NS_ASSUME_NONNULL_BEGIN
             [[UIMenuController sharedMenuController] setMenuVisible:NO animated:NO];
         }
 
-        NSArray *menuItems = self.viewItem.menuControllerItems;
+        NSArray *menuItems = self.viewItem.textMenuControllerItems;
+        [UIMenuController sharedMenuController].menuItems = menuItems;
+        CGPoint location = [sender locationInView:self.view];
+        CGRect targetRect = CGRectMake(location.x, location.y, 1, 1);
+        [[UIMenuController sharedMenuController] setTargetRect:targetRect inView:self.view];
+        [[UIMenuController sharedMenuController] setMenuVisible:YES animated:YES];
+    }
+}
+
+- (void)longPressMediaGesture:(UIGestureRecognizer *)sender
+{
+    // We "eagerly" respond when the long press begins, not when it ends.
+    if (sender.state == UIGestureRecognizerStateBegan) {
+        if (!self.viewItem) {
+            return;
+        }
+
+        [self.view becomeFirstResponder];
+
+        if ([UIMenuController sharedMenuController].isMenuVisible) {
+            [[UIMenuController sharedMenuController] setMenuVisible:NO animated:NO];
+        }
+
+        NSArray *menuItems = self.viewItem.mediaMenuControllerItems;
         [UIMenuController sharedMenuController].menuItems = menuItems;
         CGPoint location = [sender locationInView:self.view];
         CGRect targetRect = CGRectMake(location.x, location.y, 1, 1);
@@ -342,19 +365,29 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.viewItem canPerformAction:action];
 }
 
-- (void)copyAction:(nullable id)sender
+- (void)copyTextAction:(nullable id)sender
 {
-    [self.viewItem copyAction];
+    [self.viewItem copyTextAction];
 }
 
-- (void)shareAction:(nullable id)sender
+- (void)copyMediaAction:(nullable id)sender
 {
-    [self.viewItem shareAction];
+    [self.viewItem copyMediaAction];
 }
 
-- (void)saveAction:(nullable id)sender
+- (void)shareTextAction:(nullable id)sender
 {
-    [self.viewItem saveAction];
+    [self.viewItem shareTextAction];
+}
+
+- (void)shareMediaAction:(nullable id)sender
+{
+    [self.viewItem shareMediaAction];
+}
+
+- (void)saveMediaAction:(nullable id)sender
+{
+    [self.viewItem saveMediaAction];
 }
 
 - (void)deleteAction:(nullable id)sender

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -173,7 +173,7 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         self.addSubview(stackView)
         fileNameLabel?.autoPinWidthToSuperview(withMargin: 32)
 
-        // We want to center the stackView in it's superview while ensuring
+        // We want to center the stackView in it's superview while also ensuring
         // it's superview is big enough to contain it.
         stackView.autoPinWidthToSuperview()
         stackView.autoVCenterInSuperview()
@@ -295,7 +295,7 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         self.addSubview(stackView)
         fileNameLabel?.autoPinWidthToSuperview(withMargin: 32)
 
-        // We want to center the stackView in it's superview while ensuring
+        // We want to center the stackView in it's superview while also ensuring
         // it's superview is big enough to contain it.
         stackView.autoPinWidthToSuperview()
         stackView.autoVCenterInSuperview()

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -348,7 +348,7 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
     private var controlTintColor: UIColor {
         switch mode {
         case .small, .large:
-            return UIColor.ows_materialBlue()
+            return UIColor.ows_materialBlue
         case .attachmentApproval:
             return UIColor.white
         }

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -172,8 +172,16 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         let stackView = wrapViewsInVerticalStack(subviews: subviews)
         self.addSubview(stackView)
         fileNameLabel?.autoPinWidthToSuperview(withMargin: 32)
+
+        // We want to center the stackView in it's superview while ensuring
+        // it's superview is big enough to contain it.
         stackView.autoPinWidthToSuperview()
         stackView.autoVCenterInSuperview()
+        NSLayoutConstraint.autoSetPriority(UILayoutPriorityDefaultLow) {
+            stackView.autoPinHeightToSuperview()
+        }
+        stackView.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
+        stackView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
     }
 
     private func createAnimatedPreview() {
@@ -286,8 +294,16 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         let stackView = wrapViewsInVerticalStack(subviews: subviews)
         self.addSubview(stackView)
         fileNameLabel?.autoPinWidthToSuperview(withMargin: 32)
+
+        // We want to center the stackView in it's superview while ensuring
+        // it's superview is big enough to contain it.
         stackView.autoPinWidthToSuperview()
         stackView.autoVCenterInSuperview()
+        NSLayoutConstraint.autoSetPriority(UILayoutPriorityDefaultLow) {
+            stackView.autoPinHeightToSuperview()
+        }
+        stackView.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
+        stackView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
     }
 
     private func createHeroViewSize() -> CGFloat {

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -108,7 +108,10 @@ public class SignalAttachment: NSObject {
     // MARK: Properties
 
     @objc
-    let dataSource: DataSource
+    public let dataSource: DataSource
+
+    @objc
+    public var captionText: String?
 
     @objc
     public var data: Data {

--- a/SignalMessaging/categories/UIColor+OWS.h
+++ b/SignalMessaging/categories/UIColor+OWS.h
@@ -8,21 +8,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIColor (OWS)
 
-+ (UIColor *)ows_signalBrandBlueColor;
-+ (UIColor *)ows_materialBlueColor;
-+ (UIColor *)ows_destructiveRedColor;
-+ (UIColor *)ows_fadedBlueColor;
-+ (UIColor *)ows_darkBackgroundColor;
-+ (UIColor *)ows_darkGrayColor;
-+ (UIColor *)ows_yellowColor;
-+ (UIColor *)ows_reminderYellowColor;
-+ (UIColor *)ows_reminderDarkYellowColor;
-+ (UIColor *)ows_greenColor;
-+ (UIColor *)ows_redColor;
-+ (UIColor *)ows_blackColor;
-+ (UIColor *)ows_errorMessageBorderColor;
-+ (UIColor *)ows_infoMessageBorderColor;
-+ (UIColor *)ows_inputToolbarBackgroundColor;
+@property (class, readonly, nonatomic) UIColor *ows_systemPrimaryButtonColor;
+@property (class, readonly, nonatomic) UIColor *ows_signalBrandBlueColor;
+@property (class, readonly, nonatomic) UIColor *ows_materialBlueColor;
+@property (class, readonly, nonatomic) UIColor *ows_destructiveRedColor;
+@property (class, readonly, nonatomic) UIColor *ows_fadedBlueColor;
+@property (class, readonly, nonatomic) UIColor *ows_darkBackgroundColor;
+@property (class, readonly, nonatomic) UIColor *ows_darkGrayColor;
+@property (class, readonly, nonatomic) UIColor *ows_yellowColor;
+@property (class, readonly, nonatomic) UIColor *ows_reminderYellowColor;
+@property (class, readonly, nonatomic) UIColor *ows_reminderDarkYellowColor;
+@property (class, readonly, nonatomic) UIColor *ows_greenColor;
+@property (class, readonly, nonatomic) UIColor *ows_redColor;
+@property (class, readonly, nonatomic) UIColor *ows_blackColor;
+@property (class, readonly, nonatomic) UIColor *ows_errorMessageBorderColor;
+@property (class, readonly, nonatomic) UIColor *ows_infoMessageBorderColor;
+@property (class, readonly, nonatomic) UIColor *ows_inputToolbarBackgroundColor;
+
 + (UIColor *)backgroundColorForContact:(NSString *)contactIdentifier;
 + (UIColor *)colorWithRGBHex:(unsigned long)value;
 

--- a/SignalMessaging/categories/UIColor+OWS.m
+++ b/SignalMessaging/categories/UIColor+OWS.m
@@ -96,6 +96,16 @@ NS_ASSUME_NONNULL_BEGIN
     return [UIColor colorWithRed:242.f / 255.f green:242.f / 255.f blue:242.f / 255.f alpha:1.f];
 }
 
++ (UIColor *)ows_systemPrimaryButtonColor
+{
+    static UIColor *sharedColor;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^(void) {
+        sharedColor = [UIView new].tintColor;
+    });
+    return sharedColor;
+}
+
 + (UIColor *)backgroundColorForContact:(NSString *)contactIdentifier
 {
     NSArray *colors = @[

--- a/SignalMessaging/utils/ThreadUtil.m
+++ b/SignalMessaging/utils/ThreadUtil.m
@@ -118,8 +118,10 @@ NS_ASSUME_NONNULL_BEGIN
     TSOutgoingMessage *message =
         [[TSOutgoingMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
                                             inThread:thread
+                                         messageBody:attachment.captionText
                                       isVoiceMessage:[attachment isVoiceMessage]
                                     expiresInSeconds:(configuration.isEnabled ? configuration.durationSeconds : 0)];
+    
     [messageSender enqueueAttachment:attachment.dataSource
         contentType:attachment.mimeType
         sourceFilename:attachment.filenameOrDefault

--- a/SignalServiceKit/src/Messages/Interactions/TSMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSMessage.m
@@ -156,7 +156,7 @@ static const NSUInteger OWSMessageSchemaVersion = 4;
         // messages are not only unnecessary, but worse, would be rendered redundantly. For safety, rather
         // than building the logic to try to find and delete the redundant "dummy" text messages which users
         // have been seeing and interacting with, we delete the body field from the attachment message,
-        // which iOS users has never seen directly.
+        // which iOS users have never seen directly.
         if (_attachmentIds.count > 0) {
             _body = nil;
         }

--- a/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.h
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(nullable TSThread *)thread
+                      messageBody:(nullable NSString *)messageBody
                    isVoiceMessage:(BOOL)isVoiceMessage
                  expiresInSeconds:(uint32_t)expiresInSeconds;
 

--- a/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
@@ -123,12 +123,13 @@ NSString *const kTSOutgoingMessageSentRecipientAll = @"kTSOutgoingMessageSentRec
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp
                          inThread:(nullable TSThread *)thread
+                      messageBody:(nullable NSString *)messageBody
                    isVoiceMessage:(BOOL)isVoiceMessage
                  expiresInSeconds:(uint32_t)expiresInSeconds
 {
     self = [self initWithTimestamp:timestamp
                           inThread:thread
-                       messageBody:nil
+                       messageBody:messageBody
                      attachmentIds:[NSMutableArray new]
                   expiresInSeconds:expiresInSeconds
                    expireStartedAt:0];

--- a/SignalServiceKit/src/Messages/OWSMessageManager.m
+++ b/SignalServiceKit/src/Messages/OWSMessageManager.m
@@ -1053,22 +1053,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     DDLogDebug(@"%@ shouldMarkMessageAsRead: %d (%@)", self.logTag, shouldMarkMessageAsRead, envelope.source);
 
-    //    // Other clients allow attachments to be sent along with body, we want the text displayed as a separate
-    //    // message
-    //    if ([attachmentIds count] > 0 && body != nil && body.length > 0) {
-    //        // We want the text to be displayed under the attachment.
-    //        uint64_t textMessageTimestamp = timestamp + 1;
-    //        TSIncomingMessage *textMessage = [[TSIncomingMessage alloc] initWithTimestamp:textMessageTimestamp
-    //                                                                             inThread:thread
-    //                                                                             authorId:envelope.source
-    //                                                                       sourceDeviceId:envelope.sourceDevice
-    //                                                                          messageBody:body
-    //                                                                        attachmentIds:@[]
-    //                                                                     expiresInSeconds:dataMessage.expireTimer];
-    //        DDLogDebug(@"%@ incoming extra text message: %@", self.logTag, incomingMessage.debugDescription);
-    //        [textMessage saveWithTransaction:transaction];
-    //    }
-
     // In case we already have a read receipt for this new message (this happens sometimes).
     [OWSReadReceiptManager.sharedManager applyEarlyReadReceiptsForIncomingMessage:incomingMessage
                                                                       transaction:transaction];

--- a/SignalServiceKit/src/Messages/OWSMessageManager.m
+++ b/SignalServiceKit/src/Messages/OWSMessageManager.m
@@ -1053,21 +1053,21 @@ NS_ASSUME_NONNULL_BEGIN
 
     DDLogDebug(@"%@ shouldMarkMessageAsRead: %d (%@)", self.logTag, shouldMarkMessageAsRead, envelope.source);
 
-    // Other clients allow attachments to be sent along with body, we want the text displayed as a separate
-    // message
-    if ([attachmentIds count] > 0 && body != nil && body.length > 0) {
-        // We want the text to be displayed under the attachment.
-        uint64_t textMessageTimestamp = timestamp + 1;
-        TSIncomingMessage *textMessage = [[TSIncomingMessage alloc] initWithTimestamp:textMessageTimestamp
-                                                                             inThread:thread
-                                                                             authorId:envelope.source
-                                                                       sourceDeviceId:envelope.sourceDevice
-                                                                          messageBody:body
-                                                                        attachmentIds:@[]
-                                                                     expiresInSeconds:dataMessage.expireTimer];
-        DDLogDebug(@"%@ incoming extra text message: %@", self.logTag, incomingMessage.debugDescription);
-        [textMessage saveWithTransaction:transaction];
-    }
+    //    // Other clients allow attachments to be sent along with body, we want the text displayed as a separate
+    //    // message
+    //    if ([attachmentIds count] > 0 && body != nil && body.length > 0) {
+    //        // We want the text to be displayed under the attachment.
+    //        uint64_t textMessageTimestamp = timestamp + 1;
+    //        TSIncomingMessage *textMessage = [[TSIncomingMessage alloc] initWithTimestamp:textMessageTimestamp
+    //                                                                             inThread:thread
+    //                                                                             authorId:envelope.source
+    //                                                                       sourceDeviceId:envelope.sourceDevice
+    //                                                                          messageBody:body
+    //                                                                        attachmentIds:@[]
+    //                                                                     expiresInSeconds:dataMessage.expireTimer];
+    //        DDLogDebug(@"%@ incoming extra text message: %@", self.logTag, incomingMessage.debugDescription);
+    //        [textMessage saveWithTransaction:transaction];
+    //    }
 
     // In case we already have a read receipt for this new message (this happens sometimes).
     [OWSReadReceiptManager.sharedManager applyEarlyReadReceiptsForIncomingMessage:incomingMessage

--- a/SignalShareExtension/SAEFailedViewController.swift
+++ b/SignalShareExtension/SAEFailedViewController.swift
@@ -40,7 +40,7 @@ class SAEFailedViewController: UIViewController {
                                                                 action: #selector(cancelPressed))
         self.navigationItem.title = "Signal"
 
-        self.view.backgroundColor = UIColor.ows_signalBrandBlue()
+        self.view.backgroundColor = UIColor.ows_signalBrandBlue
 
         let logoImage = UIImage(named: "logoSignal")
         let logoImageView = UIImageView(image: logoImage)

--- a/SignalShareExtension/SAELoadViewController.swift
+++ b/SignalShareExtension/SAELoadViewController.swift
@@ -61,7 +61,7 @@ class SAELoadViewController: UIViewController {
                                                                 action: #selector(cancelPressed))
         self.navigationItem.title = "Signal"
 
-        self.view.backgroundColor = UIColor.ows_signalBrandBlue()
+        self.view.backgroundColor = UIColor.ows_signalBrandBlue
 
         let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle:.whiteLarge)
         self.activityIndicator = activityIndicator


### PR DESCRIPTION
Adds attachment captioning, currently only via the share extension.

In broad strokes this PR:

1. At the data level, we now "understand" that a message can have both an attachment and a text caption. No more need to split incoming captioned attachments into two TSInteractons.

2. UI changes to send captions in the AttachmentApproval view.

3. UI changes to view captioned attachments in the ConversationView and the MessageDetail view.

More comments in line...

PTAL @charlesmchen 