### PR TITLE
Charlesmchen/release configuration

### DIFF
--- a/Scripts/bump_build_number.py
+++ b/Scripts/bump_build_number.py
@@ -4,10 +4,28 @@ import os
 import re
 import commands
 import subprocess
+import argparse
+import inspect    
 
 def fail(message):
+    file_name = __file__
+    current_line_no = inspect.stack()[1][2]
+    current_function_name = inspect.stack()[1][3]
+    print 'Failure in:', file_name, current_line_no, current_function_name
     print message
     sys.exit(1)
+
+
+def execute_command(command):
+    try:
+        print ' '.join(command)
+        output = subprocess.check_output(command)
+        if output:
+            print output
+    except subprocess.CalledProcessError as e:
+        print e.output
+        sys.exit(1)
+
 
 def find_project_root():
     path = os.path.abspath(os.curdir)
@@ -25,8 +43,114 @@ def find_project_root():
         path = new_path
     
     fail('Could not find project root path')
+        
+        
+def is_valid_release_version(value):
+    regex = re.compile(r'^(\d+)\.(\d+)\.(\d+)$')
+    match = regex.search(value)
+    return match is not None
+        
+        
+def is_valid_build_version(value):
+    # Internal builds have an option "i" suffix.
+    regex = re.compile(r'^(\d+)\.(\d+)\.(\d+)\.(\d+)i?$')
+    match = regex.search(value)
+    return match is not None
+        
 
+def set_versions(plist_file_path, release_version, build_version):
+    if not is_valid_release_version(release_version):
+        fail('Invalid release version: %s' % release_version)
+    if not is_valid_build_version(build_version):
+        fail('Invalid build version: %s' % build_version)
+
+    with open(plist_file_path, 'rt') as f:
+        text = f.read()
+    # print 'text', text
+
+    # The "short" version is the release number.
+    #
+    # <key>CFBundleShortVersionString</key>
+    # <string>2.20.0</string>
+    #
+    # Internal builds have an option "i" suffix.
+    file_regex = re.compile(r'<key>CFBundleShortVersionString</key>\s*<string>([\d\.]+)</string>', re.MULTILINE)
+    file_match = file_regex.search(text)
+    # print 'match', match
+    if not file_match:   
+        fail('Could not parse .plist')
+    text = text[:file_match.start(1)] + release_version + text[file_match.end(1):]
+
+    # The "long" version is the build number.
+    #
+    # <key>CFBundleVersion</key>
+    # <string>2.20.0.3</string>
+    #
+    # Internal builds have an option "i" suffix.
+    file_regex = re.compile(r'<key>CFBundleVersion</key>\s*<string>([\d\.]+i?)</string>', re.MULTILINE)
+    file_match = file_regex.search(text)
+    # print 'match', match
+    if not file_match:   
+        fail('Could not parse .plist')
+    text = text[:file_match.start(1)] + build_version + text[file_match.end(1):]
+    
+    with open(plist_file_path, 'wt') as f:
+        f.write(text)
+        
+        
+def get_versions(plist_file_path):
+    with open(plist_file_path, 'rt') as f:
+        text = f.read()
+    # print 'text', text
+
+    # <key>CFBundleVersion</key>
+    # <string>2.13.0.13</string>
+    #
+    # Internal builds have an option "i" suffix.
+    file_regex = re.compile(r'<key>CFBundleVersion</key>\s*<string>([\d\.]+i?)</string>', re.MULTILINE)
+    file_match = file_regex.search(text)
+    # print 'match', match
+    if not file_match:   
+        fail('Could not parse .plist')
+    
+    # e.g. "2.13.0.13"
+    old_build_version = file_match.group(1)
+    print 'old_build_version:', old_build_version
+    
+    if not is_valid_build_version(old_build_version):
+        fail('Invalid build version: %s' % old_build_version)
+    
+    # Internal builds have an option "i" suffix.
+    build_number_regex = re.compile(r'\.(\d+)i?$')
+    build_number_match = build_number_regex.search(old_build_version)
+    if not build_number_match:   
+        fail('Could not parse .plist version')
+    
+    # e.g. "13"
+    old_build_number = build_number_match.group(1)
+    print 'old_build_number:', old_build_number
+    
+    # Internal builds have an option "i" suffix.
+    release_number_regex = re.compile(r'^(.+)\.\d+i?$')
+    release_number_match = release_number_regex.search(old_build_version)
+    if not release_number_match:   
+        fail('Could not parse .plist')
+    
+    # e.g. "2.13.0"
+    old_release_version = release_number_match.group(1)
+    print 'old_release_version:', old_release_version
+    
+    # Given "2.13.0.13", this should return "2.13.0" and "13" as strings.
+    return old_release_version, old_build_number
+        
+        
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Precommit cleanup script.')
+    parser.add_argument('--internal', action='store_true', help='flags internal builds by adding an "i" suffix to the build number.')
+    parser.add_argument('--version', help='used for starting a new version.')
+
+    args = parser.parse_args()
+    
     project_root_path = find_project_root()
     # print 'project_root_path', project_root_path
     # plist_path
@@ -54,75 +178,40 @@ if __name__ == '__main__':
     # ---------------
     # Main App
     # ---------------
-    with open(main_plist_path, 'rt') as f:
-        text = f.read()
-    # print 'text', text
 
-    # <key>CFBundleVersion</key>
-    # <string>2.13.0.13</string>
-    file_regex = re.compile(r'<key>CFBundleVersion</key>\s*<string>([\d\.]+)</string>', re.MULTILINE)
-    file_match = file_regex.search(text)
-    # print 'match', match
-    if not file_match:   
-        fail('Could not parse .plist')
+    old_release_version, old_build_number = get_versions(main_plist_path)
+
+    if args.version:
+        # e.g. --version 1.2.3 -> "1.2.3", "1.2.3.0"
+        new_release_version = args.version.strip()
+        new_build_version = new_release_version + ".0"
+    else:
+        new_build_number = str(1 + int(old_build_number))
+        print 'new_build_number:', new_build_number
     
-    old_build_number = file_match.group(1)
-    print 'old_build_number:', old_build_number
-    
-    build_number_regex = re.compile(r'\.(\d+)$')
-    build_number_match = build_number_regex.search(old_build_number)
-    if not build_number_match:   
-        fail('Could not parse .plist version')
-    
-    build_number = build_number_match.group(1)
-    build_number = str(1 + int(build_number))
-    new_build_number = old_build_number[:build_number_match.start(1)] + build_number
-    print 'new_build_number:', new_build_number 
-    
-    release_number_regex = re.compile(r'^(.+)\.\d+$')
-    release_number_match = release_number_regex.search(old_build_number)
-    if not release_number_match:   
-        fail('Could not parse .plist version')
-    
-    release_number = release_number_match.group(1)
-    print 'release_number:', release_number
-    
-    text = text[:file_match.start(1)] + new_build_number + text[file_match.end(1):]
-    with open(main_plist_path, 'wt') as f:
-        f.write(text)
+        new_release_version = old_release_version
+        new_build_version = old_release_version + "." + new_build_number
+
+    if args.internal:
+        new_build_version = new_build_version + "i"
+
+    print 'new_release_version:', new_release_version
+    print 'new_build_version:', new_build_version
+
+    set_versions(main_plist_path, new_release_version, new_build_version)
     
     # ---------------
     # Share Extension
     # ---------------
-    with open(share_ext_plist_path, 'rt') as f:
-        text = f.read()
-    # print 'text', text
 
-    # <key>CFBundleVersion</key>
-    # <string>2.13.0.13</string>
-    file_regex = re.compile(r'<key>CFBundleShortVersionString</key>\s*<string>([\d\.]+)</string>', re.MULTILINE)
-    file_match = file_regex.search(text)
-    # print 'match', match
-    if not file_match:   
-        fail('Could not parse .plist')
-    text = text[:file_match.start(1)] + release_number + text[file_match.end(1):]
-
-    # <key>CFBundleVersion</key>
-    # <string>2.13.0.13</string>
-    file_regex = re.compile(r'<key>CFBundleVersion</key>\s*<string>([\d\.]+)</string>', re.MULTILINE)
-    file_match = file_regex.search(text)
-    # print 'match', match
-    if not file_match:   
-        fail('Could not parse .plist')
-    text = text[:file_match.start(1)] + new_build_number + text[file_match.end(1):]
-    
-    with open(share_ext_plist_path, 'wt') as f:
-        f.write(text)
+    set_versions(share_ext_plist_path, new_release_version, new_build_version)
     
     # ---------------
     # Git
     # ---------------
-    output = subprocess.check_output(['git', 'add', '.'])
-    output = subprocess.check_output(['git', 'commit', '-m', 'Bump build to %s.\n\n// FREEBIE' % new_build_number])
+    command = ['git', 'add', '.']
+    execute_command(command)
+    command = ['git', 'commit', '-m', '"Bump build to %s."' % new_build_version]
+    execute_command(command)
     
         

--- a/Signal.xcodeproj/xcshareddata/xcschemes/Signal-Internal.xcscheme
+++ b/Signal.xcodeproj/xcshareddata/xcschemes/Signal-Internal.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D221A088169C9E5E00537ABF"
+               BuildableName = "Signal.app"
+               BlueprintName = "Signal"
+               ReferencedContainer = "container:Signal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D221A088169C9E5E00537ABF"
+            BuildableName = "Signal.app"
+            BlueprintName = "Signal"
+            ReferencedContainer = "container:Signal.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D221A088169C9E5E00537ABF"
+            BuildableName = "Signal.app"
+            BlueprintName = "Signal"
+            ReferencedContainer = "container:Signal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "INTERNAL"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DEBUG"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "App Store Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D221A088169C9E5E00537ABF"
+            BuildableName = "Signal.app"
+            BlueprintName = "Signal"
+            ReferencedContainer = "container:Signal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "App Store Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Signal.xcodeproj/xcshareddata/xcschemes/SignalShareExtension.xcscheme
+++ b/Signal.xcodeproj/xcshareddata/xcschemes/SignalShareExtension.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "453518671FC635DD00210559"
+               BuildableName = "SignalShareExtension.appex"
+               BlueprintName = "SignalShareExtension"
+               ReferencedContainer = "container:Signal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D221A088169C9E5E00537ABF"
+               BuildableName = "Signal.app"
+               BlueprintName = "Signal"
+               ReferencedContainer = "container:Signal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "453518671FC635DD00210559"
+            BuildableName = "SignalShareExtension.appex"
+            BlueprintName = "SignalShareExtension"
+            ReferencedContainer = "container:Signal.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D221A088169C9E5E00537ABF"
+            BuildableName = "Signal.app"
+            BlueprintName = "Signal"
+            ReferencedContainer = "container:Signal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "App Store Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D221A088169C9E5E00537ABF"
+            BuildableName = "Signal.app"
+            BlueprintName = "Signal"
+            ReferencedContainer = "container:Signal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "App Store Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
PTAL @michaelkirk 

First steps toward an "internal" release track so all team members can use the Debug UI.  The "MVP" of internal release track is to share the same app id (etc.) with Signal, use "release"

* Convert SAE scheme to a shared scheme.
* Add Signal "internal" (shared) scheme with DEBUG and INTERNAL flags set for Signal project _only_ (e.g. not for SSK, etc.).
   * This will activate the Debug UI.  
   * We don't use the INTERNAL flag yet, but we likely will in the future.
* Modify build version script to support --version and --internal switches.

```
# Bump build number as usual.
./Scripts/bump_build_number.py
# Start new release.
./Scripts/bump_build_number.py --version 2.3.4
# Bump build number; flag as internal release.
./Scripts/bump_build_number.py --internal 
# Start new release AND mark next build as internal.
./Scripts/bump_build_number.py --internal --version 2.3.5
```

Possible future work:

* Use a separate app id, app group id.
   * This will require service changes which I'd like to avoid for near term.
* Use a separate app name.
* Indicate whether or not its a release build in "app settings" > About.
* Possibly use only INTERNAL and not DEBUG in internal builds and add new SHOW_DEBUG_UI preprocessor symbol which is true if INTERNAL or DEBUG are set.
