### PR TITLE
fullscreen approval/captioning view

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.h
@@ -22,10 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)voiceMemoGestureDidChange:(CGFloat)cancelAlpha;
 
-#pragma mark - Attachment Approval
-
-- (void)didApproveAttachment:(SignalAttachment *)attachment;
-
 @end
 
 #pragma mark -
@@ -59,12 +55,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setVoiceMemoUICancelAlpha:(CGFloat)cancelAlpha;
 
 - (void)cancelVoiceMemoIfNecessary;
-
-#pragma mark - Attachment Approval
-
-- (void)showApprovalUIForAttachment:(SignalAttachment *)attachment;
-- (void)viewWillAppear:(BOOL)animated;
-- (void)viewWillDisappear:(BOOL)animated;
 
 @end
 

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -372,11 +372,12 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
                 owsFail("\(strongSelf.TAG) couldn't load asset.")
                 return
             }
-            let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: asset.rendition.utiType)
+            let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: asset.rendition.utiType, imageQuality: .original)
 
-            strongSelf.delegate?.gifPickerDidSelect(attachment: attachment)
-
-            strongSelf.dismiss(animated: true, completion: nil)
+            strongSelf.dismiss(animated: true) {
+                // Delegate presents view controllers, so it's important that *this* controller be dismissed before that occurs.
+                strongSelf.delegate?.gifPickerDidSelect(attachment: attachment)
+            }
         }.catch { [weak self] error in
             guard let strongSelf = self else {
                 Logger.info("\(GifPickerViewController.TAG) ignoring failure, since VC was dismissed before fetching finished.")

--- a/Signal/src/util/MainAppContext.m
+++ b/Signal/src/util/MainAppContext.m
@@ -120,6 +120,11 @@ NS_ASSUME_NONNULL_BEGIN
     [[UIApplication sharedApplication] setStatusBarStyle:statusBarStyle];
 }
 
+- (void)setStatusBarHidden:(BOOL)isHidden animated:(BOOL)isAnimated
+{
+    [[UIApplication sharedApplication] setStatusBarHidden:isHidden animated:isAnimated];
+}
+
 - (BOOL)isInBackground
 {
     return [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -78,6 +78,8 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
         Logger.debug("\(logTag) in \(#function)")
         super.viewWillAppear(animated)
 
+        CurrentAppContext().setStatusBarHidden(true, animated: animated)
+
         mediaMessageView.viewWillAppear(animated)
     }
 
@@ -91,6 +93,10 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
         super.viewWillDisappear(animated)
 
         mediaMessageView.viewWillDisappear(animated)
+
+        // Since this VC is being dismissed, the "show status bar" animation would feel like
+        // it's occuring on the presenting view controller - it's better not to animate at all.
+        CurrentAppContext().setStatusBarHidden(false, animated: false)
     }
 
     // MARK: - Create Views

--- a/SignalServiceKit/src/Util/AppContext.h
+++ b/SignalServiceKit/src/Util/AppContext.h
@@ -55,8 +55,8 @@ typedef void (^BackgroundTaskExpirationHandler)(void);
 // Should only be called if isMainApp is YES.
 - (void)setMainAppBadgeNumber:(NSInteger)value;
 
-
 - (void)setStatusBarStyle:(UIStatusBarStyle)statusBarStyle;
+- (void)setStatusBarHidden:(BOOL)isHidden animated:(BOOL)isAnimated;
 
 // Returns the VC that should be used to present alerts, modals, etc.
 - (nullable UIViewController *)frontmostViewController;

--- a/SignalShareExtension/utils/ShareAppExtensionContext.m
+++ b/SignalShareExtension/utils/ShareAppExtensionContext.m
@@ -128,6 +128,11 @@ NS_ASSUME_NONNULL_BEGIN
     DDLogInfo(@"Ignoring request to set status bar style since we're in an app extension");
 }
 
+- (void)setStatusBarHidden:(BOOL)isHidden animated:(BOOL)isAnimated
+{
+    DDLogInfo(@"Ignoring request to show/hide status bar style since we're in an app extension");
+}
+
 - (BOOL)isInBackground
 {
     return self.isSAEInBackground;


### PR DESCRIPTION
Reuse the approval view form the share extension as a captioning screen in the main app.

To me there is one glaring issue with this approach as it currently stands affecting picking videos:

![video-confirmation-low-res](https://user-images.githubusercontent.com/217057/35058046-b70eb692-fb84-11e7-8d7e-12452454ecb2.gif)

After picking a video, the UIImagePicker shows it's own a playback/confirmation screen before notifying the delegate of the picked media. (it only does this with video/GIFs, not static images). 

After confirming the video selection in that ImagePicker screen, our delegate is notified, and we show our own approval view (with captioning). The first screen is redundant. It would be nice to just skip the UIImagePicker confirmation screen, and use the caption/approval view as the single confirmation. But it doesn't seem possible, short of creating our own custom image picker experience, which could have some other upsides, but would significantly increase the scope of this work.