### PR TITLE
Fix profile avatar flicker

### DIFF
--- a/SignalMessaging/profiles/OWSProfileManager.m
+++ b/SignalMessaging/profiles/OWSProfileManager.m
@@ -959,7 +959,7 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 
         [userProfile updateWithProfileName:profileName
                              avatarUrlPath:avatarUrlPath
-                            avatarFileName:nil
+                            avatarFileName:userProfile.avatarFileName // use existing file name if already downloaded
                             lastUpdateDate:[NSDate new]
                               dbConnection:self.dbConnection
                                 completion:nil];

--- a/SignalMessaging/profiles/ProfileFetcherJob.swift
+++ b/SignalMessaging/profiles/ProfileFetcherJob.swift
@@ -74,11 +74,11 @@ public class ProfileFetcherJob: NSObject {
         if !ignoreThrottling {
             if let lastDate = ProfileFetcherJob.fetchDateMap[recipientId] {
                 let lastTimeInterval = fabs(lastDate.timeIntervalSinceNow)
-                // Don't check a profile more often than every N minutes.
+                // Don't check a profile more often than every N seconds.
                 //
-                // Only throttle profile fetch in production builds in order to
-                // facilitate debugging.
-                let kGetProfileMaxFrequencySeconds = _isDebugAssertConfiguration() ? 0 : 60.0 * 5.0
+                // Throttle less in debug to make it easier to test problems
+                // with our fetching logic.
+                let kGetProfileMaxFrequencySeconds = _isDebugAssertConfiguration() ? 60 : 60.0 * 5.0
                 guard lastTimeInterval > kGetProfileMaxFrequencySeconds else {
                     return Promise(error: ProfileFetcherJobError.throttled(lastTimeInterval: lastTimeInterval))
                 }


### PR DESCRIPTION
1. We were clobbering our saved avatar filepath.
2. Our "should notify" check was too aggressive.

Also added (a little) debounce time to debug profile fetching.

PTAL @charlesmchen