### PR TITLE
Fix intermittent content offset problem

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.h
@@ -26,8 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didApproveAttachment:(SignalAttachment *)attachment;
 
-- (void)toolbarHeightDidChange:(CGFloat)newHeight;
-
 @end
 
 #pragma mark -


### PR DESCRIPTION
Using the CollectionView's frame to determine if we're at the bottom
doesn't make sense unless the collection view is correctly layed out.

This fixes the issue we were reproducing yesterday wherein picking someone from the content picker would obscure content behind the input toolbar if the keyboard was popped when you tapped their name.

PTAL @charlesmchen 